### PR TITLE
Select all the text when focusing the input

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -100,7 +100,7 @@ module.exports = React.createClass({
             // Our dropdown will be open, so we need to listen for our click away events
             // and put focus on the input
             _.defer(this.resetClickAwayHandler);
-            $(this.refs.input).focus();
+            $(this.refs.input).focus().select();
         }
     },
 
@@ -247,7 +247,7 @@ module.exports = React.createClass({
             this.props.onChange(this.state.currentValue);
         } else {
             this.openDropdown();
-            $(this.refs.input).focus();
+            $(this.refs.input).focus().select();
         }
     },
 


### PR DESCRIPTION
@zlailari will you please review this?

# Tests / QA
Point your package.json to:

```
"js-libs": "git+ssh://git@github.com/Expensify/JS-Libs.git#ef4e81c55c9482c58bf83dcf81dd26c835bfcaef",
```

and run `npm i`

1. On the expenses page, use the inline editor for an expense that already has a category
1. Verify that when you click on the category cell, the dropdown is open, the text field has focus, and has all the text selected (so you can immediately start typing for search)