### PR TITLE
Value change should change combobox

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -25,6 +25,12 @@ module.exports = window.CreateClass({
             window.PropTypes.number
         ]),
 
+        // A default value to have selected - Use this one rather than defaultValue when the parent view might change the value passed.
+        value: window.PropTypes.oneOfType([
+            window.PropTypes.string,
+            window.PropTypes.number
+        ]),
+
         // A callback that is fired when the value of the selector has changed
         onChange: window.PropTypes.func,
 
@@ -66,15 +72,15 @@ module.exports = window.CreateClass({
     getInitialState(noDefaultValue, newOptions) {
         this.options = newOptions || this.props.options;
 
+        const currentValue = this.initialValue || this.props.value || this.props.defaultValue;
+
         // Convert an array of strings into an array of objects for our dropdown
         const truncatedOptions = _(this.options).first(this.props.maxItemsToShow).map(option => ({
             text: option.text,
             value: option.value,
             disabled: option.disabled,
             focused: false,
-            isSelected: this.initialValue
-                ? option.value.toString() === this.initialValue
-                : option.value.toString() === this.props.defaultValue
+            isSelected: option.value.toString() === currentValue
         }));
 
         if (!truncatedOptions.length) {
@@ -91,7 +97,7 @@ module.exports = window.CreateClass({
             });
         }
 
-        let defaultSelectedOption = _(this.options).findWhere({value: this.initialValue || this.props.defaultValue});
+        let defaultSelectedOption = _(this.options).findWhere({value: currentValue});
 
         // If no default was found and initialText was present then we can use initialText values
         if (!defaultSelectedOption && this.initialText) {
@@ -101,12 +107,22 @@ module.exports = window.CreateClass({
 
         return {
             isDropdownOpen: this.props.openOnInit,
-            currentValue: noDefaultValue ? this.initialValue || '' : this.props.defaultValue || '',
+            currentValue: noDefaultValue ? this.initialValue || '' : this.props.value || this.props.defaultValue || '',
             currentText: defaultSelectedOption ? defaultSelectedOption.text : '',
             options: truncatedOptions,
             focusedIndex: 0,
             selectedIndex: null
         };
+    },
+
+    componentWillReceiveProps(nextProps) {
+        if (!_.isUndefined(nextProps.value) && nextProps.value !== this.state.currentValue) {
+            const selectedOption = _(this.options).findWhere({value: nextProps.value});
+            this.setState({
+                currentValue: selectedOption.value || '',
+                currentText: selectedOption.text || ''
+            });
+        }
     },
 
     componentDidMount() {
@@ -240,7 +256,7 @@ module.exports = window.CreateClass({
         this.reset(true);
 
         // Trigger a change so that inline editor knows to cancel itself
-        this.props.onChange(this.initialValue || this.props.defaultValue);
+        this.props.onChange(this.initialValue || this.props.value || this.props.defaultValue);
     },
 
     /**
@@ -439,7 +455,7 @@ module.exports = window.CreateClass({
             this.reset(true);
 
             // Fire our onChange callback
-            this.props.onChange(this.initialValue || this.props.defaultValue);
+            this.props.onChange(this.initialValue || this.props.value || this.props.defaultValue);
 
             // Stop the event from propagating if the escape key is pressed
             if (e.which === 27) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-libs",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "JavaScript libraries that are shared across different repos",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
@BStitesExpensify , will you please review this?

So, as a general rule in react:
- defaultValue is used in react when you just want to give a default value to a field, and let the child view handle the value itself then
- value is used when changing the value attribute passed from the parent to the child should actually change the value 

So, in this PR, I'm adding a new attribute `value` to the combobox, so that whenever I pass a new value to `React.c.FormElementCombobox`, it updates it in the combobox, so the parent can just rely on its state, and doesn't have to call methods from the child view.

Used like that in this PR: https://github.com/Expensify/Web-Expensify/pull/17455:
```
<React.c.FormElementCombobox
    options={categoryOptions}
    propertyToDisplay="text"
    onChange={val => this.filter('category', val)}
    value={String(filters.category)}
/>
```

# Tests
Tested with my [Web PR](https://github.com/Expensify/Web-Expensify/pull/17455):
- Changing the filters
- Resetting the filters
![combo](https://cloud.githubusercontent.com/assets/2463975/26748938/d181430e-47b7-11e7-9fed-c754966c8678.gif)

# QA
Non regression tests: Try adding an expense with tag and category. Play with these 2 combobox and make sure you don't see anything strange.
