### PR TITLE
Restore text being string and pass new prop children

### DIFF
--- a/lib/components/form/element/dropdown.js
+++ b/lib/components/form/element/dropdown.js
@@ -8,7 +8,9 @@ module.exports = window.CreateClass({
                 // The value of the option, should be unique
                 value: window.PropTypes.any,
                 // The human readable text of the option
-                text: window.PropTypes.any,
+                text: window.PropTypes.string,
+                // If we need more than text to style more each option
+                children: window.PropTypes.element,
                 // Whether or not the option is currently in focus
                 focused: window.PropTypes.bool,
                 // Whether or not the option is currently selected

--- a/lib/components/form/element/dropdownItem.js
+++ b/lib/components/form/element/dropdownItem.js
@@ -4,6 +4,7 @@
  * A very basic dropdown item
  * @param {Object} props
  * @param {String} props.text
+ * @param {String} props.children
  * @param {String} props.value
  * @param {Boolean} props.disabled
  * @param {Function} props.onClick
@@ -35,7 +36,7 @@ module.exports = (props) => {
         <li className={React.classNames(classes.li)}>
             <a className={React.classNames(classes.a)} onClick={clickHandler} tabIndex="-1">
                 {props.isSelected && props.isSelectable !== false ? <span><React.c.Icon name="checkmark" />{' '}</span> : ''}
-                {props.text}
+                {props.text ? Str.htmlDecode(props.text) : props.children}
             </a>
         </li>
     );


### PR DESCRIPTION
@BStitesExpensify , will you please review this?

Partial revert of https://github.com/Expensify/JS-Libs/pull/59/files.
[Talked about this with Tim](https://github.com/Expensify/Web-Expensify/pull/17455#discussion_r123549717). Let's not "hack" the `text` props to pass elements. Create a new prop `children` instead if we want some advanced design for the dropdown items

# Tests (No QA)
Tested with my [web PR](https://github.com/Expensify/Web-Expensify/pull/17455):
![image](https://user-images.githubusercontent.com/2463975/27445194-bd3ddad0-572d-11e7-9e47-37a16657c384.png)

