### PR TITLE
Make combobox fast when deleting the whole search text

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -567,7 +567,7 @@ module.exports = window.CreateClass({
                 currentValue: '',
                 currentText: '',
                 isDropdownOpen: true,
-                options: this.options
+                options: this.getTruncatedOptions('')
             }, this.resetClickAwayHandler);
 
             // Trigger the callback to clear out the value

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-libs",
-  "version": "1.8.20",
+  "version": "1.8.21",
   "description": "JavaScript libraries that are shared across different repos",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
@tgolen , will you please review this?

# Needed for
https://github.com/Expensify/Expensify/issues/73200#event-1471060712

# Tests
1. Check that attendee selector with 10k users doesn't freeze the browser when deleting the search text.
1. Play around with category, tag selectors.