### PR TITLE
Prevent IE11 from late-firing a focus event in combobox widget.

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -256,7 +256,12 @@ module.exports = window.CreateClass({
             options: newOptions
         });
         if (this.state.isDropdownOpen) {
-            $(this.refs.input).focus().select();
+            // IE11 will intermittently re-open the dropdown on an input.focus() or input.select() 
+            // Causes https://github.com/Expensify/Expensify/issues/77688
+            const msie = RegExp('trident', 'i').test(navigator.userAgent);
+            if (!msie) {
+                $(this.refs.input).focus().select();
+            }
         }
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-libs",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "JavaScript libraries that are shared across different repos",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
@iwiznia , will you please review this?

IE11 will open the dropdown list for a category pulldown anytime the input element receives focus. Unfortunately, when an item in the dropdown is selected on the Per Diem page in Policy Editor, we focus() and select() on the input element which highlights the text in the combobox. Then IE11 processes the focus event on the input, and re-opens the combobox dropdown, making for ugly UX and other side-effects.

# Fixes
$ https://github.com/Expensify/Expensify/issues/77688

# Tests
1. Open the Policy Editor in IE11. 
2. Choose "Per Diem"
3. Enable it if necessary.
4. Choose a "Default Per Diem Category"
5. Change the value using the combobox dropdown.

Before: would show the dropdown immediately after selecting the value.

Now: Suppresses the focus and does not re-open. Additionally, since it leaves the dropdown in an "open" state in React, it still catches the outsideClickHandler, causing all sorts of funkiness with the Per Diem rates. This may or may not solve both issues, wanted to get this solved first.

Bonus regression: Tested category comboboxes throughout the site on both Chrome and IE11, and this appears to have not affected other parts of the site.

NOTE:

I am not 100% satisfied with this fix. It gets the job done, but for some reason, this bad behaviour ONLY happens in the Per Diem combobox/page, but I don't understand what else might cause this strangeness. The focus event is embedded very deeply in this widget, so I don't have a clean way to change this behaviour just for the Per Diem widget. 

That said, I was unable to discover why this misbehaviour is only on the Per Diem combobox and would appreciate a second set of eyes to see if I am missing something about React that might cause this behaviour. 

I assume this is a race condition between React updating the state.isDropdownOpen flag and IE11 handling it or cancelling the event in a timely fashion. As such, there might not be a better solve. 

# QA
1. Same as above.