### PR TITLE
Look in the non-truncated options for the matching value

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -238,17 +238,19 @@ module.exports = window.CreateClass({
      * @param {String} val
      */
     setValue(val) {
-        let currentText = '';
         // Deselect all other options but the one matching our value
         const newOptions = _(this.state.options).map((o) => {
             const option = o;
             const isSelected = _.isEqual(option.value, val);
             option.isSelected = isSelected || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value}));
-            if (isSelected && !option.isFake) {
-                currentText = option.text;
-            }
             return option;
         });
+
+        // We need to look in `this.options` for the matching option because `this.state.options` is a truncated list
+        // and might not have every option
+        const optionMatchingVal = _.findWhere(this.options, {value: val});
+        const currentText = _.get(optionMatchingVal, 'text', '');
+
         this.initialValue = val;
         this.setState({
             currentValue: val,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-libs",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "JavaScript libraries that are shared across different repos",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
@arimai will you please review this?

This caused the issue https://github.com/Expensify/Expensify/issues/83311 because if the "matching" option is option #501 (anything more than 500), then we couldn't find the matching text to set the current text of the combobox to.

# Fixes
https://github.com/Expensify/Expensify/issues/83311

# Tests & QA
Will be tested in the web PR
