### PR TITLE
manually hide would-be-stale tooltips

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -576,8 +576,7 @@ module.exports = window.CreateClass({
                 this.stopEvent(e);
 
                 // Destroy any lingering tooltips
-                // Fixes https://github.com/Expensify/Expensify/issues/83616
-                $('.tooltip').tooltip('hide');
+                $('.expensify-dropdown [data-toggle="tooltip"]').tooltip('hide');
             }
             break;
 


### PR DESCRIPTION
@tgolen , will you please review this?

# Fixes
Expensify/Expensify#83616 - tooltips in dropdowns normally closed by the "esc" key or `mouseleave` were remaining on screen after the user hit the "esc" key because we stop event bubbling. This ensures that any tooltips that remain on screen after a dropdown is closed is also removed.

# Tests
Locally:
- In the bugged state, the stale tooltips are no longer even referenced by the tooltip originator; it is safe to remove them
- tested functionality in console and interface
  - tooltips are now destroyed when user presses `esc`
  - tooltips once destroyed can be reinstantiated (expected behavior)

# QA
1. What does QA need to do to validate your changes?

Replication:
1. __Open__ any drop-down where its options may have tooltips
2. __Hover__ over an option until a tooltip appears
3. __Press__ "esc"

Expected Behavior: When using the "esc" key to close a dropdown, all tooltips should also be destroyed

see Expensify/Expensify#83616 for more details

1. What areas to they need to test for regressions?
This code triggers on all drop-downs - possible regression areas include any drop-downs that do not conform to the type listed in the original issue
