### PR TITLE
Update attendee search to prevent duplicates

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -703,13 +703,14 @@ class Combobox extends React.Component {
         ];
         let hasMoreResults = false;
         let matches = new Set();
+        const searchOptions = _.uniq(this.options, 'value');
 
         for (let i = 0; i < matchRegexes.length; i++) {
             if (matches.size < this.props.maxSearchResults) {
-                for (let j = 0; j < this.options.length; j++) {
+                for (let j = 0; j < searchOptions.length; j++) {
                     // Don't include the disabled options
-                    if (!this.options[j].disabled && matchRegexes[i].test(this.options[j].text.toString().replace(new RegExp(/&nbsp;/g), ''))) {
-                        matches.add(this.options[j]);
+                    if (!searchOptions[j].disabled && matchRegexes[i].test(searchOptions[j].text.toString().replace(new RegExp(/&nbsp;/g), ''))) {
+                        matches.add(searchOptions[j]);
                     }
 
                     if (matches.size === this.props.maxSearchResults) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-libs",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "JavaScript libraries that are shared across different repos",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
@arimai will you please review this?

For users with recent attendees, the attendees selector is showing duplicate values when they search for names that show up in both the recent attendees section and the internal attendees section
### Fixed Issues
$ None i just saw this issue

# Tests/QA
1. Log into an account without recent attendees 
1. Create a new expense and search for an existing user 
1. Confirm that they only shows up once. 
1. Add an internal attendee to the expense and save it. 
1. Create a new expense 
1. Search for the attendee that you just added (it's now an internal attendee and a recent attendee) 
1. Confirm that the attendee only shows up once

| Before  | After |
| ------------- | ------------- |
|  ![2019-02-08_15-49-21 1](https://user-images.githubusercontent.com/16747822/52514390-1fe2ff80-2bc6-11e9-8e71-1e80e059db8a.gif)  |  ![2019-02-08_15-43-10 1](https://user-images.githubusercontent.com/16747822/52514386-19548800-2bc6-11e9-8383-fb4e1abfb980.gif)  |
