### PR TITLE
Log hmmm when showing error modal to user

### DIFF
--- a/lib/PubSub.jsx
+++ b/lib/PubSub.jsx
@@ -30,6 +30,8 @@ const generateID = (eventName) => {
 const extractEventName = eventID => eventID.substr(0, eventID.indexOf('@#@'));
 
 module.exports = {
+    ERROR: 'ev_error',
+
     /**
      * Publish an event
      *
@@ -42,7 +44,7 @@ module.exports = {
         }
 
         const eventIDs = _.keys(eventMap[eventName]);
-        if (eventName === 'ev_error') {
+        if (eventName === this.ERROR) {
             // Doing the split slice 2 because the 1st element of the stacktrace will always be from here (PubSub.publish)
             // When debugging, we just need to know who called PubSub.publish (so, all next elements in the stack)
             Log.hmmm('Error published', 0, {tplt: param.tplt, stackTrace: new Error().stack.split(" at ").slice(2)});


### PR DESCRIPTION
@marcaaron, @tgolen will you please review this?

### Fixed Issues
Help debug issues like https://github.com/Expensify/Expensify/issues/100437 and https://github.com/Expensify/Expensify/issues/97274
Sometimes, user tell us they see an error modal, but we can't find anything in the logs because the error doesn't come from the server.

This PR will help us to know where the error was published from.

# Tests (No QA)

![image](https://user-images.githubusercontent.com/2463975/54063122-5741cd80-41bf-11e9-978c-58e5a9f4e0ef.png)

![image](https://user-images.githubusercontent.com/2463975/54063146-88ba9900-41bf-11e9-8db8-8c9a52840d94.png)

-----

![image](https://user-images.githubusercontent.com/2463975/54144942-14177280-43ea-11e9-910b-a62a821fb9b8.png)

![image](https://user-images.githubusercontent.com/2463975/54144960-20033480-43ea-11e9-9dbe-0639ebd53461.png)
