### PR TITLE
Never sort selected combobox options below the divider to the top of the list

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -273,7 +273,7 @@ class Combobox extends React.Component {
 
         // Take each array and format it, sort it, and move selected items to top (if applicable)
         const truncatedOptions = _.chain(splitOptions)
-            .map(array => (
+            .map((array, index) => (
                 _.chain(array)
                     .map(option => ({
                         text: option.text,
@@ -289,7 +289,9 @@ class Combobox extends React.Component {
                         if (o.showLast) {
                             return 2;
                         }
-                        return o.isSelected && this.props.alwaysShowSelectedOnTop ? 0 : 1;
+
+                        // We only want items in the first array (before the divider to display selected options on top)
+                        return index === 0 && o.isSelected && this.props.alwaysShowSelectedOnTop ? 0 : 1;
                     })
                     .first(this.props.maxItemsToShow)
                     .value())


### PR DESCRIPTION
@NikkiWines will you please review this?

Only allows options above the divider to "always show on top"

### Fixed Issues
No issue

# Tests / QA
1. Test in conjunction with https://github.com/Expensify/Web-Expensify/pull/24357 
1. No QA