### PR TITLE
Don't expand parameters when sending log requests

### DIFF
--- a/lib/Log.jsx
+++ b/lib/Log.jsx
@@ -60,7 +60,7 @@ const Log = {
         if (window.DEBUG) {
             Log.client(`${msg} - ${JSON.stringify(parameters)}`);
         }
-        const params = {...parameters, message};
+        const params = {parameters, message};
         API(Network('/api.php')).logToServer(params);
     },
 


### PR DESCRIPTION
@arimai  will you please review this?

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/105040

# Tests
1. Call `Log.alert('Test', 0, {param1: 1, param2: 2});` from the console and make sure the parameters that I appended are logged:

```
2019-05-23T00:57:51.164491+00:00 expensidev php-fpm: 70L3ON /api.php rocio@expensify.com !web! ?api? [alrt] [alXt] Test ~~ parameter: '[param1: '1' param2: '2' stack: '"Error\n    at Object.alert (https://www.expensify.com.dev/newjs/module.php?name=shared:13886:39)\n    at :1:5"']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36'
```

# QA
None.