### PR TITLE
Allows disabled options to appear in combobox via boolean prop

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -747,14 +747,15 @@ class Combobox extends React.Component {
         for (let i = 0; i < matchRegexes.length; i++) {
             if (matches.size < this.props.maxSearchResults) {
                 for (let j = 0; j < searchOptions.length; j++) {
-                    // Don't include the disabled options
-                    if (!searchOptions[j].disabled && matchRegexes[i].test(searchOptions[j].text.toString().replace(new RegExp(/&nbsp;/g), ''))) {
-                        matches.add(searchOptions[j]);
-                    }
+                    const option = searchOptions[j];
+                    const isDisabled = option.disabled;
+                    const isMatch = matchRegexes[i].test(option.text.toString().replace(new RegExp(/&nbsp;/g), ''));
 
-                    // Do show Disabled options if we have specified that we want them to show
-                    if (searchOptions[j].disabled && this.props.showDisabledOptionsInResults) {
-                        matches.add(searchOptions[j]);
+                    // Don't include the disabled options that match the regex unless we specified we want them to show.
+                    // If we want them to show then add them whether they match the regex or not.
+                    if ((!isDisabled && isMatch)
+                    || (isDisabled && this.props.showDisabledOptionsInResults)) {
+                        matches.add(option);
                     }
 
                     if (matches.size === this.props.maxSearchResults) {


### PR DESCRIPTION
@yuwenmemon will you please review this?

We recently updated a dropdown with non selectable headers to use the combobox. Since these disabled headers do not appear in search results we are adding a way here to override the default behavior of the returned options when searching for a combobox item. By passing a `showDisabledOptionsInResults` prop to the combobox we can allow the headers to appear in results.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/104302

# Tests / QA
1. This should be tested with [this Web-E PR](https://github.com/Expensify/Web-Expensify/pull/24881) that will use this new functionality. 