### PR TITLE
Remove call for tooltip that was killed

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -674,7 +674,6 @@ class Combobox extends React.Component {
                     isDropdownOpen: false
                 }), () => {
                     this.resetClickAwayHandler();
-                    this.destroyTooltips();
                 });
 
                 // Fire our onChange callback


### PR DESCRIPTION
@objectsforheads  will you please review this? /cc @marcaaron @tgolen @changled 

Bug probably introduced in https://github.com/Expensify/JS-Libs/pull/138

### Fixed Issues
https://github.com/Expensify/Expensify/issues/105500

# Tests
- open mega edit
- select an attendee not in the list by writing it 
- Check no js error is shown