### PR TITLE
Migrate OnOffSwitch to JS-Libs

### DIFF
--- a/lib/components/form/element/onOffSwitch.jsx
+++ b/lib/components/form/element/onOffSwitch.jsx
@@ -82,6 +82,7 @@ class OnOffSwitch extends Component {
         this.onChangeCallback = this.onChangeCallback.bind(this);
         this.lock = this.lock.bind(this);
         this.unlock = this.unlock.bind(this);
+        this.getValue = this.getValue.bind(this);
 
         this.state = {
             checked: this.props.checked,


### PR DESCRIPTION
@alex-mechler and @chiragsalian will you please review this?

Moved the OnOffSwitch to JS-Libs

### Fixed Issues
https://github.com/Expensify/Expensify/issues/102757

# Tests
1. In [Web-Expensify/site/shared.js](https://github.com/Expensify/Web-Expensify/blob/86c9bf1801d23463803eb2b6398f8f46e12b8858/site/shared.js#L52-L60), _add_ this line in React.c:
`OnOffSwitch: require('js-libs/lib/components/form/element/onOffSwitch').default,`
<img width="400" alt="Screen Shot 2019-06-12 at 3 18 12 PM" src="https://user-images.githubusercontent.com/10782771/59390743-0219d880-8d27-11e9-86d0-61770d187d39.png">

2. _Delete_ all contents of file [Web-Expensify/site/component/form/element/onOffSwitch.jsx](https://github.com/Expensify/Web-Expensify/blob/425560abc386aa29299896edf1f4e661754e3f42/site/component/form/element/onOffSwitch.jsx)
3. _Link_ JS-Libs with Web-Expensify (instructions [here](https://stackoverflow.com/c/expensify/a/3018/168))
   - You should be running `npm run grunt link/unlink` in JS-Libs/lib/components/form/element/
4. _Open_ Expensify app on dev and _go to_  **Settings** -> **Policy** -> [any group policy] -> **Categories**
5. _Toggle_ the **Car** category off
<img width="400" alt="Screen Shot 2019-06-12 at 3 26 14 PM" src="https://user-images.githubusercontent.com/10782771/59390714-ef9f9f00-8d26-11e9-82d7-d7d8478566b0.png">

6. _Create_ a new report and _set_ the policy to the policy you selected in Step 4
7. _Add_ a new expense to the report and _**verify**_ that you do not see the **Car** category listed
<img width="400" alt="Screen Shot 2019-06-12 at 3 28 03 PM" src="https://user-images.githubusercontent.com/10782771/59390707-eadaeb00-8d26-11e9-94d7-e76f0aef689d.png">

# QA
None. Will be tested in Web-Expensify and Web-Secure