### PR TITLE
Add pretty moment string constant

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -157,7 +157,7 @@ export const CONST = {
         /**
          * Pretty format used for report history items
          *
-         * @example Jun 19, 2019 12:38 PM PDT
+         * @example Jun 19, 2019 12:38 PM
          *
          * @type {String}
          */


### PR DESCRIPTION
@changled will you please review this?

Just adds a new constant for moment.

### Fixed Issues
No issue

# Tests
1. Go to `expensify.com.dev` and in JS console verify the correct output
1. Enter `moment('Jun 19 2019 8:25am PDT', CONST.DATE.MOMENT_DATE_TIME_PRETTY).format('lll')`
1. **Verify** "Jun 19, 2019 8:25 AM"

# QA
No QA