### PR TITLE
Remove uneccessary focus hack from combobox

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -359,15 +359,6 @@ class Combobox extends React.Component {
                 return option;
             })
         }));
-
-        if (this.state.isDropdownOpen) {
-            // IE11 will intermittently re-open the dropdown on an input.focus() or input.select()
-            // Causes https://github.com/Expensify/Expensify/issues/77688
-            const msie = RegExp('trident', 'i').test(navigator.userAgent);
-            if (!msie) {
-                $(this.value).focus().select();
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
@chiragsalian will you please review this?

I don't think we need this anymore. The focus causes more headache than help because it causes the cursor to lie within the input of the combo box, which prevents the dropdown from showing when we click on it.

### Fixed Issues
$ For the deploy blocker on https://github.com/Expensify/Web-Expensify/pull/25082#issuecomment-506000657

# Tests

1. Navigate to Staging.expensify.com
2. Log in and enable New distance feature 
3. Go to Policy > Expenses and create few Distance rates 
4. Go to expenses and create new Distance expense
5. Click on distance rate drop down and select any rate. 
6. After selection appears, click on it again
7. Make sure the drop-down shows again

---

- Also, made sure the type-to-complete features still worked and that the cursor played nice there as well:
![beEn9ob7sG](https://user-images.githubusercontent.com/4741899/60214954-79696500-981b-11e9-9285-6a1ac6b00794.gif)
