### PR TITLE
Fix combobox - clone state options as array instead of as object

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -396,7 +396,7 @@ class Combobox extends React.Component {
     deselectCurrentOption() {
         if (this.state.selectedIndex !== null && this.state.options[this.state.selectedIndex]) {
             this.setState((state) => {
-                const newOptions = state.options.slice(0);
+                const newOptions = [...state.options];
                 newOptions[state.selectedIndex].isSelected = false;
 
                 return {
@@ -414,7 +414,7 @@ class Combobox extends React.Component {
      */
     switchFocusedIndex(oldFocusedIndex, newFocusedIndex) {
         this.setState((state) => {
-            const newOptions = state.options.slice(0);
+            const newOptions = [...state.options];
             newOptions[oldFocusedIndex].focused = false;
             newOptions[newFocusedIndex].focused = true;
 


### PR DESCRIPTION
@marcaaron will you please review this?

Options were copied as object instead of array when setting the state. So, when later we tried doing state.options.length, it gave undefined.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/107486

# Tests / QA

Open up an expense on web expenses page
Filter the category by typing `in` so there are a few options
Use the down arrow key on your keyboard to go to the next item
On the last item, after hitting the down arrow key, the selection should go back to the 1st item of the list
