### PR TITLE
[NO QA] Add new constant for pending card icon

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -508,7 +508,8 @@ export const UI = {
         MANAGED_CARD: 'corporate-card',
         CARD: 'credit-card',
         CLOCK: 'time',
-        PER_DIEM: 'per-diem'
+        PER_DIEM: 'per-diem',
+        PENDING_CARD: 'card-transaction-pending'
     },
     spinnerDIV: '<div class="spinner"></div>',
     spinnerSmallDIV: '<div class="spinner spinner-small"></div>',


### PR DESCRIPTION
@johnmlee101 will you please review this?

We need this const to update the getIcon function here https://github.com/Expensify/Web-Expensify/pull/25432/files#diff-2e17bbc74c6736a97b56af3caa15aba3R2350

### Fixed Issues
$ Expensify/Expensify#108240

# Tests
1. Pull this and pull https://github.com/Expensify/Web-Expensify/pull/25432/files
2. Make sure a pending transactions have the icon on the reports page
![2019-08-02_12-42-53](https://user-images.githubusercontent.com/42391420/62394780-1017f880-b523-11e9-81dc-444c139b0980.png)

# QA
N/A
