### PR TITLE
Add command to get Concierge response search score info

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -817,7 +817,6 @@ export default function API(network, args) {
                 return performPOSTRequest('ChatBot_FroalaS3Hash_Get');
             },
 
-
             /**
              * Get recent events from chatbot
              *
@@ -831,6 +830,17 @@ export default function API(network, args) {
                 const commandName = 'ChatBot_Event_GetRecent';
                 requireParameters(['limit', 'type'], parameters, commandName);
                 return performPOSTRequest(commandName, parameters, 'events');
+            },
+
+            /**
+             * Get the scoring data for saved responses from Bedrock.
+             *
+             * @param {Object} [parameters]
+             *
+             * @returns {APIDeferred}
+             */
+            getResponseData(parameters) {
+                return performPOSTRequest('ChatBot_GetResponseData', parameters);
             },
         },
 


### PR DESCRIPTION
@chiragsalian will you please review this?

This adds a new API call for "better search now".

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/103358

# Tests
1. This will be tested along with the Better Search Now Web-Expensify PR. It's unused until that change.

# QA
N/A
