### PR TITLE
Update QBD sync manager version to 190082321

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -135,7 +135,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_190061118.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_190082321.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },


### PR DESCRIPTION
@francoisl will you please review this?

Update Sync Manager version to v19.0.08.23.21
Executable uploaded in this [Web-Static PR](https://github.com/Expensify/Web-Static/pull/58)

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/106730

# Tests/QA
1. On a Control policy, go to Connections -> Accounting Integrations -> QuickBooks Desktop
1. Click Connect to Quickbooks Desktop -> Single User/Personal Desktop -> Download the Expensify Sync Manager
1. Verify that a file is successfully downloaded with the title "Expensify_QuickBooksDesktop_Setup_190082321.exe"
