### PR TITLE
Reuse targetEmail WAF for UserInfo

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -783,7 +783,7 @@ export default function API(network, args) {
              *
              * @param {Object} parameters
              * @param {String} parameters.chatID
-             * @param {String} [parameters.searchEmail]
+             * @param {String} [parameters.targetEmail]
              *
              * @returns {APIDeferred}
              */


### PR DESCRIPTION
@alex-mechler will you please review this?

Change param so we can reuse _targetEmail_ WAF

### Fixed Issues
https://github.com/Expensify/Web-Expensify/pull/25727#discussion_r320608784

# Tests/QA (regression)
Test with [this Web PR](https://github.com/Expensify/Web-Expensify/pull/25757)