### PR TITLE
Remove accountID from API.chatbot.reopenChat

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -865,7 +865,7 @@ export default function API(network, args) {
              */
             reopenChat(parameters) {
                 const commandName = 'ChatBot_Chat_Reopen';
-                requireParameters(['chatID', 'accountID', 'shouldReassign'], parameters, commandName);
+                requireParameters(['chatID', 'shouldReassign'], parameters, commandName);
                 return performPOSTRequest(commandName, parameters);
             },
         },


### PR DESCRIPTION
@fnwbr will you please review this?

Removes the required parameter of `accountID` from reopenChat since we can get it from the `authToken`.

### Fixed Issues
$ No issue

# Tests
1. Test with https://github.com/Expensify/Web-Expensify/pull/25607

# No Web / Mobile QA