### PR TITLE
Updating to latest version of babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,27 @@
     "grunt": "*",
     "grunt-eslint": "21.0.0",
     "grunt-chokidar": "1.0.0",
-    "babelify": "8.0.0",
-    "babel-core": "6.26.0",
-    "babel-plugin-transform-decorators-legacy": "1.3.4",
-    "babel-preset-env": "1.6.1",
-    "babel-preset-react": "6.24.1",
-    "babel-preset-stage-0": "6.24.1",
+    "babelify": "10.0.0",
+    "@babel/core": "7.6.4",
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-proposal-decorators": "7.6.0",
+    "@babel/plugin-proposal-do-expressions": "^7.0.0",
+    "@babel/plugin-proposal-export-default-from": "^7.0.0",
+    "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
+    "@babel/plugin-proposal-function-bind": "^7.0.0",
+    "@babel/plugin-proposal-function-sent": "^7.0.0",
+    "@babel/plugin-proposal-json-strings": "^7.0.0",
+    "@babel/plugin-proposal-logical-assignment-operators": "^7.0.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+    "@babel/plugin-proposal-numeric-separator": "^7.0.0",
+    "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+    "@babel/plugin-proposal-pipeline-operator": "^7.0.0",
+    "@babel/plugin-proposal-throw-expressions": "^7.0.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+    "@babel/plugin-syntax-import-meta": "^7.0.0",
+    "@babel/polyfill": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
     "jit-grunt": "^0.10.0"
   },
   "browserify": {
@@ -44,9 +59,8 @@
         "babelify",
         {
           "presets": [
-            "env",
-            "react",
-            "stage-0"
+            "@babel/preset-env",
+            "@babel/preset-react"
           ]
         }
       ]


### PR DESCRIPTION
This will be tested in a web PR, but you can also test with `npm i && npm run grunt watch` and verify that it works properly and ends with the watcher running.