### PR TITLE
Prevent combobox auto-scroll on item selection

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -850,7 +850,7 @@ class Combobox extends React.Component {
             currentValue: selectedValue,
             currentText: get(currentlySelectedOption, 'text', ''),
             isDropdownOpen: false,
-            hasError: get(currentlySelectedOption, 'hasError', false),
+            hasError: get(currentlySelectedOption, 'hasError', false)
         }, () => {
             this.resetClickAwayHandler();
 


### PR DESCRIPTION
@tgolen will you please review this? cc: @marcaaron since you also had eyes on this

Update the combobox so that we don't always scroll to the top on item selection
Has a corresponding Web-E PR related to it: https://github.com/Expensify/Web-Expensify/pull/26213

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/115583#issuecomment-547173703

# Tests

Ensure you've checked out the corresponding Web-E branch: `nikki-multipersonselector-props`

If you don't have a dev account that will show this inbox task, click below

<details><summary><b>Pre- Requisites</b></summary>
<p>

1. Create an account `test@test.com` on a new domain `../script/clitools.sh generator:account`
1. Validate the `test.com` domain with `../script/clitools.sh generator:domain` 
1. Find the account ID of the new domain with `../script/sql.sh` and `select accountID from accounts where email = '+@test.com';`
1. Update the domain to be configured for using the card with `../script/sql.sh` and `insert into nameValuePairs (created, accountid, name, value) values ('2019-10-02 00:00:00', <ACCOUNT_ID_FROM_PREVIOUS_STEP>, 'private_expensifyCardSettings', '{"paymentBankAccountID":4,"limit":1000000}');`
1. Log in with the `test@test.com` account
1. In the welcome inbox task, select a control policy
1. Navigate to Settings > Policies > Your Policy > People
1. Add at least 7 new people as managers (we need to test the scroll functionality of the combobox so a lot option are needed). The simplest way to do this is to upgrade to `Advanced Approval` and then make everyone submit to themselves in the People table in your policy settings
</p>
</details>

## Test the inbox task 
1. Verify you now see this new inbox task for configuring card limits (if you can't see it, try clicking on the `Show Hidden Tasks` button at the bottom of the screen)
1. Click on the box containing managers to open the selector. 
1. Confirm you are able to successfully unselect a manager 
1. Scroll and unselect another manager that is further down the list
1. Confirm the scroll does **not** reset and your location maintains the same

# Web QA

There is a staging account available that has the inbox card set up - search for `Staging Expensify Card Credentials` in 1Password. 

Otherwise, If you don't have an account that will show this inbox task, click below. 

<details><summary><b>Pre- Requisites</b></summary>
<p>

- Be the admin of a domain that is configured to use the expensify card, and has domain groups where the default card limits have NOT been set yet (or you can maybe set them to `0`).
- Have an expensify card assigned to an admin that does NOT have a custom limit yet
- Have an expensify card assigned to an employee that does NOT have a custom limit yet
- Be on an account where you've answered the initial inbox welcome task to create a collect or control policy
- Have someone with requisite ring access run the following query for you
```
INSERT INTO nameValuePairs (
	created, 
	accountid, 
	name, value
)
VALUES (
	'2019-10-02 00:00:00', 
	(
		SELECT accountID 
		FROM accounts 
		WHERE email = '+@<yourdomainhere>'
	), 
	'private_expensifyCardSettings', 	
	'{"paymentBankAccountID":4,"limit":1000000}'
);
```
1. Navigate to Settings > Policies > Your Policy > People
1. Add at least 7 new people as managers (we need to test the scroll functionality of the combobox so a lot option are needed). The simplest way to do this is to upgrade to `Advanced Approval` and then make everyone submit to themselves in the People table in your policy settings.
1. Verify you now see this new inbox task for configuring card limits
</p>
</details>

## Test the inbox task 
1. Verify you now see this new inbox task for configuring card limits (if you can't see it, try clicking on the `Show Hidden Tasks` button at the bottom of the screen)
1. Click on the box containing managers to open the selector. 
1. Confirm you are able to successfully unselect a manager 
1. Scroll and unselect another manager that is further down the list
1. Confirm the scroll does **not** reset and your location maintains the same

![2019-11-06_11-16-21 (1)](https://user-images.githubusercontent.com/16747822/68330186-a65e3c00-0087-11ea-888f-d827e60809b6.gif)