### PR TITLE
Add chromeexpensify.com to public domains constant

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -745,7 +745,7 @@ export const UI = {
     DIALOG_Z_INDEX: 4000
 };
 
-// List of most often used public domains
+// List of most frequently used public domains
 export const PUBLIC_DOMAINS = [
     'expensify.sms',
     'chromeexpensify.com',


### PR DESCRIPTION
1. Adding `chromeexpensify.com` to the list
2. Updating the list to feature the 30 most frequently used public domains, plus `chromeexpensify.com` 

See the linked issue for more details and how I queried the list.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/119642

# Tests
None - Will be tested with the upcoming Web-Expensify PR on staging, where we'll confirm that `chromeexpensify.com` will not show up in domain control anymore, after this change was deployed to staging.

# QA
None