### PR TITLE
Add evernote.user to public domains

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -796,6 +796,7 @@ export const UI = {
 
 // List of most frequently used public domains
 export const PUBLIC_DOMAINS = [
+    'evernote.user',
     'expensify.sms',
     'chromeexpensify.com',
     'gmail.com',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-libs",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "JavaScript libraries that are shared across different repos",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION


### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/120035

# Tests
no