### PR TITLE
Add extension method to API.jsx

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -198,20 +198,18 @@ export default function API(network, args) {
          *
          * @example
          *
-         * conciergeAPI.chatbot.getNew = (parameters) => {
-         *     return conciergeAPI.extendMethod({
-         *         commandName: 'ChatBot_Escalate_GetNextChat',
-         *         requireParameters: ['queueList'],
-         *         checkCodeRevision: true,
-         *     })(parameters);
-         * }
+         * conciergeAPI.chatbot.getNew = (parameters) => conciergeAPI.extendMethod({
+         *     commandName: 'ChatBot_Escalate_GetNextChat',
+         *     requireParameters: ['queueList'],
+         *     checkCodeRevision: true,
+         * })(parameters);
          *
          * @param {Object} data
          * @param {String} data.commandName
          * @param {Function} [data.validate]
          * @param {String[]} [data.requireParameters]
          * @param {String} [data.returnedPropertyType]
-         * @param {Boolean} data.checkCodeRevision
+         * @param {Boolean} [data.checkCodeRevision]
          *
          * @return {Function}
          */


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

cc @tgolen @fnwbr 

Adds a `extendMethod` method to `API.jsx` allowing the base API to be extended with new methods.

This would go with https://github.com/Expensify/Web-Expensify/pull/26411

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/109455

# Tests
1. Pair with the linked web PR. Make sure Concierge works OK.

# QA
1. All possible regressions for Concierge.