### PR TITLE
Use spread operator for properties in combobox

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -297,13 +297,9 @@ class Combobox extends React.Component {
             .map(array => (
                 _.chain(array)
                     .map(option => ({
-                        text: option.text,
-                        children: option.children,
-                        value: option.value,
-                        disabled: option.disabled,
-                        divider: option.divider,
                         focused: false,
-                        isSelected: option.selected && (_.isEqual(option.value, currentValue) || Boolean(_.findWhere(alreadySelected, {value: option.value})))
+                        isSelected: option.selected && (_.isEqual(option.value, currentValue) || Boolean(_.findWhere(alreadySelected, {value: option.value}))),
+                        ...option
                     }))
                     .sortBy((o) => {
                         // Unselectable text-only entries (isFake: true) go to the bottom and selected entries go to the top only if alwaysShowSelectedOnTop was passed


### PR DESCRIPTION
@johnmlee101 will you please review this?

Related to https://github.com/Expensify/Web-Expensify/pull/26769, use the spread operator to transfer all the properties of our Combobox options when making our truncated list.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/123956

# Tests/QA
1. Click on [+] to create expenses
1. Enter Name / Amount
1. Click on Attendees field
1. Search 'd' >> ''divider'
1. Select ''divider'
1. Make sure you see the "divider" text come in as a blue free-form option:
<img width="529" alt="Screen Shot 2020-01-29 at 1 52 21 PM" src="https://user-images.githubusercontent.com/4741899/73387610-cd02cc00-429e-11ea-9f03-5eb61f7a026b.png">

