### PR TITLE
Fix readonly prop in combobox

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -218,13 +218,13 @@ class Combobox extends React.Component {
 
         if (!_.isUndefined(nextProps.openOnInit) && !_.isEqual(nextProps.openOnInit, this.props.openOnInit)) {
             this.setState({
-                isDropdownOpen: this.props.openOnInit
+                isDropdownOpen: nextProps.openOnInit
             });
         }
 
-        if (!_.isUndefined(nextProps.isDisabled) && !_.isEqual(nextProps.isDisabled, this.props.isDisabled)) {
+        if (!_.isUndefined(nextProps.isReadOnly) && !_.isEqual(nextProps.isReadOnly, this.props.isReadOnly)) {
             this.setState({
-                isDisabled: this.props.isReadOnly
+                isDisabled: nextProps.isReadOnly
             });
         }
     }


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

Apparently this code was introduced in [this commit](https://github.com/Expensify/JS-Libs/commit/801cdb11b88780e882ee7010724f2fd68bd2b74f#diff-943035546d2322e43ef8b60dcd8ab131R190) but then the [diff in the PR does not show it](https://github.com/Expensify/JS-Libs/pull/112/files)... a bit weird, the message of the commit does not inspire confidence.

In any case, was trying to change the `isReadOnly` prop of the component and it was not working. There are 2 issues:
1. We were using the wrong prop name (I assume due to the fact is a weird name to begin with and does not match the state)
1. We were not passing the new prop, we kept the old one.

On top of that the last issue seems to be happening on `openOnInit`, I changed it, but did not test it really, but it seems as wrong as the other one, no?

### Fixed Issues
https://github.com/Expensify/Expensify/issues/125365

# Tests
1. Checkout https://github.com/Expensify/Web-Expensify/pull/26949
1. Check the timezone selector gets disabled/enabled when checking the automatic checkbox

# QA
1. No