### PR TITLE
[No QA] Update eslint to get new acorn package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "underscore": "1.9.1"
   },
   "devDependencies": {
-    "eslint-config-expensify": "2.0.1",
+    "eslint-config-expensify": "2.0.7",
     "grunt": "*",
-    "grunt-eslint": "21.0.0",
+    "grunt-eslint": "22.0.0",
     "grunt-chokidar": "1.0.0",
     "babelify": "10.0.0",
     "@babel/core": "7.6.4",


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/126666

# Tests
1. Run `npm i && npm list acorn`
1. Verify that acorn is on version 7.1.1

![image](https://user-images.githubusercontent.com/1228807/76240170-660af800-61f8-11ea-88fc-fa0e101c19f1.png)


# QA
None