### PR TITLE
Use underscore instead of $ for htmlEncoding

### DIFF
--- a/lib/ExpensiMark.jsx
+++ b/lib/ExpensiMark.jsx
@@ -46,7 +46,7 @@ export default class ExpensiMark {
      */
     replace(text) {
         // This ensures that any html the user puts into the comment field shows as raw html
-        text = Str.htmlEncode(text);
+        text = Str.safeEscape(text);
 
         this.rules.forEach((rule) => {
             text = text.replace(new RegExp(rule.regex, "g"), rule.replacement);


### PR DESCRIPTION
@yuwenmemon  will you please review this?

When adding the parser to mobile, it failed because htmlEncoding makes use of `$`, which isn't available on mobile. This PR updates the parser to use `safeEscape` instead, which works for both web and mobile.

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/127941

# Tests
1. qUnit tests for web
2. Tested using https://github.com/Expensify/Mobile-Expensify/pull/11561

# QA
None, qUnit tests will cover this when the hash is updated in Web-Expensify after this is merged
