### PR TITLE
Update the number of free SmartScans to 25

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -474,7 +474,7 @@ export const CONST = {
      */
     SMART_SCAN: {
         COST: 20,
-        FREE_NUMBER: 5
+        FREE_NUMBER: 25
     },
 
     SMS: {


### PR DESCRIPTION
@marcaaron - will you please review this? (Doesn't look like I can puller bear?)

We are updating the number of SmartScans from 5 ↪️25, this updates a constant that had the wrong number.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/129463

# Tests & QA
1. Create a new account 
2. Go to the bottom of [`Settings > Your Account > Preferences`](https://www.expensify.com.dev/settings?param={%22section%22:%22preferences%22})
3. Verify it states: `Your account is currently limited to 25 free SmartScans each month.` 
(❗Important piece being the **25**).

<img width="1539" alt="Screen Shot 2020-04-21 at 1 40 44 PM" src="https://user-images.githubusercontent.com/2838819/79911898-03e80a00-83d6-11ea-9164-20b8e99fa744.png">



