### PR TITLE
Add API call to delete domain notes

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -487,6 +487,21 @@ export default function API(network, args) {
             return performPOSTRequest(commandName, parameters);
         },
 
+        /**
+         * Performs API command Domain_DeleteNote
+         *
+         * @param {Object} parameters
+         * @param {String} parameters.note-html
+         * @param {String} [parameters.domainName]
+         *
+         * @returns {APIDeferred}
+         */
+        Domain_Delete_Note(parameters) {
+            const commandName = 'Domain_DeleteNote';
+            requireParameters(['note-html'], parameters, commandName)
+            return  performPOSTRequest(commandName, parameters);
+        },
+
         expensiworks: {
             /**
              * Get a job to work on


### PR DESCRIPTION
Just adding a new API command to delete notes. Full PR that uses this here https://github.com/Expensify/Web-Expensify/pull/27755

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/130372

# Tests
1. Checkout the web-expensify PR
2. Go to concierge
3. Go to the "user info" tab
4. Add a few notes
5. Click the trashcan next to the note
6. Make sure the note disappears

# QA
None
