### PR TITLE
Add SetPassword command to API.jsx

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -389,6 +389,7 @@ export default function API(network, args) {
 
         /**
          * Sets the password for an account
+         *
          * @param {Object} parameters
          * @param {String} parameters.email
          * @param {String} parameters.password


### PR DESCRIPTION
Adds `SetPassword` to API.jsx so we can call it in https://github.com/Expensify/Web-Expensify/pull/27904

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/130434

# Tests
❌ 

# QA
❌ 