### PR TITLE
Add ValidateEmail method to API.jsx

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -407,12 +407,12 @@ export default function API(network, args) {
          *
          * @param {Object} parameters
          * @param {String} validateCode
-         * @param {String} email
+         * @param {Number} accountID
          * @returns {ExpensifyAPIDeferred}
          */
         validateEmail(parameters) {
             const commandName = 'ValidateEmail';
-            requireParameters(['validateCode', 'email'], parameters, commandName);
+            requireParameters(['validateCode', 'accountID'], parameters, commandName);
             return performPOSTRequest(commandName, parameters);
         },
 


### PR DESCRIPTION
Adds `ValidateEmail` to `API.jsx` so we can validate an account via the homepage.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/130434

# Tests
1. Test in conjunction with [this Web-E PR](https://github.com/Expensify/Web-Expensify/pull/27958)

# QA
None