### PR TITLE
Hardcode cpa.com as a public domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-libs",
-  "version": "2.5.9",
+  "version": "2.5.8",
   "description": "JavaScript libraries that are shared across different repos",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
@marcaaron  will you please review this?

In addition to added `cpa.com` I put the domains in alphabetical order. Seems like we should and it might be helpful

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/132609

# No QA