### PR TITLE
Listen for PERSONAL_DETAILS_UPDATED events in ReportHistoryStore and clear cache if fired

### DIFF
--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -90,9 +90,10 @@ export default class ReportHistoryStore {
              * (like Web, Mobile) to assign which events would do so.
              *
              * @param {String[]} events
+             * @param {PubSub} pubSubInstance
              */
-            bindCacheClearingEvents(events) {
-                _.each(events, event => PubSub.subscribe(event, this.clearCache));
+            bindCacheClearingEvents(events, pubSubInstance = PubSub) {
+                _.each(events, event => pubSubInstance.subscribe(event, this.clearCache));
             },
 
             // We need this to be publically available for cases where we get the report history


### PR DESCRIPTION
@marcaaron please review

Allows us to clear out the report history store's cache. This is needed when having to refresh all report history items, like when you update your avatar.

### Fixed Issues
For https://github.com/Expensify/Expensify/issues/125803

# Tests/QA
See https://github.com/Expensify/Web-Expensify/pull/28490
