### PR TITLE
Add parameters to resendValidateCode

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -357,7 +357,7 @@ export default function API(network, args) {
          *
          * @return {ExpensifyAPIDeferred}
          */
-        resendValidateCode(parameters) {
+        resendValidateCode(parameters = {}) {
             const commandName = 'ResendValidateCode';
             return performPOSTRequest(commandName, {
                 ...parameters, 


### PR DESCRIPTION
@marcaaron will you please review this?

CC @Jag96  

This change is related to [this PR](https://github.com/Expensify/Web-Expensify/pull/28245). 

We were not taking parameters in this command for some reason. 

# Tests

I used this API command on Web-E with params before and after this change. After this change the behavior was as expected. 

# QA
No Web QA

