### PR TITLE
Added check for sms in combobox

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -265,7 +265,7 @@ class Combobox extends React.Component {
         const currentValue = this.initialValue || value;
 
         // We use removeSMSDomain here in case currentValue is a phone number
-        let defaultSelectedOption = _(this.options).find(o => Str.removeSMSDomain(o.value === currentValue && !o.isFake);
+        let defaultSelectedOption = _(this.options).find(o => Str.removeSMSDomain(o.value) === currentValue && !o.isFake);
 
         // If no default was found and initialText was present then we can use initialText values
         if (!defaultSelectedOption && this.initialText) {


### PR DESCRIPTION
Added a regex check for '@expensify.sms' to combobox, which allows it to display phone numbers properly on render. 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/137146

# Tests

I tested this change using the use case of the linked issue. 

# QA

Repeat the testing steps in the linked issue once this is merged and the SHA is bumped in Web-E