### PR TITLE
Add ExpensiMark regex for email, e.g. 'nmurray@expensify.com'

### DIFF
--- a/lib/ExpensiMark.jsx
+++ b/lib/ExpensiMark.jsx
@@ -66,15 +66,15 @@ export default class ExpensiMark {
                 replacement: '<code>$1</code>',
             },
             {
+                name: 'email',
+                regex: /\b[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\b/,
+                replacement: (match) => `<a href="mailto:${match}">${match}</a>`,
+            },
+            {
                 name: 'newline',
                 regex: /\n/,
                 replacement: '<br>',
             },
-            {
-                name: 'email',
-                regex: /\S+@\S+\.\S+/,
-                replacement: (match) => `<a href="mailto:${match}">${match}</a>`,
-            }
         ];
     }
 


### PR DESCRIPTION
Please review @marcaaron 

I opted for the HTML5 standard email validation regex noted [here](https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)). Swapped in word boundaries in case a user sends a large amount of text with an email address in it.

There isn't an email regex that works 100% of the time, and we could consider longer, more-specific ones like the [RFC 5322 compliant one](https://emailregex.com/index.html), or something even more simplistic. 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/138075

# Tests
1. Follow-up Web-E and Mobile-E PRs will have the tests.

# QA
No QA
