### PR TITLE
Don't apply Expensimark rules for strings inside code-fence

### DIFF
--- a/lib/ExpensiMark.jsx
+++ b/lib/ExpensiMark.jsx
@@ -17,7 +17,7 @@ export default class ExpensiMark {
                 name: 'codeFence',
 
                 // &#60; is a backtick symbol we are matching on three of them before then after a new line character
-                regex: /&#x60;&#x60;&#x60;\n((?:(?!&#x60;&#x60;&#x60;)[\s\S])+)\n&#x60;&#x60;&#x60;/,
+                regex: /&#x60;&#x60;&#x60;\n((?:(?!&#x60;&#x60;&#x60;)[\s\S])+)\n&#x60;&#x60;&#x60;/g,
                 replacement: (match, firstCapturedGroup) => {
 
                     // We're using a function here to perform an additional replace on the content inside the backticks because
@@ -33,12 +33,12 @@ export default class ExpensiMark {
              */
             {
                 name: 'link',
-                regex: /\[([\w\s\d]+)\]\(((?:\/|https?:\/\/)[\w\d./?=#]+)\)(?![^<]*<\/pre>)/,
+                regex: /\[([\w\s\d]+)\]\(((?:\/|https?:\/\/)[\w\d./?=#]+)\)(?![^<]*<\/pre>)/g,
                 replacement: '<a href="$2" target="_blank">$1</a>',
             },
             {
                 name: 'autolink',
-                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)[^\s<>*~_"\'´.-][^\s<>"\'´]*?\.[a-z\d]+[^\s<>*~"\']*)\1(?![^<]*<\/pre>)/,
+                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)[^\s<>*~_"\'´.-][^\s<>"\'´]*?\.[a-z\d]+[^\s<>*~"\']*)\1(?![^<]*<\/pre>)/g,
                 replacement: '$1<a href="$2" target="_blank">$2</a>$1',
             },
             {
@@ -48,30 +48,30 @@ export default class ExpensiMark {
                  * Additionally, something like `\b\_([^<>]*?)\_\b` doesn't work because it won't replace `_https://www.test.com_`
                  */
                 name: 'italic',
-                regex: /(?!_blank">)\b\_(.*?)\_\b(?![^<]*<\/pre>)/,
+                regex: /(?!_blank">)\b\_(.*?)\_\b(?![^<]*<\/pre>)/g,
                 replacement: '<em>$1</em>'
             },
             {
                 // Use \B in this case because \b doesn't match * or ~. \B will match everything that \b doesn't, so it works for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*(.*?)\*\B(?![^<]*<\/pre>)/,
+                regex: /\B\*(.*?)\*\B(?![^<]*<\/pre>)/g,
                 replacement: '<strong>$1</strong>'
             },
             {
                 name: 'strikethrough',
-                regex: /\B\~(.*?)\~\B(?![^<]*<\/pre>)/,
+                regex: /\B\~(.*?)\~\B(?![^<]*<\/pre>)/g,
                 replacement: '<del>$1</del>'
             },
             {
                 name: 'inlineCodeBlock',
 
                 // Use the url escaped version of a backtick (`) symbol
-                regex: /\B&#x60;(.*?)&#x60;\B(?![^<]*<\/pre>)/,
+                regex: /\B&#x60;(.*?)&#x60;\B(?![^<]*<\/pre>)/g,
                 replacement: '<code>$1</code>',
             },
             {
                 name: 'newline',
-                regex: /\n/,
+                regex: /\n/g,
                 replacement: '<br>',
             },
         ];
@@ -89,7 +89,7 @@ export default class ExpensiMark {
         let replacedText = Str.safeEscape(text);
 
         this.rules.forEach((rule) => {
-            replacedText = replacedText.replace(new RegExp(rule.regex, "g"), rule.replacement);
+            replacedText = replacedText.replace(rule.regex, rule.replacement);
         });
 
         return replacedText;


### PR DESCRIPTION
@marcaaron will you please review this?
cc @francoisl 

We were applying ExpensiMark replacements on syntax inside code fences, which we probably want to avoid:
<img width="838" alt="Screen Shot 2020-09-09 at 6 13 28 PM" src="https://user-images.githubusercontent.com/4741899/92670124-2bc60480-f2c8-11ea-8c02-7234ba7cb4ff.png">

### Fixed Issues
None, just noticed in the wild.

# Tests
- Added QUnit tests

# QA
- Add a code fenced comment to a report with other syntax inside of it (copy paste this in but remove the `\`s):
```
\`\`\`
This is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)
\`\`\`
```

- Compare that to pasting in the text raw.
- Make sure that the code block does not remove any of the special syntax:
<img width="903" alt="Screen Shot 2020-09-09 at 6 20 47 PM" src="https://user-images.githubusercontent.com/4741899/92670598-3503a100-f2c9-11ea-9f58-e47c6b682498.png">


