### PR TITLE
Add string check for removeSMSDomain

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -266,8 +266,8 @@ class Combobox extends React.Component {
 
         // We use removeSMSDomain here in case currentValue is a phone number
         let defaultSelectedOption = _(this.options).find(o => {
-            (Str.isString(o) ? Str.removeSMSDomain(o.value) : o.value) === currentValue
-            && !o.isFake
+            return (Str.isString(o) ? Str.removeSMSDomain(o.value) : o.value) === currentValue
+            && !o.isFake;
         });
 
         // If no default was found and initialText was present then we can use initialText values


### PR DESCRIPTION
Fix for bug caused by calling `removeSMSDomain` with a non-string value

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/141045

# Tests/QA
1. Login and go to expenses and create a new expense
2. Verify that the expense dialog is displayed and no errors are printed to the console
