### PR TITLE
Don't process markdown inside inline code-blocks

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -138,8 +138,8 @@ test('Test links that end in a comma autolink correctly', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test links inside two backticks autolink correctly', () => {
+test('Test links inside two backticks are not autolinked', () => {
     const testString = '`https://github.com/Expensify/Expensify/issues/143231`';
-    const resultString = '<code><a href="https://github.com/Expensify/Expensify/issues/143231" target="_blank">https://github.com/Expensify/Expensify/issues/143231</a></code>';
+    const resultString = '<code>https://github.com/Expensify/Expensify/issues/143231</code>';
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -31,31 +31,7 @@ export default class ExpensiMark {
             },
 
             /**
-             * Converts markdown style links to anchor tags e.g. [Expensify](https://www.expensify.com)
-             * We need to convert before the autolink rule since it will not try to create a link
-             * from an existing anchor tag.
-             */
-            {
-                name: 'link',
-                regex: /\[([\w\s\d!?]+)\]\((((?:https?):\/\/|www\.)[-\w\d./?=#{%:}]+)\)(?![^<]*<\/pre>)/g,
-                replacement: '<a href="$2" target="_blank">$1</a>',
-            },
-            {
-                name: 'autolink',
-                // eslint-disable-next-line max-len
-                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)[^\s<>*~_"'´.-][^\s<>"'´]*?\.[a-z\d]+[^\s)<>*~"',`]*)\1(?![^<]*<\/pre>)/g,
-                pre: (string) => {
-                    return string.replace(/&#x60;/g, '`');
-                },
-                post: (string) => {
-                    return string.replace(/`/g, '&#x60;');
-                },
-                replacement: (match, firstGroup, secondGroup) => {
-                    return `${firstGroup}<a href="${secondGroup}" target="_blank">${secondGroup}</a>${firstGroup}`;
-                },
-            },
-            /**
-             * Apply this rule first to avoid formatting strings inside an inline code-block
+             * Apply inline code-block to avoid applying any other formatting rules inside of it,
              * like we do for the multi-line code-blocks
              */
             {
@@ -64,6 +40,25 @@ export default class ExpensiMark {
                 // Use the url escaped version of a backtick (`) symbol
                 regex: /\B&#x60;(.*?)&#x60;\B(?![^<]*<\/pre>)/g,
                 replacement: '<code>$1</code>',
+            },
+
+            /**
+             * Converts markdown style links to anchor tags e.g. [Expensify](https://www.expensify.com)
+             * We need to convert before the autolink rule since it will not try to create a link
+             * from an existing anchor tag.
+             */
+            {
+                name: 'link',
+                regex: /\[([\w\s\d!?]+)\]\((((?:https?):\/\/|www\.)[-\w\d./?=#{%:}]+)\)(?![^<]*(<\/pre>|<\/code>))/g,
+                replacement: '<a href="$2" target="_blank">$1</a>',
+            },
+            {
+                name: 'autolink',
+                // eslint-disable-next-line max-len
+                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)[^\s<>*~_"'´.-][^\s<>"'´]*?\.[a-z\d]+[^\s)<>*~"',`]*)\1(?![^<]*(<\/pre>|<\/code>))/g,
+                replacement: (match, firstGroup, secondGroup) => {
+                    return `${firstGroup}<a href="${secondGroup}" target="_blank">${secondGroup}</a>${firstGroup}`;
+                },
             },
             {
                 /**


### PR DESCRIPTION
Skip applying ExpensiMark rules for strings inside an inline code-fence. 

More context [here](https://expensify.slack.com/archives/C011W8BJ9L6/p1602661558038700).

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/143244

# Tests
Added test case to `__tests__/ExpensiMark-test.js`

# QA
Test that markdown special characters inside inline code blocks on web, mobile, and native chat are not formatted.

![Screen Shot 2020-10-15 at 3 21 55 PM](https://user-images.githubusercontent.com/12268372/96118723-f468fa00-0efc-11eb-9c9a-511b7bbec240.png)
