### PR TITLE
Match links when there are periods at the end

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -98,7 +98,6 @@ test('Test url replacements', () => {
         + 'test again '
         + 'http://test.com/test '
         + 'www.test.com '
-        + 'https://www.test.com '
         + 'http://test.com)';
 
     const urlTestReplacedString = 'Testing '
@@ -106,10 +105,15 @@ test('Test url replacements', () => {
         + 'test again '
         + '<a href="http://test.com/test" target="_blank">http://test.com/test</a> '
         + '<a href="www.test.com" target="_blank">www.test.com</a> '
-        + '<a href="https://www.test.com" target="_blank">https://www.test.com</a> '
         + '<a href="http://test.com" target="_blank">http://test.com</a>)';
 
     expect(parser.replace(urlTestStartString)).toBe(urlTestReplacedString);
+});
+
+test('Auto-link works on a www. test url', () => {
+    const testString = 'https://www.test.com';
+    const resultString = '<a href="https://www.test.com" target="_blank">https://www.test.com</a>';
+    expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test markdown style link with various styles', () => {
@@ -141,5 +145,11 @@ test('Test links that end in a comma autolink correctly', () => {
 test('Test links inside two backticks are not autolinked', () => {
     const testString = '`https://github.com/Expensify/Expensify/issues/143231`';
     const resultString = '<code>https://github.com/Expensify/Expensify/issues/143231</code>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test a period at the end of a link autolinks correctly', () => {
+    const testString = 'https://github.com/Expensify/ReactNativeChat/pull/645.';
+    const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/645</a>.';
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -55,10 +55,8 @@ export default class ExpensiMark {
             {
                 name: 'autolink',
                 // eslint-disable-next-line max-len
-                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)[^\s<>*~_"'´.-][^\s<>"'´]*?\.[a-z\d]+[^\s)<>*~"',`]*)\1(?![^<]*(<\/pre>|<\/code>))/g,
-                replacement: (match, firstGroup, secondGroup) => {
-                    return `${firstGroup}<a href="${secondGroup}" target="_blank">${secondGroup}</a>${firstGroup}`;
-                },
+                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)([a-z]+.)?[^\s<>*~_"'´.-][^\s<>"'´]*?\.[a-z\d]+[^\s)<>*~"',`\.]+)\1(?![^<]*(<\/pre>|<\/code>))/g,
+                replacement: '$1<a href="$2" target="_blank">$2</a>$1',
             },
             {
                 /**


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/143811

# Tests
1. Added `ExpensiMark` test for this case in Jest made sure nothing else is breaking

# QA
1. Write a text link comment (auto link style) with a `.` symbol at the end verify it auto links without the `.` symbol.