### PR TITLE
Improve Expensimark to better handle links

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -123,7 +123,9 @@ test('Test markdown style link with various styles', () => {
         + '[Expensify!](https://www.expensify.com) '
         + '[Expensify?](https://www.expensify.com) '
         + '[Expensify](https://www.expensify-test.com) '
-        + '[Expensify](https://www.expensify.com/settings?param={%22section%22:%22account%22})';
+        + '[Expensify](https://www.expensify.com/settings?param={%22section%22:%22account%22}) '
+        + '[Expensify](https://www.expensify.com/settings?param=(%22section%22+%22account%22)) '
+        + '[Expensify](https://www.expensify.com/settings?param=[%22section%22:%22account%22])';
 
     const resultString = 'Go to <del><a href="https://www.expensify.com" target="_blank">Expensify</a></del> '
         + '<em><a href="https://www.expensify.com" target="_blank">Expensify</a></em> '
@@ -131,7 +133,9 @@ test('Test markdown style link with various styles', () => {
         + '<a href="https://www.expensify.com" target="_blank">Expensify!</a> '
         + '<a href="https://www.expensify.com" target="_blank">Expensify?</a> '
         + '<a href="https://www.expensify-test.com" target="_blank">Expensify</a> '
-        + '<a href="https://www.expensify.com/settings?param={%22section%22:%22account%22}" target="_blank">Expensify</a>';
+        + '<a href="https://www.expensify.com/settings?param={%22section%22:%22account%22}" target="_blank">Expensify</a> '
+        + '<a href="https://www.expensify.com/settings?param=(%22section%22+%22account%22)" target="_blank">Expensify</a> '
+        + '<a href="https://www.expensify.com/settings?param=[%22section%22:%22account%22]" target="_blank">Expensify</a>';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -139,6 +143,12 @@ test('Test markdown style link with various styles', () => {
 test('Test links that end in a comma autolink correctly', () => {
     const testString = 'https://github.com/Expensify/Expensify/issues/143231,';
     const resultString = '<a href="https://github.com/Expensify/Expensify/issues/143231" target="_blank">https://github.com/Expensify/Expensify/issues/143231</a>,';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test links that have a comma in the middle autolink correctly', () => {
+    const testString = 'https://github.com/Expensify/Expensify/issues/143,231';
+    const resultString = '<a href="https://github.com/Expensify/Expensify/issues/143,231" target="_blank">https://github.com/Expensify/Expensify/issues/143,231</a>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -151,5 +161,11 @@ test('Test links inside two backticks are not autolinked', () => {
 test('Test a period at the end of a link autolinks correctly', () => {
     const testString = 'https://github.com/Expensify/ReactNativeChat/pull/645.';
     const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/645</a>.';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test a period in the middle of a link autolinks correctly', () => {
+    const testString = 'https://github.com/Expensify/ReactNativeChat/pull/6.45';
+    const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/6.45" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/6.45</a>';
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -49,13 +49,13 @@ export default class ExpensiMark {
              */
             {
                 name: 'link',
-                regex: /\[([\w\s\d!?]+)\]\((((?:https?):\/\/|www\.)[-\w\d./?=#{%:}()+&;[\]]+)\)($|\s|[.,;])(?![^<]*(<\/pre>|<\/code>))/g,
+                regex: /\[([\w\s\d!?]+)\]\((((?:https?):\/\/|www\.)[-\w\d./?=#{%:}()+&;[\]]+)\)($|\s|[.,;~_*])(?![^<]*(<\/pre>|<\/code>))/g,
                 replacement: '<a href="$2" target="_blank">$1</a>$4',
             },
             {
                 name: 'autolink',
                 // eslint-disable-next-line max-len
-                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)([a-z]+.)?[^\s<>*~_"'´.-][^\s<>"'´]*?\.[a-z\d]+[^\s<>*~"'`]+[^).,])\1(?![^<]*(<\/pre>|<\/code>))/g,
+                regex: /(?![^<]*>|[^<>]*<\/)([_*~]*?)(((?:https?):\/\/|www\.)([a-z]+.)?[^\s<>*~_"'´.-][^\s<>"'´]*?\.[a-z\d]+[^\s<>*~"'`]+[^).,:;\s])\1(?![^<]*(<\/pre>|<\/code>))/g,
                 replacement: '$1<a href="$2" target="_blank">$2</a>$1',
             },
             {


### PR DESCRIPTION
@marcaaron, can you review this? Since we both keep touching it, let's make sure we never undo each other's efforts 😆  

A few new things going on here:
- Regular links may have both commas `,` and dots `.` after the `.com` part (for example, `.com.dev`!), so let's allow those.
- Links in the `[link](www.link.com)` form may contain additional parentheses in the `www.link.com` part, so we need to make sure to grab them (but still ignore the last one). To do so, we'll interpret as "last" closing parenthesis anyone followed by a whitespace, end of the line, `.`, `,` or `;`, which are combinations I wouldn't expect to see in a link but are common in regular writing or followed by other markup symbols (there are already automated tests in place to check this).
- We need to handle a few additional characters in there too: `+ [ ] ( ) ;`, as they may exist in links.

### Fixed Issues
 https://github.com/Expensify/Expensify/issues/144272

# Tests
Updated automated tests

# QA
To be done in the [web PR](https://github.com/Expensify/Web-Expensify/pull/29517)

