### PR TITLE
Also catch encoded characters in the link regex

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -28,8 +28,8 @@ test('Test strikethrough markdown replacement', () => {
 
 // Markdown style links replaced successfully
 test('Test markdown style links', () => {
-    const testString = 'Go to [Expensify](https://www.expensify.com) to learn more. [Expensify](www.expensify.com) [Expensify](expensify.com)';
-    const resultString = 'Go to <a href="https://www.expensify.com" target="_blank">Expensify</a> to learn more. <a href="http://www.expensify.com" target="_blank">Expensify</a> <a href="http://expensify.com" target="_blank">Expensify</a>';
+    const testString = 'Go to [Expensify](https://www.expensify.com) to learn more. [Expensify](www.expensify.com) [Expensify](expensify.com) [It\'s really the coolest](expensify.com)';
+    const resultString = 'Go to <a href="https://www.expensify.com" target="_blank">Expensify</a> to learn more. <a href="http://www.expensify.com" target="_blank">Expensify</a> <a href="http://expensify.com" target="_blank">Expensify</a> <a href="http://expensify.com" target="_blank">It&#x27;s really the coolest</a>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -52,7 +52,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'link',
-                regex: new RegExp(`\\[([\\w\\s\\d!?]+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi'),
+                regex: new RegExp(`\\[([\\w\\s\\d!?&#;]+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi'),
 
                 // We use a function here to check if there is already a https:// on the link. If there is not, we force
                 // the link to be absolute by prepending '//' to the target.


### PR DESCRIPTION
Catches encoded characters (like `'`) in the named part of a markdown link

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/146204

# Tests
Automated tests, manual tests will be conducted in RNC

# QA
N/A