### PR TITLE
Lowercase returned extensions

### DIFF
--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -9,6 +9,11 @@ describe('Str.isImage', () => {
         expect(Str.isImage(buildTestURLForType('jpg'))).toBeTruthy();
         expect(Str.isImage(buildTestURLForType('bmp'))).toBeTruthy();
         expect(Str.isImage(buildTestURLForType('png'))).toBeTruthy();
+        expect(Str.isImage(buildTestURLForType('GIF'))).toBeTruthy();
+        expect(Str.isImage(buildTestURLForType('JPEG'))).toBeTruthy();
+        expect(Str.isImage(buildTestURLForType('JPG'))).toBeTruthy();
+        expect(Str.isImage(buildTestURLForType('BMP'))).toBeTruthy();
+        expect(Str.isImage(buildTestURLForType('PNG'))).toBeTruthy();
     });
 
     it('Does not confirm these types', () => {
@@ -23,5 +28,6 @@ describe('Str.isImage', () => {
 describe('Str.isPDF', () => {
     it('Correctly identifies PDF', () => {
         expect(Str.isPDF(buildTestURLForType('pdf'))).toBeTruthy();
+        expect(Str.isPDF(buildTestURLForType('PDF'))).toBeTruthy();
     });
 });

--- a/lib/str.js
+++ b/lib/str.js
@@ -996,7 +996,7 @@ const Str = {
      * @returns {String}
      */
     getExtension(url) {
-        return _.first(_.last(url.split('.')).split('?'));
+        return _.first(_.last(url.split('.')).split('?')).toLowerCase();
     },
 
     /**


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/148293

# Tests
1. Automated tests updated. 
2. QA

# QA
1. Apply these changes to RNC (https://github.com/Expensify/ReactNativeChat/pull/967)
2. Attempt to upload an image that you have changed the file extension to be caps for (IE .png->.PNG)
3. _Verify_ you get a preview of the image
![image](https://user-images.githubusercontent.com/22447860/102263663-7d82ba00-3ec9-11eb-9f18-abf424f70c82.png)

