### PR TITLE
Move from BOTIFY to OS_BOTIFY

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
               uses: cla-assistant/github-action@v2.0.2-alpha
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PERSONAL_ACCESS_TOKEN : ${{ secrets.BOTIFY_TOKEN }}
+                  PERSONAL_ACCESS_TOKEN : ${{ secrets.OS_BOTIFY_TOKEN }}
               with:
                   path-to-signatures: '${{ github.repository }}/cla.json'
                   path-to-document: 'https://github.com/${{ github.repository }}/blob/master/CLA.md'


### PR DESCRIPTION
@rafecolton - Will you please review?

Similar to https://github.com/Expensify/react-native-onyx/pull/27

Let's make a few changes in the settings:
1. Remove `BOTIFY` secret from this repo
3. Add `OS_BOTIFY_TOKEN`
4. Then let's merge this PR and I will verify everything is good.
