### PR TITLE
Use https for public dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7785,9 +7785,8 @@
       "dev": true
     },
     "simply-deferred": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/simply-deferred/-/simply-deferred-3.0.0.tgz",
-      "integrity": "sha1-bWagZMHysHERyATg7EMlp7UYYp0="
+      "version": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+      "from": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5"
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
-    "simply-deferred": "git+https://git@github.com:Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+    "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
     "underscore": "1.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
@Jag96 - Will you please reivew?

Since `simply-deferred` is public we can use https to clone it instead of ssh, once this is merged it will allow `expensify.cash` and `react-native-onyx` to build without any need for SSH keys.

### Fixed Issues
https://github.com/Expensify/react-native-onyx/runs/1579163896#step:5:5

# Tests
1. Make sure npm install works
2. Make sure actions pass
