### PR TITLE
Replaced non-breaking spaces with equivalent ascii space Fixes Expensify/Expensify.cash/#993

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -15,7 +15,7 @@ test('Test bold markdown replacement', () => {
 // Words wrapped in * successfully replaced with <strong></strong>
 test('Test quote markdown replacement', () => {
     const quoteTestStartString = '&gt;This is a *quote* that started on a new line.\nHere is a &gt;quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not<br><pre>here&nbsp;is&nbsp;a&nbsp;codefenced&nbsp;quote<br>&gt;it&nbsp;should&nbsp;not&nbsp;be&nbsp;quoted</pre>';
+    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not<br><pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br>&gt;it&#32;should&#32;not&#32;be&#32;quoted</pre>';
 
     expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
 });
@@ -63,12 +63,12 @@ test('Test period replacements', () => {
 
 test('Test code fencing', () => {
     const codeFenceExampleMarkdown = '```\nconst javaScript = \'javaScript\'\n```';
-    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&nbsp;javaScript&nbsp;=&nbsp;&#x27;javaScript&#x27;</pre>');
+    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
 });
 
 test('Test code fencing with spaces and new lines', () => {
     const codeFenceExample = '```\nconst javaScript = \'javaScript\'\n    const php = \'php\'\n```';
-    expect(parser.replace(codeFenceExample)).toBe('<pre>const&nbsp;javaScript&nbsp;=&nbsp;&#x27;javaScript&#x27;<br>&nbsp;&nbsp;&nbsp;&nbsp;const&nbsp;php&nbsp;=&nbsp;&#x27;php&#x27;</pre>');
+    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br>&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
 });
 
 test('Test inline code blocks', () => {
@@ -83,7 +83,7 @@ test('Test inline code blocks with ExpensiMark syntax inside', () => {
 
 test('Test code fencing with ExpensiMark syntax inside', () => {
     const codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
-    expect(parser.replace(codeFenceExample)).toBe('<pre>This&nbsp;is&nbsp;how&nbsp;you&nbsp;can&nbsp;write&nbsp;~strikethrough~,&nbsp;*bold*,&nbsp;_italics_,&nbsp;and&nbsp;[links](https://www.expensify.com)</pre>');
+    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
 });
 
 test('Test combination replacements', () => {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -31,8 +31,9 @@ export default class ExpensiMark {
                 // not respect whitespace characters at all like HTML does. We do not want to mess
                 // with the new lines here since they need to be converted into <br>. And we don't
                 // want to do this anywhere else since that would break HTML.
+                // &nbsp; will create styling issues so use &#32;
                 replacement: (match, firstCapturedGroup) => {
-                    const group = firstCapturedGroup.replace(/(?:(?![\n\r])\s)/g, '&nbsp;');
+                    const group = firstCapturedGroup.replace(/(?:(?![\n\r])\s)/g, '&#32;');
                     return `<pre>${group}</pre>`;
                 },
             },


### PR DESCRIPTION
**Causing text wrapping issues in Expensify.cash**

 @marcaaron Please review it.

After testing I found out the using `&nbsp;` chars instead on spaces are creating a one big line which as a result will break into new lines on the browser or rendering engine's mercy. Usually, the result would be that words will break into multiple lines.


### Fixed Issues
 Fixes https://github.com/Expensify/Expensify.cash/issues/993

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
   Jest tests

2. What tests did you perform that validates your change worked?

   I performed visual testing on the Expensify.cash where results are as follows:
![Screenshot_2020-12-31 Expensify cash](https://user-images.githubusercontent.com/24370807/103387698-33394400-4b2b-11eb-91d7-2b2643f3b7d2.png)

The first one is the issue and the second one is the result. Same result on the mobile app.
