### PR TITLE
fix email rendering bug

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -145,7 +145,7 @@ test('Test url replacements', () => {
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/6.45" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/6.45</a> '
         + '<a href="https://github.com/Expensify/Expensify/issues/143,231" target="_blank">https://github.com/Expensify/Expensify/issues/143,231</a> '
         + '<a href="http://testRareTLDs.beer" target="_blank">testRareTLDs.beer</a> '
-        + 'test@expensify.com '
+        + '<a href="mailto:test@expensify.com">test@expensify.com</a> '
         + 'test.completelyFakeTLD '
         + 'mm..food';
 
@@ -205,3 +205,34 @@ test('Test a url ending with a closing parentheses autolinks correctly', () => {
     const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/645</a>)';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test markdown style email link with various styles', () => {
+    const testString = 'Go to ~[Expensify](concierge@expensify.com)~ '
+        + '_[Expensify](concierge@expensify.com)_ '
+        + '*[Expensify](concierge@expensify.com)* '
+        + '[Expensify!](no-concierge1@expensify.com) '
+        + '[Expensify?](concierge?@expensify.com) ';
+
+    const resultString = 'Go to <del><a href="mailto:concierge@expensify.com">Expensify</a></del> '
+        + '<em><a href="mailto:concierge@expensify.com">Expensify</a></em> '
+        + '<strong><a href="mailto:concierge@expensify.com">Expensify</a></strong> '
+        + '<a href="mailto:no-concierge1@expensify.com">Expensify!</a> '
+        + '<a href="mailto:concierge?@expensify.com">Expensify?</a> ';
+
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test general email link with various styles', () => {
+    const testString = 'Go to concierge@expensify.com '
+        + 'no-concierge@expensify.com '
+        + 'concierge!@expensify.com '
+        + 'concierge1?@expensify.com ';
+
+    const resultString = 'Go to <a href="mailto:concierge@expensify.com">concierge@expensify.com</a> '
+        + '<a href="mailto:no-concierge@expensify.com">no-concierge@expensify.com</a> '
+        + '<a href="mailto:concierge!@expensify.com">concierge!@expensify.com</a> '
+        + '<a href="mailto:concierge1?@expensify.com">concierge1?@expensify.com</a> ';
+
+    expect(parser.replace(testString)).toBe(resultString);
+});
+

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -64,7 +64,7 @@ export default class ExpensiMark {
                 regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)(?![^<]*(<\\pre>|<\\code>))/gim,
                 replacement: '<a href="mailto:$2">$2</a>'
             },
-            
+
             /**
              * Converts markdown style links to anchor tags e.g. [Expensify](https://www.expensify.com)
              * We need to convert before the autolink rule since it will not try to create a link

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -50,6 +50,22 @@ export default class ExpensiMark {
             },
 
             /**
+             * Converts markdown style links to anchor tags e.g. [Expensify](concierge@expensify.com)
+             * We need to convert before the auto email link rule since it will not try to create a link
+             * from an existing anchor tag.
+             */
+            {
+                name: 'email',
+                regex: /\[([\w\\s\\d!?&#;]+)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)\)/gim,
+                replacement: '<a href="mailto:$2">$1</a>'
+            },
+            {
+                name: 'autoEmail',
+                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)(?![^<]*(<\\pre>|<\\code>))/gim,
+                replacement: '<a href="mailto:$2">$2</a>'
+            },
+            
+            /**
              * Converts markdown style links to anchor tags e.g. [Expensify](https://www.expensify.com)
              * We need to convert before the autolink rule since it will not try to create a link
              * from an existing anchor tag.


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

This PR fixed email link rendering bug by adding additional email regular expressions to the current rules.

### Fixed Issues
Expensify/Expensify.cash#990

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
