### PR TITLE
Add @CLABotify and apply new version for CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: "CLA Assistant"
+name: CLA Assistant
 
 on:
     issue_comment:
@@ -10,12 +10,23 @@ jobs:
     CLA:
         runs-on: ubuntu-latest
         steps:
-            - name: "CLA Assistant"
-              if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-              uses: cla-assistant/github-action@v2.0.2-alpha
+            - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
+              id: sign
+              with:
+                  text: ${{ github.event.comment.body }}
+                  regex: '\s*I have read the CLA Document and I hereby sign the CLA\s*'
+            - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
+              id: recheck
+              with:
+                  text: ${{ github.event.comment.body }}
+                  regex: '\s*recheck\s*'
+            - name: CLA Assistant
+              if: ${{ steps.recheck.outputs.match != '' || steps.sign.outputs.match != '' }} || github.event_name == 'pull_request_target'
+                # Version: 2.0.3-alpha
+              uses: cla-assistant/github-action@c89158d361bea4a5a06ff7781b6c4e8aa49dbcc9
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PERSONAL_ACCESS_TOKEN : ${{ secrets.OS_BOTIFY_TOKEN }}
+                  PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOTIFY_TOKEN }}
               with:
                   path-to-signatures: '${{ github.repository }}/cla.json'
                   path-to-document: 'https://github.com/${{ github.repository }}/blob/master/CLA.md'


### PR DESCRIPTION
Please review @coleaeason 

### Details
Adds @CLABotify to handle CLA signatures

### Fixed Issues
Fixes 1 /3 of https://github.com/Expensify/Expensify/issues/148866

### Tests
1. Make a PR (e.g. this one)
2. Make sure CLA botify passes, if it does, it means the token has access to the repo.
