### PR TITLE
Fixed URL highlight

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 import ExpensiMark from '../lib/ExpensiMark';
+
 const parser = new ExpensiMark();
 
 // Words wrapped in * successfully replaced with <strong></strong>
@@ -38,6 +39,25 @@ test('Test strikethrough markdown replacement', () => {
 test('Test markdown style links', () => {
     const testString = 'Go to [Expensify](https://www.expensify.com) to learn more. [Expensify](www.expensify.com) [Expensify](expensify.com) [It\'s really the coolest](expensify.com)';
     const resultString = 'Go to <a href="https://www.expensify.com" target="_blank">Expensify</a> to learn more. <a href="http://www.expensify.com" target="_blank">Expensify</a> <a href="http://expensify.com" target="_blank">Expensify</a> <a href="http://expensify.com" target="_blank">It&#x27;s really the coolest</a>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+// Critical Markdown style links replaced successfully
+test('Test critical markdown style links', () => {
+    const testString = 'Testing '
+    + '[first](https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878) '
+    + '[first no https://](www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878) '
+    + '[second](http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled) '
+    + '[second no http://](necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled) '
+    + '[third](https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) '
+    + '[third no https://](github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash)';
+    const resultString = 'Testing '
+    + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">first</a> '
+    + '<a href="http://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">first no https://</a> '
+    + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">second</a> '
+    + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">second no http://</a> '
+    + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">third</a> '
+    + '<a href="http://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">third no https://</a>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -123,6 +143,10 @@ test('Test url replacements', () => {
         + 'testRareTLDs.beer '
         + 'test@expensify.com '
         + 'test.completelyFakeTLD '
+        + 'https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878) '
+        + 'http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled '
+        + 'https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash '
+        + 'https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash '
         + 'mm..food';
 
     const urlTestReplacedString = 'Testing '
@@ -147,6 +171,10 @@ test('Test url replacements', () => {
         + '<a href="http://testRareTLDs.beer" target="_blank">testRareTLDs.beer</a> '
         + '<a href="mailto:test@expensify.com">test@expensify.com</a> '
         + 'test.completelyFakeTLD '
+        + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878)" target="_blank">https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878)</a> '
+        + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled</a> '
+        + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> '
+        + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> '
         + 'mm..food';
 
     expect(parser.replace(urlTestStartString)).toBe(urlTestReplacedString);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -3,8 +3,8 @@ import TLD_REGEX from './tlds';
 
 const URL_WEBSITE_REGEX = `(https?:\\/\\/)?((?:www\\.)?[-a-z0-9]+?\\.)+(?:${TLD_REGEX})(?:\\:\\d{2,4}|\\b|(?=_))`;
 const URL_PATH_REGEX = '(?:\\/[-\\w$@.&+!*"\'(),=%]*[-\\w~@:%)]|\\/)*';
-const URL_PARAM_REGEX = '(?:\\?[-\\w$@.&+!*"\'(),=%{}:;\\[\\]]+)?';
-const URL_FRAGMENT_REGEX = '(?:#[-\\w$@.&+!*"\'(),=%;\\/]*)?';
+const URL_PARAM_REGEX = '(?:\\?[-\\w$@.&+!*"\'()\\/,=%{}:;\\[\\]]+)?';
+const URL_FRAGMENT_REGEX = '(?:#[-\\w$@.&+!*"\'()[\\],=%;\\/:~]*)?';
 const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}${URL_PARAM_REGEX}${URL_FRAGMENT_REGEX})`;
 
 export default class ExpensiMark {
@@ -76,7 +76,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `\\[([\\w\\s\\d!?&#;]+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
+                        `\\[([\\w\\s\\d!?&#;:\\/]+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
@@ -115,7 +115,7 @@ export default class ExpensiMark {
                  * `_https://www.test.com_`
                  */
                 name: 'italic',
-                regex: /(?!_blank">)\b_(.*?)_\b(?![^<]*(<\/pre>|<\/code>))/g,
+                regex: /(?!_blank">)\b_(.*?)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<em>$1</em>'
             },
             {
@@ -123,12 +123,12 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*(.*?)\*\B(?![^<]*(<\/pre>|<\/code>))/g,
+                regex: /\B\*(.*?)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<strong>$1</strong>'
             },
             {
                 name: 'strikethrough',
-                regex: /\B~(.*?)~\B(?![^<]*(<\/pre>|<\/code>))/g,
+                regex: /\B~(.*?)~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<del>$1</del>'
             },
             {


### PR DESCRIPTION
@roryabraham @kadiealexander  will you please review this?

Fixed the URL highlighting issue when URL's included `:`, `~`, `/` _(on param)_, `[` and `]`. 
Added ability to use `:` and `/` on a link text (between `[` and `]`).

Made sure all three URL's mentioned on the issue page worked, without causing regressions. Added tests for all this cases, and plus a couple more I could think of (and was having trouble with).

### Fixed Issues
Fixes [#1234](https://github.com/Expensify/Expensify.cash/issues/1234)

# Tests & QA
1. What unit/integration tests cover your change? What autoQA tests cover your change?

Added quite a number of test URL's on `ExpensiMark-test.js`.


2. What tests did you perform that validates your changed worked?

On the gifs presented next, the following string was pasted on all the platforms:
```
Testing [first](https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878), [second](http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled), and [third](http://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash)!
```

#### Web
![desktop](https://i.ibb.co/S0PBqLJ/web.gif)

#### Desktop
![desktop](https://i.ibb.co/xYWD8D3/desktop.gif)

#### Android
![android](https://i.ibb.co/JpbccMR/android.gif)

#### iOS
![ios](https://i.ibb.co/MDS8gqC/ios.gif)