### PR TITLE
[No QA] Bump version to prep for npm deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "expensify-common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expensify-common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Expensify, Inc.",
   "description": "Expensify libraries and components shared across different repos",
   "homepage": "https://expensify.com",


### PR DESCRIPTION
Bump npm version to prep for deploy. Deploying [this PR](https://github.com/Expensify/expensify-common/pull/327).

### Fixed Issues
n/a

# Tests
n/a

# QA
n/a
