### PR TITLE
Remove moment from expensify-common

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -8,7 +8,9 @@
 function getSixWeeksBeforeToday() {
     const today = new Date();
     today.setDate(today.getDate() - (7 * 6));
-    return `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+    const date = `${(today.getDate() < 10 ? '0' : '')}${today.getDate()}`;
+    const month = `${(today.getMonth() < 10 ? '0' : '')}${today.getMonth()}`;
+    return `${today.getFullYear()}-${month}-${date}`;
 }
 
 /**
@@ -19,7 +21,9 @@ function getSixWeeksBeforeToday() {
 function getOneDayAfterToday() {
     const today = new Date();
     today.setDate(today.getDate() + 1);
-    return `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+    const date = `${(today.getDate() < 10 ? '0' : '')}${today.getDate()}`;
+    const month = `${(today.getMonth() < 10 ? '0' : '')}${today.getMonth()}`;
+    return `${today.getFullYear()}-${month}-${date}`;
 }
 
 const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -1,6 +1,18 @@
 /* eslint-disable no-useless-escape */
 
 /**
+ * Formats a Date object into YYYY-MM-DD
+ *
+ * @returns {String}
+ */
+function formatDate(date) {
+    const addLeadingZero = n => `${n < 10 ? '0' : ''}${n}`;
+    const day = addLeadingZero(date.getDate());
+    const month = addLeadingZero(date.getMonth() + 1);
+    return `${date.getFullYear()}-${month}-${day}`;
+}
+
+/**
  * Return the YYYY-MM-DD format for date six weeks before today.
  *
  * @returns {String}
@@ -8,9 +20,7 @@
 function getSixWeeksBeforeToday() {
     const today = new Date();
     today.setDate(today.getDate() - (7 * 6));
-    const date = `${(today.getDate() < 10 ? '0' : '')}${today.getDate()}`;
-    const month = `${(today.getMonth() < 10 ? '0' : '')}${today.getMonth()}`;
-    return `${today.getFullYear()}-${month}-${date}`;
+    return formatDate(today);
 }
 
 /**
@@ -21,9 +31,7 @@ function getSixWeeksBeforeToday() {
 function getOneDayAfterToday() {
     const today = new Date();
     today.setDate(today.getDate() + 1);
-    const date = `${(today.getDate() < 10 ? '0' : '')}${today.getDate()}`;
-    const month = `${(today.getMonth() < 10 ? '0' : '')}${today.getMonth()}`;
-    return `${today.getFullYear()}-${month}-${date}`;
+    return formatDate(today);
 }
 
 const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -1,39 +1,5 @@
 /* eslint-disable no-useless-escape */
 
-/**
- * Formats a Date object into YYYY-MM-DD
- *
- * @returns {String}
- */
-function formatDate(date) {
-    const addLeadingZero = n => `${n < 10 ? '0' : ''}${n}`;
-    const day = addLeadingZero(date.getDate());
-    const month = addLeadingZero(date.getMonth() + 1);
-    return `${date.getFullYear()}-${month}-${day}`;
-}
-
-/**
- * Return the YYYY-MM-DD format for date six weeks before today.
- *
- * @returns {String}
- */
-function getSixWeeksBeforeToday() {
-    const today = new Date();
-    today.setDate(today.getDate() - (7 * 6));
-    return formatDate(today);
-}
-
-/**
- * Return the YYYY-MM-DD format for one day after.
- *
- * @returns {String}
- */
-function getOneDayAfterToday() {
-    const today = new Date();
-    today.setDate(today.getDate() + 1);
-    return formatDate(today);
-}
-
 const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
 
 const MOMENT_FORMAT_STRING = 'YYYY-MM-DD';
@@ -449,12 +415,6 @@ export const CONST = {
          * Difference between the local time and UTC time in ms
          */
         TIMEZONE_OFFSET_MS: new Date().getTimezoneOffset() * 60000,
-
-        /**
-         * Start and End dates for report, expenses filters, receipts,...
-         */
-        DEFAULT_START_DATE: getSixWeeksBeforeToday(),
-        DEFAULT_END_DATE: getOneDayAfterToday(),
 
         SHORT_MONTH_SHORT_DAY: 'MMM d', // e.g. Jan 1
         LONG_YEAR_MONTH_DAY_24_TIME: 'yyyy-MM-dd HH:mm:ss', // e.g. 2020-01-01 20:45:15

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -1,5 +1,26 @@
 /* eslint-disable no-useless-escape */
-import moment from 'moment';
+
+/**
+ * Return the YYYY-MM-DD format for date six weeks before today.
+ *
+ * @returns {String}
+ */
+function getSixWeeksBeforeToday() {
+    const today = new Date();
+    today.setDate(today.getDate() - (7 * 6));
+    return `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+}
+
+/**
+ * Return the YYYY-MM-DD format for one day after.
+ *
+ * @returns {String}
+ */
+function getOneDayAfterToday() {
+    const today = new Date();
+    today.setDate(today.getDate() + 1);
+    return `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+}
 
 const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
 
@@ -420,8 +441,8 @@ export const CONST = {
         /**
          * Start and End dates for report, expenses filters, receipts,...
          */
-        DEFAULT_START_DATE: moment().subtract(6, 'weeks').format(MOMENT_FORMAT_STRING),
-        DEFAULT_END_DATE: moment().add(1, 'day').format(MOMENT_FORMAT_STRING),
+        DEFAULT_START_DATE: getSixWeeksBeforeToday(),
+        DEFAULT_END_DATE: getOneDayAfterToday(),
 
         SHORT_MONTH_SHORT_DAY: 'MMM d', // e.g. Jan 1
         LONG_YEAR_MONTH_DAY_24_TIME: 'yyyy-MM-dd HH:mm:ss', // e.g. 2020-01-01 20:45:15

--- a/package-lock.json
+++ b/package-lock.json
@@ -6451,11 +6451,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "jquery": "3.3.1",
     "lodash.get": "4.4.2",
     "lodash.has": "4.5.2",
-    "moment": "2.20.1",
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

[Explanation of the change or anything fishy that is going on]

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/153792

# Tests
Test in conjunction with `Web-Expensify` PR [here](https://github.com/Expensify/Web-Expensify/pull/30229)

1. Start out on Web-E `master` and verify the values of `CONST.DATE.DEFAULT_START_DATE` and `CONST.DATE.DEFAULT_END_DATE` in the JS console.
2. Switch to the test branch, `npm install`, and `grunt watch`
3. Verify the values are the same

**Before:**
![Screen Shot 2021-02-08 at 8 32 48 AM](https://user-images.githubusercontent.com/32969087/107266877-39ec8e00-69ea-11eb-9171-968fb6663950.png)

**After:**
![Screen Shot 2021-02-08 at 8 46 55 AM](https://user-images.githubusercontent.com/32969087/107266901-407b0580-69ea-11eb-8995-72b9569cd652.png)

# QA
❌ 