### PR TITLE
Setup OnOffSwitch component with tooltips

### DIFF
--- a/lib/components/form/element/onOffSwitch.jsx
+++ b/lib/components/form/element/onOffSwitch.jsx
@@ -61,6 +61,9 @@ const propTypes = {
     // There is usually text just following a switch that says "ENABLED" and "DISABLED" and
     // you can use this option to hide that text
     hideEnabledDisabledText: PropTypes.bool,
+
+    // Text to display in a tooltip
+    tooltipText: PropTypes.string,
 };
 
 const defaultProps = {
@@ -78,6 +81,7 @@ const defaultProps = {
     safeDescription: false,
     hideEnabledDisabledText: false,
     extraClasses: [],
+    tooltipText: '',
 };
 
 class OnOffSwitch extends Component {
@@ -193,6 +197,7 @@ class OnOffSwitch extends Component {
                         {marginLeft10: !this.props.labelOnRight}
                     ]}
                     hideEnabledDisabledText={this.props.hideEnabledDisabledText}
+                    tooltipText={this.props.tooltipText}
                 />
                 {this.props.label && this.props.labelOnRight && (
                     <label

--- a/lib/components/form/element/switch.js
+++ b/lib/components/form/element/switch.js
@@ -1,6 +1,7 @@
 /* globals Func, Modal */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 import _ from 'underscore';
@@ -35,6 +36,9 @@ const propTypes = {
     // There is usually text just following a switch that says "ENABLED" and "DISABLED" and
     // you can use this option to hide that text
     hideEnabledDisabledText: PropTypes.bool,
+
+    // Text to display in a tooltip
+    tooltipText: PropTypes.string,
 };
 
 const defaultProps = {
@@ -44,6 +48,7 @@ const defaultProps = {
     confirm: null,
     extraClasses: [],
     hideEnabledDisabledText: false,
+    tooltipText: '',
 };
 
 class Switch extends React.Component {
@@ -54,6 +59,10 @@ class Switch extends React.Component {
         this.showConfirm = this.showConfirm.bind(this);
 
         this.checkbox = null;
+    }
+
+    componentDidMount() {
+        $(ReactDOM.findDOMNode(this)).tooltip('destroy').tooltip();
     }
 
     /**
@@ -102,7 +111,7 @@ class Switch extends React.Component {
 
     render() {
         return (
-            <span className={cn('onoffswitch-wrapper', this.props.extraClasses)}>
+            <span className={cn('onoffswitch-wrapper js_tooltip', this.props.extraClasses)} title={this.props.tooltipText}>
                 <input
                     ref={el => this.checkbox = el}
                     type="checkbox"


### PR DESCRIPTION
@ctkochan22 you've been PB'd

This is part of a solution to https://github.com/Expensify/Expensify/issues/153817

In reality, the issue was just a miscommunication/misunderstanding on the part of our success agents. To prevent such confusion in the future, we can display a tooltip when on the `OnOffSwitch` when it's disabled. This PR sets up the `OnOffSwitch` so that it can use tooltips.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/153817

# Tests
No automated tests. Was tested in Web-Expensify – one `OnOffSwitch` was provided the `tooltipText` prop, the other two were not.

https://user-images.githubusercontent.com/47436092/107329559-2cc0b500-6a65-11eb-834a-bbd7d6f3c33c.mov

# QA
None.