### PR TITLE
Only run CLA on PR comments or events

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,6 +9,8 @@ on:
 jobs:
     CLA:
         runs-on: ubuntu-latest
+        # This job only runs for pull request comments or pull request target events (not issue comments)
+        if: github.event.issue.pull_request || github.event_name == 'pull_request_target'
         steps:
             - uses: actions-ecosystem/action-regex-match@9c35fe9ac1840239939c59e5db8839422eed8a73
               id: sign


### PR DESCRIPTION
### Details
This restricts the CLA bot from running only on PR comments or events, if you were to comment on an issue you'd get an email saying the GitHub action failed on your issue comment.

### Fixed Issues
Fixes https://github.com/Expensify/Expensify/issues/154742

### Tests
1. I edited the logic in [my public test repo here to match the logic in this PR](https://github.com/Andrew-Test-Org/Public-Test-Repo/blob/main/.github/workflows/CLA.yml)
2. I then pushed a [PR that had the CLA run](https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/590183836) ✅
3. I then [left a comment on a PR that ran the CLA](https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/590184939) ✅ 
4. I then [left a comment on an issue and verified the CLA did not run](https://github.com/Andrew-Test-Org/Public-Test-Repo/actions/runs/590202855) ✅ 
