### PR TITLE
Update QBD Sync Manager version

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -351,7 +351,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_190091923.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_19012129.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },


### PR DESCRIPTION
Pullerbear review (@thienlnam)

### Fixed Issues
Needed for https://github.com/Expensify/Expensify/issues/150106

### Tests/QA
Will only be testable on Web-E after updating it to use the latest expensify-common, but here are the steps:

1. Create a new policy
2. Go to Connections  > QuickBooks Desktop, expand the section
3. Click on the "Need to reinstall the Sync Manager? Click here" link
4. Make sure something downloads

![image](https://user-images.githubusercontent.com/2229301/108918546-686f8900-75e6-11eb-8e91-737964d6c601.png)
