### PR TITLE
Add GithubUtils and generateVersionComparisonURL

### DIFF
--- a/__tests__/GithubUtils-test.js
+++ b/__tests__/GithubUtils-test.js
@@ -42,39 +42,121 @@ const expectedResponse = {
     url: 'https://api.github.com/repos/Andrew-Test-Org/Public-Test-Repo/issues/29'
 };
 
-describe('GithubUtils.getStagingDeployCash', () => {
-    test('Test finding an open issue successfully', () => {
-        const octokit = new Octokit();
-        const github = new GithubUtils(octokit);
-        octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: [issue]});
-        return github.getStagingDeployCash().then(data => expect(data).toStrictEqual(expectedResponse));
+describe('GithubUtils', () => {
+    describe('getStagingDeployCash', () => {
+        test('Test finding an open issue successfully', () => {
+            const octokit = new Octokit();
+            const github = new GithubUtils(octokit);
+            octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: [issue]});
+            return github.getStagingDeployCash().then(data => expect(data).toStrictEqual(expectedResponse));
+        });
+
+        test('Test finding an open issue without a body', () => {
+            const octokit = new Octokit();
+            const github = new GithubUtils(octokit);
+
+            const noBodyIssue = issue;
+            noBodyIssue.body = '';
+
+            octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: [noBodyIssue]});
+            return github.getStagingDeployCash()
+                .catch(e => expect(e).toEqual(new Error('Unable to find StagingDeployCash issue with correct data.')));
+        });
+
+        test('Test finding more than one issue', () => {
+            const octokit = new Octokit();
+            const github = new GithubUtils(octokit);
+            octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: [{a: 1}, {b: 2}]});
+            return github.getStagingDeployCash()
+                .catch(e => expect(e).toEqual(new Error('Found more than one StagingDeployCash issue.')));
+        });
+
+        test('Test finding no issues', () => {
+            const octokit = new Octokit();
+            const github = new GithubUtils(octokit);
+            octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: []});
+            return github.getStagingDeployCash()
+                .catch(e => expect(e).toEqual(new Error('Unable to find StagingDeployCash issue.')));
+        });
     });
 
-    test('Test finding an open issue without a body', () => {
-        const octokit = new Octokit();
-        const github = new GithubUtils(octokit);
+    describe('generateVersionComparisonURL', () => {
+        const REPO_SLUG = 'test-owner/test-repo';
+        const MOCK_TAGS = [{name: '2.2.2'},{name: '2.2.1'},{name: '2.1.0-1'},{name: '2.1.0'},{name: '2.0.0-1'},{name: '2.0.0'},{name: '1.2.2-2'},{name: '1.2.2-1'},{name: '1.2.2'},{name: '1.2.1'},{name: '1.2.0'},{name: '1.1.0'},{name: '1.0.4'},{name: '1.0.3'},{name: '1.0.2'},{name: '1.0.1'},{name: '1.0.0'},{name: '0.0.1'}];
 
-        const noBodyIssue = issue;
-        noBodyIssue.body = '';
+        const mockGithub = jest.fn(() => ({
+            getOctokit: () => ({
+                repos: {
+                    listTags: jest.fn(() => Promise.resolve({data: MOCK_TAGS})),
+                },
+            }),
+        }));
 
-        octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: [noBodyIssue]});
-        return github.getStagingDeployCash()
-            .catch(e => expect(e).toEqual(new Error('Unable to find StagingDeployCash issue with correct data.')));
-    });
+        const octokit = mockGithub().getOctokit();
+        const githubUtils = new GithubUtils(octokit);
 
-    test('Test finding more than one issue', () => {
-        const octokit = new Octokit();
-        const github = new GithubUtils(octokit);
-        octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: [{a: 1}, {b: 2}]});
-        return github.getStagingDeployCash()
-            .catch(e => expect(e).toEqual(new Error('Found more than one StagingDeployCash issue.')));
-    });
+        describe('MAJOR comparison', () => {
+            test('should return a comparison url between 2.2.2 and 1.2.2', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MAJOR');
 
-    test('Test finding no issues', () => {
-        const octokit = new Octokit();
-        const github = new GithubUtils(octokit);
-        octokit.issues.listForRepo = jest.fn().mockResolvedValue({data: []});
-        return github.getStagingDeployCash()
-            .catch(e => expect(e).toEqual(new Error('Unable to find StagingDeployCash issue.')));
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...2.2.2');
+            });
+
+            test('should return a comparison url between 1.2.0 and 0.0.1', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.2.0', 'MAJOR');
+
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.2.0');
+            });
+        });
+
+        describe('MINOR comparison', () => {
+            test('should return a comparison url between 2.2.2 and 2.1.0', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MINOR');
+
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.2.2');
+            });
+
+            test('should return a comparison url between 1.1.0 and 1.0.4', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.1.0', 'MINOR');
+
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/1.0.4...1.1.0');
+            });
+        });
+
+        describe('PATCH comparison', () => {
+            test('should return a comparison url between 2.2.2 and 2.2.1', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'PATCH');
+
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/2.2.1...2.2.2');
+            });
+
+            test('should return a comparison url between 1.0.0 and 0.0.1', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.0.0', 'PATCH');
+
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.0.0');
+            });
+        });
+
+        describe('BUILD comparison', () => {
+            test('should return a comparison url between 2.1.0-1 and 2.1.0', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.1.0-1', 'BUILD');
+
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.1.0-1');
+            });
+
+            test('should return a comparison url between 1.2.2-2 and 1.2.2', async () => {
+                const result = await githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.2.2-2', 'BUILD');
+
+                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...1.2.2-2');
+            });
+        });
     });
 });

--- a/__tests__/GithubUtils-test.js
+++ b/__tests__/GithubUtils-test.js
@@ -87,7 +87,7 @@ describe('GithubUtils', () => {
         const mockGithub = jest.fn(() => ({
             getOctokit: () => ({
                 repos: {
-                    listTags: jest.fn(() => Promise.resolve({data: MOCK_TAGS})),
+                    listTags: jest.fn().mockResolvedValue({data: MOCK_TAGS}),
                 },
             }),
         }));
@@ -96,66 +96,67 @@ describe('GithubUtils', () => {
         const githubUtils = new GithubUtils(octokit);
 
         describe('MAJOR comparison', () => {
-            test('should return a comparison url between 2.2.2 and 1.2.2', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MAJOR');
+            test('should return a comparison url between 2.2.2 and 1.2.2', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MAJOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...2.2.2')
+                    );
 
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...2.2.2');
             });
 
-            test('should return a comparison url between 1.2.0 and 0.0.1', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '1.2.0', 'MAJOR');
-
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.2.0');
+            test('should return a comparison url between 1.2.0 and 0.0.1', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.2.0', 'MAJOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.2.0')
+                    );
             });
         });
 
         describe('MINOR comparison', () => {
-            test('should return a comparison url between 2.2.2 and 2.1.0', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MINOR');
-
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.2.2');
+            test('should return a comparison url between 2.2.2 and 2.1.0', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MINOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.2.2')
+                    );
             });
 
-            test('should return a comparison url between 1.1.0 and 1.0.4', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '1.1.0', 'MINOR');
-
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/1.0.4...1.1.0');
+            test('should return a comparison url between 1.1.0 and 1.0.4', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.1.0', 'MINOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.0.4...1.1.0')
+                    );
             });
         });
 
         describe('PATCH comparison', () => {
-            test('should return a comparison url between 2.2.2 and 2.2.1', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'PATCH');
-
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/2.2.1...2.2.2');
+            test('should return a comparison url between 2.2.2 and 2.2.1', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'PATCH').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.2.1...2.2.2')
+                    );
             });
 
-            test('should return a comparison url between 1.0.0 and 0.0.1', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '1.0.0', 'PATCH');
-
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.0.0');
+            test('should return a comparison url between 1.0.0 and 0.0.1', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.0.0', 'PATCH').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.0.0')
+                    );
             });
         });
 
         describe('BUILD comparison', () => {
-            test('should return a comparison url between 2.1.0-1 and 2.1.0', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '2.1.0-1', 'BUILD');
-
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.1.0-1');
+            test('should return a comparison url between 2.1.0-1 and 2.1.0', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '2.1.0-1', 'BUILD').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.1.0-1')
+                    );
             });
 
-            test('should return a comparison url between 1.2.2-2 and 1.2.2', async () => {
-                const result = await githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '1.2.2-2', 'BUILD');
-
-                expect(result).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...1.2.2-2');
+            test('should return a comparison url between 1.2.2-2 and 1.2.2', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.2.2-2', 'BUILD').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...1.2.2-2')
+                    );
             });
         });
     });

--- a/lib/GithubUtils.js
+++ b/lib/GithubUtils.js
@@ -1,6 +1,12 @@
+const core = require('@actions/core');
+const semverParse = require('semver/functions/parse');
+const semverSatisfies = require('semver/functions/satisfies');
+
 export const GITHUB_OWNER = 'Expensify';
 export const EXPENSIFY_ISSUE_REPO = 'Expensify';
 export const EXPENSIFY_CASH_REPO = 'Expensify.cash';
+
+const EXPENSIFY_CASH_URL = 'https://github.com/Expensify/Expensify.cash';
 
 export default class GithubUtils {
     /**
@@ -45,9 +51,8 @@ export default class GithubUtils {
             const versionRegex = new RegExp('([0-9]+).([0-9]+).([0-9]+)(?:-([0-9]+))?', 'g');
             const tag = issue.body.match(versionRegex)[0].replace(/`/g, '');
 
-            const expensifyCashURL = 'https://github.com/Expensify/Expensify.cash';
             // eslint-disable-next-line max-len
-            const compareURLRegex = new RegExp(`${expensifyCashURL}/compare/${versionRegex.source}...${versionRegex.source}`, 'g');
+            const compareURLRegex = new RegExp(`${EXPENSIFY_CASH_URL}/compare/${versionRegex.source}...${versionRegex.source}`, 'g');
             const comparisonURL = issue.body.match(compareURLRegex)[0];
 
             const PRListRegex = new RegExp(`${expensifyCashURL}/pull/([0-9]+)`, 'g');
@@ -59,5 +64,60 @@ export default class GithubUtils {
         } catch (exception) {
             throw new Error('Unable to find StagingDeployCash issue with correct data.');
         }
+    }
+
+    /**
+     * Generate a comparison URL between two versions following the semverLevel passed
+     *
+     * @param {String} repoSlug - The slug of the repository: <owner>/<repository_name>
+     * @param {String} tag - The tag to compare first the previous semverLevel
+     * @param {String} semverLevel - The semantic versioning MAJOR, MINOR, PATCH and BUILD
+     * @return {Promise} the url generated
+     */
+    generateVersionComparisonURL(repoSlug, tag, semverLevel) {
+        return new Promise((resolve, reject) => {
+            const getComparisonURL = (previousTag, currentTag) => (
+                `${EXPENSIFY_CASH_URL}/compare/${previousTag}...${currentTag}`
+            );
+
+            const [repoOwner, repoName] = repoSlug.split('/');
+            const tagSemver = semverParse(tag);
+
+            return this.octokit.repos.listTags({
+                owner: repoOwner,
+                repo: repoName,
+            })
+                .then(githubResponse => githubResponse.data.some(({name: repoTag}) => {
+                    if (semverLevel === 'MAJOR'
+                        && semverSatisfies(repoTag, `<${tagSemver.major}.x.x`)
+                    ) {
+                        resolve(getComparisonURL(repoTag, tagSemver));
+                        return true;
+                    }
+
+                    if (semverLevel === 'MINOR'
+                        && semverSatisfies(repoTag, `<${tagSemver.major}.${tagSemver.minor}.x`)
+                    ) {
+                        resolve(getComparisonURL(repoTag, tagSemver));
+                        return true;
+                    }
+
+                    if (semverLevel === 'PATCH'
+                        && semverSatisfies(repoTag, `<${tagSemver}`)
+                    ) {
+                        resolve(getComparisonURL(repoTag, tagSemver));
+                        return true;
+                    }
+
+                    if (semverLevel === 'BUILD'
+                        && semverSatisfies(repoTag, `<=${tagSemver.major}.${tagSemver.minor}.${tagSemver.patch}`)
+                    ) {
+                        resolve(getComparisonURL(repoTag, tagSemver));
+                        return true;
+                    }
+                    return false;
+                }))
+                .catch(githubError => reject(core.setFailed(githubError)));
+        });
     }
 }

--- a/lib/GithubUtils.js
+++ b/lib/GithubUtils.js
@@ -1,4 +1,3 @@
-const core = require('@actions/core');
 const semverParse = require('semver/functions/parse');
 const semverSatisfies = require('semver/functions/satisfies');
 
@@ -117,7 +116,7 @@ export default class GithubUtils {
                     }
                     return false;
                 }))
-                .catch(githubError => reject(core.setFailed(githubError)));
+                .catch(githubError => reject(githubError));
         });
     }
 }

--- a/lib/GithubUtils.js
+++ b/lib/GithubUtils.js
@@ -55,7 +55,7 @@ export default class GithubUtils {
             const compareURLRegex = new RegExp(`${EXPENSIFY_CASH_URL}/compare/${versionRegex.source}...${versionRegex.source}`, 'g');
             const comparisonURL = issue.body.match(compareURLRegex)[0];
 
-            const PRListRegex = new RegExp(`${expensifyCashURL}/pull/([0-9]+)`, 'g');
+            const PRListRegex = new RegExp(`${EXPENSIFY_CASH_URL}/pull/([0-9]+)`, 'g');
             const PRList = issue.body.match(PRListRegex);
 
             return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -40,6 +45,14 @@
         "lodash": "^4.17.19",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@babel/generator": {
@@ -82,6 +95,14 @@
         "@babel/helper-validator-option": "^7.12.1",
         "browserslist": "^4.14.5",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -952,6 +973,14 @@
         "@babel/types": "^7.12.10",
         "core-js-compat": "^3.8.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-modules": {
@@ -2794,6 +2823,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "cssom": {
@@ -6660,7 +6697,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -6926,6 +6962,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -8096,10 +8140,12 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -9265,8 +9311,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@actions/core": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
-      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "url": "git+ssh://git@github.com/Expensify/JS-Libs.git"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
     "classnames": "2.2.5",
     "clipboard": "2.0.4",
     "html-entities": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "git+ssh://git@github.com/Expensify/JS-Libs.git"
   },
   "dependencies": {
+    "@actions/core": "^1.2.6",
     "classnames": "2.2.5",
     "clipboard": "2.0.4",
     "html-entities": "^1.3.1",
@@ -27,6 +28,7 @@
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",
+    "semver": "^7.3.4",
     "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
     "underscore": "1.9.1"
   },


### PR DESCRIPTION
@roryabraham will you please review this?

[Explanation of the change or anything fishy that is going on]

I added the class GithubUtils and its method generateVersionComparisonURL.
I installed the following missing packages 'semver' and '@actions/core'.

PS: Also for the tests I needed to use async/await else I got some timeout. Also I tried different workaround for example expect(Promise).resolves.toBe(url) but it was not working correctly. At least with async/await we are sure the tests are working correctly.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/1577

# Tests

For repository with the following tags 2.2.2, 2.2.1, 2.1.0-1, 2.1.0, 2.0.0-1, 2.0.0, 1.2.2-2, 1.2.2-1, 1.2.2, 1.2.1, 1.2.0, 1.1.0, 1.0.4, 1.0.3, 1.0.2, 1.0.1, 1.0.0 and 0.0.1

MAJOR comparison
-- if we pass the tag 2.2.2 as param it should return https://<ETC>/1.2.2...2.2.2
-- if we pass the tag 1.2.0 as param it should return https://<ETC>/0.0.1...1.2.0

MINOR comparison
-- if we pass the tag 2.2.2 as param it should return https://<ETC>/2.1.0...2.2.2
-- if we pass the tag 1.1.0 as param it should return https://<ETC>/1.0.4...1.1.0

PATCH comparison
-- if we pass the tag 2.2.2 as param it should return https://<ETC>/2.2.1...2.2.2
-- if we pass the tag 1.0.0 as param it should return https://<ETC>/0.0.1...1.0.0

BUILD comparison
-- if we pass the tag 2.1.0-1 as param it should return https://<ETC>/2.1.0...2.1.0-1
-- if we pass the tag 1.2.2-2 as param it should return https://<ETC>/1.2.2...1.2.2-2

# QA

If the `generateVersionComparisonURL` return the good url following the parameters passed.
