### PR TITLE
Implement getPullRequestsMergedBetween function

### DIFF
--- a/__tests__/GitUtils-test.js
+++ b/__tests__/GitUtils-test.js
@@ -1,0 +1,17 @@
+import GitUtils from '../lib/GitUtils';
+
+describe('GitUtils', () => {
+    describe('getPullRequestNumberFromCommitMessage', () => {
+        test('Test matching PR number from commit message', () => {
+            const gitUtils = new GitUtils();
+            const pullRequestNumber = gitUtils.getPullRequestNumberFromCommitMessage("Merge pull request #337 from Expensify/francoisUpdateQbdSyncManager");
+            expect(pullRequestNumber).toStrictEqual('337');
+        });
+
+        test('Test non-matching PR number from commit message', () => {
+            const gitUtils = new GitUtils();
+            const pullRequestNumber = gitUtils.getPullRequestNumberFromCommitMessage("Update QBD Sync Manager version");
+            expect(pullRequestNumber).toBeNull();
+        });
+    });
+});

--- a/__tests__/GitUtils-test.js
+++ b/__tests__/GitUtils-test.js
@@ -1,17 +1,57 @@
-import GitUtils from '../lib/GitUtils';
+const GitUtils = require('../lib/GitUtils');
+const childproc = require('child_process');
+jest.mock('child_process');
+jest.mock('util', () => ({ promisify: (fn) => fn }));
+const { exec } = childproc;
+
+const data = [
+    {
+        gitLog: `Start adding StagingDeployCash logic
+        Setting up bones
+        Merge pull request #337 from Expensify/francoisUpdateQbdSyncManager
+        Merge pull request #336 from Expensify/andrew-pr-cla
+        Update QBD Sync Manager version
+        Only run CLA on PR comments or events
+        Merge pull request #331 from Expensify/marcaaron-killMoment
+        Merge pull request #330 from Expensify/andrew-cla-update
+        Merge pull request #333 from Expensify/Rory-AddOnOffSwitchTooltip
+        Setup OnOffSwitch component with tooltips
+        Merge pull request #332 from Expensify/alex-mechler-patch-1
+        Return to old hash-based deploy instrcutions
+        Remove DEFAULT_START_DATE & DEFAULT_END_DATE altogether`,
+        result: ['337', '336', '331', '330', '333', '332'],
+    },
+    {
+        gitLog: `Merge pull request #1521 from parasharrajat/parasharrajat/pdf-render
+        Merge pull request #1563 from Expensify/version-bump-e6498075e301df3e9c8d7866ea391a23c19ed9b0
+        Update version to 1.0.1-470
+        Merge pull request #1557 from aliabbasmalik8/IS-1500-compose-field-alignment-issue
+        Merge pull request #1562 from Expensify/version-bump-b9c85aa97dfb656b01a83871b4bbaed5e287c8b7
+        Update version to 1.0.1-469
+        Merge pull request #1515 from anthony-hull/typos
+        [IS-1500] Updated textalignInput utility
+        Merge pull request #1560 from Expensify/version-bump-b742a55d18e761cd7adb0849a29cfb48b3a04f99
+        Update version to 1.0.1-468
+        Merge pull request #1555 from SameeraMadushan/sameera-IsAppInstalledLogic
+        fix: set pdf width on large screens
+        [IS-1500] Fixed compose field alignment issue`,
+        result: ['1521', '1563', '1557', '1562', '1515', '1560', '1555'],
+    },
+    {
+        gitLog: `Return to old hash-based deploy instrcutions
+        Remove DEFAULT_START_DATE & DEFAULT_END_DATE altogether
+        refactor`,
+        result: [],
+    },
+];
 
 describe('GitUtils', () => {
-    describe('getPullRequestNumberFromCommitMessage', () => {
-        test('Test matching PR number from commit message', () => {
+    describe.each(data)(`getPullRequestsMergedBetween`, (exampleCase) => {
+        test('Test getPullRequestsMergedBetween by mocking exec', () => {
+            exec.mockResolvedValue({ stdout: exampleCase.gitLog, stderr: '' });
             const gitUtils = new GitUtils();
-            const pullRequestNumber = gitUtils.getPullRequestNumberFromCommitMessage("Merge pull request #337 from Expensify/francoisUpdateQbdSyncManager");
-            expect(pullRequestNumber).toStrictEqual('337');
-        });
-
-        test('Test non-matching PR number from commit message', () => {
-            const gitUtils = new GitUtils();
-            const pullRequestNumber = gitUtils.getPullRequestNumberFromCommitMessage("Update QBD Sync Manager version");
-            expect(pullRequestNumber).toBeNull();
+            return gitUtils.getPullRequestsMergedBetween('testRef1', 'testRef2')
+                .then(pullRequestNumbers => expect(pullRequestNumbers).toStrictEqual(exampleCase.result));
         });
     });
 });

--- a/lib/GitUtils.jsx
+++ b/lib/GitUtils.jsx
@@ -1,0 +1,44 @@
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+
+export default class GitUtils {
+
+    /**
+     * Takes in two git refs and returns a list of PR numbers of all PRs merged between those two refs
+     *
+     * @param {String} fromRef
+     * @param {String} toRef
+     * @returns {Promise}
+     */
+    getPullRequestsMergedBetween(fromRef, toRef) {
+        return new Promise((resolve, reject) => {
+            exec(`git log --format="%s" ${fromRef}...${toRef}`)
+                .then(({ stdout, stderr }) => {
+                    const commitMessages = stdout.split('\n');
+                    const pullRequestNumbers = commitMessages
+                        .map(commitMessage => this.getPullRequestNumberFromCommitMessage(commitMessage))
+                        .filter(prNumber => prNumber != null);
+                    resolve(pullRequestNumbers);
+                })
+                .catch((err) => {
+                    reject(err);
+                });
+        });
+    }
+
+    /**
+     * Takes in a git commit message and returns pull request number 
+     * if it is merge commit or null
+     * 
+     * @param {String} commitMessage
+     * @returns {String}
+     */
+    getPullRequestNumberFromCommitMessage(commitMessage) {
+        const regExp = new RegExp(/Merge pull request #(\d{1,6})/);
+        const match = commitMessage.match(regExp);
+        if (match == null) {
+            return null;
+        }
+        return match[1];
+    }
+}

--- a/lib/GitUtils.jsx
+++ b/lib/GitUtils.jsx
@@ -1,7 +1,7 @@
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 
-export default class GitUtils {
+module.exports = class GitUtils {
 
     /**
      * Takes in two git refs and returns a list of PR numbers of all PRs merged between those two refs
@@ -11,34 +11,11 @@ export default class GitUtils {
      * @returns {Promise}
      */
     getPullRequestsMergedBetween(fromRef, toRef) {
-        return new Promise((resolve, reject) => {
-            exec(`git log --format="%s" ${fromRef}...${toRef}`)
-                .then(({ stdout, stderr }) => {
-                    const commitMessages = stdout.split('\n');
-                    const pullRequestNumbers = commitMessages
-                        .map(commitMessage => this.getPullRequestNumberFromCommitMessage(commitMessage))
-                        .filter(prNumber => prNumber != null);
-                    resolve(pullRequestNumbers);
-                })
-                .catch((err) => {
-                    reject(err);
-                });
-        });
-    }
-
-    /**
-     * Takes in a git commit message and returns pull request number 
-     * if it is merge commit or null
-     * 
-     * @param {String} commitMessage
-     * @returns {String}
-     */
-    getPullRequestNumberFromCommitMessage(commitMessage) {
-        const regExp = new RegExp(/Merge pull request #(\d{1,6})/);
-        const match = commitMessage.match(regExp);
-        if (match == null) {
-            return null;
-        }
-        return match[1];
+        return exec(`git log --format="%s" ${fromRef}...${toRef}`)
+            .then(({ stdout, stderr }) => {
+                const pullRequestNumbers = [...stdout.matchAll(new RegExp(/Merge pull request #(\d{1,6})/, 'g'))]
+                    .map(match => match[1]);
+                return pullRequestNumbers;
+            })
     }
 }


### PR DESCRIPTION
@roryabraham @arielgreen will you please review this?

Added GitUtils class and implemented getPullRequestsMergedBetween with unit tests.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/1576

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
I added unit test for `getPullRequestNumberFromCommitMessage` function

2. What tests did you perform that validates your changed worked?
I manually executed following command and got expected result.

https://github.com/tugbadogan/expensify-common/blob/37f21ea035930a80282822f3dea6cd25e502d70b/index.js#L61-L67

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
