### PR TITLE
Update versionComparisonURL to check build versions

### DIFF
--- a/__tests__/GithubUtils-test.js
+++ b/__tests__/GithubUtils-test.js
@@ -283,7 +283,7 @@ describe('GithubUtils', () => {
 
     describe('generateVersionComparisonURL', () => {
         const REPO_SLUG = 'test-owner/test-repo';
-        const MOCK_TAGS = [{name: '2.2.2'},{name: '2.2.1'},{name: '2.1.0-1'},{name: '2.1.0'},{name: '2.0.0-1'},{name: '2.0.0'},{name: '1.2.2-2'},{name: '1.2.2-1'},{name: '1.2.2'},{name: '1.2.1'},{name: '1.2.0'},{name: '1.1.0'},{name: '1.0.4'},{name: '1.0.3'},{name: '1.0.2'},{name: '1.0.1'},{name: '1.0.0'},{name: '0.0.1'}];
+        const MOCK_TAGS = [{name: '3.1.0-0'},{name: '3.0.0'},{name: '2.2.2-0'},{name: '2.2.1-0'},{name: '2.1.0-1'},{name: '2.1.0-0'},{name: '2.0.0-1'},{name: '2.0.0-0'},{name: '1.2.2-2'},{name: '1.2.2-1'},{name: '1.2.2-0'},{name: '1.2.1-0'},{name: '1.2.0-0'},{name: '1.1.0-0'},{name: '1.0.4-0'},{name: '1.0.3-1'},{name: '1.0.3'},{name: '1.0.2-0'},{name: '1.0.1-0'},{name: '1.0.0-0'},{name: '0.0.1-0'}];
 
         const mockGithub = jest.fn(() => ({
             getOctokit: () => ({
@@ -297,66 +297,87 @@ describe('GithubUtils', () => {
         const githubUtils = new GithubUtils(octokit);
 
         describe('MAJOR comparison', () => {
-            test('should return a comparison url between 2.2.2 and 1.2.2', () => {
+            test('should return a comparison url between 2.2.2-0 and 1.2.2-2', () => {
                 return githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MAJOR').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...2.2.2')
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2-0', 'MAJOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2-2...2.2.2-0')
                     );
 
             });
 
-            test('should return a comparison url between 1.2.0 and 0.0.1', () => {
+            test('should return a comparison url between 1.2.0-0 and 0.0.1-0', () => {
                 return githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '1.2.0', 'MAJOR').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.2.0')
+                    .generateVersionComparisonURL(REPO_SLUG, '1.2.0-0', 'MAJOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1-0...1.2.0-0')
+                    );
+            });
+
+            test('should return a comparison url between 3.0.0 and 2.2.2-0', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '3.0.0', 'MAJOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.2.2-0...3.0.0')
                     );
             });
         });
 
         describe('MINOR comparison', () => {
-            test('should return a comparison url between 2.2.2 and 2.1.0', () => {
+            test('should return a comparison url between 2.2.2-0 and 2.1.0-1', () => {
                 return githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'MINOR').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.2.2')
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2-0', 'MINOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0-1...2.2.2-0')
                     );
             });
 
-            test('should return a comparison url between 1.1.0 and 1.0.4', () => {
+            test('should return a comparison url between 1.1.0-0 and 1.0.4-0', () => {
                 return githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '1.1.0', 'MINOR').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.0.4...1.1.0')
+                    .generateVersionComparisonURL(REPO_SLUG, '1.1.0-0', 'MINOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.0.4-0...1.1.0-0')
+                    );
+            });
+
+            test('should return a comparison url between 3.1.0-0 and 3.0.0', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '3.1.0-0', 'MINOR').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/3.0.0...3.1.0-0')
                     );
             });
         });
 
         describe('PATCH comparison', () => {
-            test('should return a comparison url between 2.2.2 and 2.2.1', () => {
+            test('should return a comparison url between 2.2.2-0 and 2.2.1-0', () => {
                 return githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2', 'PATCH').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.2.1...2.2.2')
+                    .generateVersionComparisonURL(REPO_SLUG, '2.2.2-0', 'PATCH').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.2.1-0...2.2.2-0')
                     );
             });
 
-            test('should return a comparison url between 1.0.0 and 0.0.1', () => {
+            test('should return a comparison url between 1.0.0-0 and 0.0.1-0', () => {
                 return githubUtils
-                    .generateVersionComparisonURL(REPO_SLUG, '1.0.0', 'PATCH').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1...1.0.0')
+                    .generateVersionComparisonURL(REPO_SLUG, '1.0.0-0', 'PATCH').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/0.0.1-0...1.0.0-0')
                     );
             });
         });
 
         describe('BUILD comparison', () => {
-            test('should return a comparison url between 2.1.0-1 and 2.1.0', () => {
+            test('should return a comparison url between 2.1.0-1 and 2.1.0-0', () => {
                 return githubUtils
                     .generateVersionComparisonURL(REPO_SLUG, '2.1.0-1', 'BUILD').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0...2.1.0-1')
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/2.1.0-0...2.1.0-1')
                     );
             });
 
-            test('should return a comparison url between 1.2.2-2 and 1.2.2', () => {
+            test('should return a comparison url between 1.2.2-2 and 1.2.2-1', () => {
                 return githubUtils
                     .generateVersionComparisonURL(REPO_SLUG, '1.2.2-2', 'BUILD').then((url) =>
-                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2...1.2.2-2')
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.2.2-1...1.2.2-2')
+                    );
+            });
+
+            test('should return a comparison url between 1.0.3-1 and 1.0.3', () => {
+                return githubUtils
+                    .generateVersionComparisonURL(REPO_SLUG, '1.0.3-1', 'BUILD').then((url) =>
+                        expect(url).toBe('https://github.com/Expensify/Expensify.cash/compare/1.0.3...1.0.3-1')
                     );
             });
         });

--- a/__tests__/GithubUtils-test.js
+++ b/__tests__/GithubUtils-test.js
@@ -283,7 +283,29 @@ describe('GithubUtils', () => {
 
     describe('generateVersionComparisonURL', () => {
         const REPO_SLUG = 'test-owner/test-repo';
-        const MOCK_TAGS = [{name: '3.1.0-0'},{name: '3.0.0'},{name: '2.2.2-0'},{name: '2.2.1-0'},{name: '2.1.0-1'},{name: '2.1.0-0'},{name: '2.0.0-1'},{name: '2.0.0-0'},{name: '1.2.2-2'},{name: '1.2.2-1'},{name: '1.2.2-0'},{name: '1.2.1-0'},{name: '1.2.0-0'},{name: '1.1.0-0'},{name: '1.0.4-0'},{name: '1.0.3-1'},{name: '1.0.3'},{name: '1.0.2-0'},{name: '1.0.1-0'},{name: '1.0.0-0'},{name: '0.0.1-0'}];
+        const MOCK_TAGS = [
+            {name: '3.1.0-0'},
+            {name: '3.0.0'},
+            {name: '2.2.2-0'},
+            {name: '2.2.1-0'},
+            {name: '2.1.0-1'},
+            {name: '2.1.0-0'},
+            {name: '2.0.0-1'},
+            {name: '2.0.0-0'},
+            {name: '1.2.2-2'},
+            {name: '1.2.2-1'},
+            {name: '1.2.2-0'},
+            {name: '1.2.1-0'},
+            {name: '1.2.0-0'},
+            {name: '1.1.0-0'},
+            {name: '1.0.4-0'},
+            {name: '1.0.3-1'},
+            {name: '1.0.3'},
+            {name: '1.0.2-0'},
+            {name: '1.0.1-0'},
+            {name: '1.0.0-0'},
+            {name: '0.0.1-0'}
+        ];
 
         const mockGithub = jest.fn(() => ({
             getOctokit: () => ({

--- a/lib/GithubUtils.js
+++ b/lib/GithubUtils.js
@@ -112,7 +112,11 @@ export default class GithubUtils {
                     }
 
                     if (semverLevel === 'MINOR'
-                        && semverSatisfies(repoTag, `<${tagSemver.major}.${tagSemver.minor}.x`, {includePrerelease: true})
+                        && semverSatisfies(
+                            repoTag,
+                            `<${tagSemver.major}.${tagSemver.minor}.x`,
+                            {includePrerelease: true}
+                        )
                     ) {
                         resolve(getComparisonURL(repoTag, tagSemver));
                         return true;
@@ -127,7 +131,11 @@ export default class GithubUtils {
 
                     if (semverLevel === 'BUILD'
                         && repoTag !== tagSemver.version
-                        && semverSatisfies(repoTag, `<=${tagSemver.major}.${tagSemver.minor}.${tagSemver.patch}`, {includePrerelease: true})
+                        && semverSatisfies(
+                            repoTag,
+                            `<=${tagSemver.major}.${tagSemver.minor}.${tagSemver.patch}`,
+                            {includePrerelease: true}
+                        )
                     ) {
                         resolve(getComparisonURL(repoTag, tagSemver));
                         return true;

--- a/lib/GithubUtils.js
+++ b/lib/GithubUtils.js
@@ -119,7 +119,7 @@ export default class GithubUtils {
                     }
 
                     if (semverLevel === 'PATCH'
-                        && semverSatisfies(repoTag, `<${tagSemver}`, {includePrerelease: true,})
+                        && semverSatisfies(repoTag, `<${tagSemver}`, {includePrerelease: true})
                     ) {
                         resolve(getComparisonURL(repoTag, tagSemver));
                         return true;

--- a/lib/GithubUtils.js
+++ b/lib/GithubUtils.js
@@ -105,28 +105,29 @@ export default class GithubUtils {
             })
                 .then(githubResponse => githubResponse.data.some(({name: repoTag}) => {
                     if (semverLevel === 'MAJOR'
-                        && semverSatisfies(repoTag, `<${tagSemver.major}.x.x`)
+                        && semverSatisfies(repoTag, `<${tagSemver.major}.x.x`, {includePrerelease: true})
                     ) {
                         resolve(getComparisonURL(repoTag, tagSemver));
                         return true;
                     }
 
                     if (semverLevel === 'MINOR'
-                        && semverSatisfies(repoTag, `<${tagSemver.major}.${tagSemver.minor}.x`)
+                        && semverSatisfies(repoTag, `<${tagSemver.major}.${tagSemver.minor}.x`, {includePrerelease: true})
                     ) {
                         resolve(getComparisonURL(repoTag, tagSemver));
                         return true;
                     }
 
                     if (semverLevel === 'PATCH'
-                        && semverSatisfies(repoTag, `<${tagSemver}`)
+                        && semverSatisfies(repoTag, `<${tagSemver}`, {includePrerelease: true,})
                     ) {
                         resolve(getComparisonURL(repoTag, tagSemver));
                         return true;
                     }
 
                     if (semverLevel === 'BUILD'
-                        && semverSatisfies(repoTag, `<=${tagSemver.major}.${tagSemver.minor}.${tagSemver.patch}`)
+                        && repoTag !== tagSemver.version
+                        && semverSatisfies(repoTag, `<=${tagSemver.major}.${tagSemver.minor}.${tagSemver.patch}`, {includePrerelease: true})
                     ) {
                         resolve(getComparisonURL(repoTag, tagSemver));
                         return true;


### PR DESCRIPTION
@roryabraham will you please review this?
cc @AndrewGable 

This PR updates `generateVersionComparisonURL` to check the build number in the version. I've also updated the tests to cover more version comparison cases. Once this is merged I'll update the expensify-common hashes in all the other repos.

### Fixed Issues
Related to https://github.com/Expensify/Expensify/issues/156562

# Tests
Added automated tests

# QA
N/A, we'll fully test this when we deploy
