### PR TITLE
Add link inside of link support and fix upwork links

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -50,14 +50,16 @@ test('Test critical markdown style links', () => {
     + '[second](http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled) '
     + '[second no http://](necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled) '
     + '[third](https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) '
-    + '[third no https://](github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash)';
+    + '[third no https://](github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) '
+    + '[link `[inside another link](https://google.com)`](https://google.com)';
     const resultString = 'Testing '
     + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">first</a> '
     + '<a href="http://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">first no https://</a> '
     + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">second</a> '
     + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">second no http://</a> '
     + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">third</a> '
-    + '<a href="http://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">third no https://</a>';
+    + '<a href="http://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">third no https://</a> '
+    + '<a href="https://google.com" target="_blank">link <code>[inside another link](https://google.com)</code></a>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -148,6 +150,7 @@ test('Test url replacements', () => {
         + 'https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash '
         + 'https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash '
         + 'mm..food '
+        + 'upwork.com/jobs/~016781e062ce860b84 '
         + 'https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:\'2125cbe0-28a9-11e9-a79c-3de0157ed580\',interval:auto,query:(language:lucene,query:\'\'),sort:!(timestamp,desc))';
 
     const urlTestReplacedString = 'Testing '
@@ -177,6 +180,7 @@ test('Test url replacements', () => {
         + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> '
         + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> '
         + 'mm..food '
+        + '<a href="http://upwork.com/jobs/~016781e062ce860b84" target="_blank">upwork.com/jobs/~016781e062ce860b84</a> '
         + '<a href="https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))" target="_blank">https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))</a>';
 
     expect(parser.replace(urlTestStartString)).toBe(urlTestReplacedString);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -2,7 +2,7 @@ import Str from './str';
 import TLD_REGEX from './tlds';
 
 const URL_WEBSITE_REGEX = `(https?:\\/\\/)?((?:www\\.)?[-a-z0-9]+?\\.)+(?:${TLD_REGEX})(?:\\:\\d{2,4}|\\b|(?=_))`;
-const URL_PATH_REGEX = '(?:\\/[-\\w$@.&+!*"\'(),=%]*[-\\w~@:%)]|\\/)*';
+const URL_PATH_REGEX = '(?:\\/[-\\w$@.&+!*"\'(),=%~]*[-\\w~@:%)]|\\/)*';
 const URL_PARAM_REGEX = '(?:\\?[-\\w$@.&+!*"\'()\\/,=%{}:;\\[\\]\\|_]+)?';
 const URL_FRAGMENT_REGEX = '(?:#[-\\w$@.&+!*"\'()[\\],=%;\\/:~]*)?';
 const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
@@ -76,7 +76,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `\\[([\\w\\s\\d!?&#;:\\/\\-\\.\\+=<>,]+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
+                        `\\[((?:[\\w\\s\\d!?&#;:\\/\\-\\.\\+=<>,]|(?:<code>.+<\\/code>))+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);


### PR DESCRIPTION
@timszot can you review this please? I'm not 100% sure this is the way we want to do `code` tags inside of links

### Fixed Issues
Fixes latest two broken links in https://github.com/Expensify/Expensify/issues/153365

# Tests
1. Automated

# QA
1. Manually applied these changes to expensify.cash
2. sent the following message
```
[test `[test](google.com)`](google.com)
https://www.upwork.com/jobs/~016781e062ce860b84
```
3. Verified it linked properly
![image](https://user-images.githubusercontent.com/22447860/111223052-e09fed80-8599-11eb-96fb-e83d1a6b1ee3.png)
