### PR TITLE
Update expensimark for italic code blocks and links with @ in them

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -51,7 +51,8 @@ test('Test critical markdown style links', () => {
     + '[second no http://](necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled) '
     + '[third](https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) '
     + '[third no https://](github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) '
-    + '[link `[inside another link](https://google.com)`](https://google.com)';
+    + '[link `[inside another link](https://google.com)`](https://google.com) '
+    + '[link with an @ in it](https://google.com)';
     const resultString = 'Testing '
     + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">first</a> '
     + '<a href="http://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">first no https://</a> '
@@ -59,7 +60,8 @@ test('Test critical markdown style links', () => {
     + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">second no http://</a> '
     + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">third</a> '
     + '<a href="http://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">third no https://</a> '
-    + '<a href="https://google.com" target="_blank">link <code>[inside another link](https://google.com)</code></a>';
+    + '<a href="https://google.com" target="_blank">link <code>[inside another link](https://google.com)</code></a> '
+    + '<a href="https://google.com" target="_blank">link with an @ in it</a>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -101,6 +103,16 @@ test('Test inline code blocks', () => {
 test('Test inline code blocks with ExpensiMark syntax inside', () => {
     const inlineCodeStartString = '`This is how you can write ~strikethrough~, *bold*, and _italics_`';
     expect(parser.replace(inlineCodeStartString)).toBe('<code>This is how you can write ~strikethrough~, *bold*, and _italics_</code>');
+});
+
+test('Test inline code blocks inside ExpensiMark', () => {
+   const testString = '_`test`_'
+   + '*`test`*'
+   + '~`test`~';
+   const resultString = '<em><code>test</code></em>'
+   + '<strong><code>test</code></strong>'
+   + '<del><code>test</code></del>';
+   expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test code fencing with ExpensiMark syntax inside', () => {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -46,7 +46,7 @@ export default class ExpensiMark {
                 name: 'inlineCodeBlock',
 
                 // Use the url escaped version of a backtick (`) symbol
-                regex: /\B&#x60;(.*?)&#x60;\B(?![^<]*<\/pre>)/g,
+                regex: /(?<=\B|_)&#x60;(.*?)&#x60;(?=\B|_)(?![^<]*<\/pre>)/g,
                 replacement: '<code>$1</code>',
             },
 
@@ -76,7 +76,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `\\[((?:[\\w\\s\\d!?&#;:\\/\\-\\.\\+=<>,]|(?:<code>.+<\\/code>))+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
+                        `\\[((?:[\\w\\s\\d!?&#;:\\/\\-\\.\\+=<>,@]|(?:<code>.+<\\/code>))+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);


### PR DESCRIPTION
cc @timszot 

### Fixed Issues
Regex updates for 
https://github.com/Expensify/Expensify/issues/156476
https://github.com/Expensify/Expensify/issues/153365

# Tests
1. New automated tests
2. Applied changes to e.cash locally, verified both cases worked
![image](https://user-images.githubusercontent.com/22447860/112895865-81120980-9092-11eb-9eb7-6fdfa03e190e.png)

# QA
Will be qa'd in the follow up e.cash pr