### PR TITLE
Don't use any lookbehinds in inline code blocks

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -45,9 +45,10 @@ export default class ExpensiMark {
             {
                 name: 'inlineCodeBlock',
 
-                // Use the url escaped version of a backtick (`) symbol
-                regex: /(?<=\B|_)&#x60;(.*?)&#x60;(?=\B|_)(?![^<]*<\/pre>)/g,
-                replacement: '<code>$1</code>',
+                // Use the url escaped version of a backtick (`) symbol. Mobile platforms do not support lookbehinds,
+                // so capture the first and third group and place them in the replacement.
+                regex: /(\B|_)&#x60;(.*?)&#x60;(\B|_)(?![^<]*<\/pre>)/g,
+                replacement: '$1<code>$2</code>$3',
             },
 
             /**


### PR DESCRIPTION
cc @timszot 

### Fixed Issues
No issue, mobile was borked

# Tests
1. Automated tests
2. Verified app did not crash when changes were applied to mobile and e.cash

# QA
N/a
