### PR TITLE
Fix end parenthesis issue with urls in ExpensiMark

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -189,7 +189,7 @@ test('Test url replacements', () => {
         + '<a href="http://testRareTLDs.beer" target="_blank">testRareTLDs.beer</a> '
         + '<a href="mailto:test@expensify.com">test@expensify.com</a> '
         + 'test.completelyFakeTLD '
-        + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878)" target="_blank">https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878)</a> '
+        + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878</a>) '
         + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled</a> '
         + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> '
         + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> '
@@ -287,10 +287,18 @@ test('Test general email link with various styles', () => {
 test('Test link with brackets', () => {
     const testString = '[google](http://google.com/(something)?after=parens) '
         + '([google](http://google.com/(something)?after=parens)) '
-        + '([google](https://google.com/)) ';
+        + '([google](https://google.com/)) '
+        + '([google](http://google.com/(something)?after=parens)))) '
+        + '(http://foo.com/(something)?after=parens) '
+        + '(((http://foo.com/(something)?after=parens))) '
+        + 'http://foo.com/(something)?after=parens))) ';
 
     const resultString = '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
     + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) '
-    + '(<a href="https://google.com/" target="_blank">google</a>) ';
+    + '(<a href="https://google.com/" target="_blank">google</a>) '
+    + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>))) '
+    + '(<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>) '
+    + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
+    + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ';
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -284,7 +284,7 @@ test('Test general email link with various styles', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test link with brackets', () => {
+test('Test markdown and url links with inconsistent starting and closing parens', () => {
     const testString = '[google](http://google.com/(something)?after=parens) '
         + '([google](http://google.com/(something)?after=parens)) '
         + '([google](https://google.com/)) '
@@ -304,6 +304,6 @@ test('Test link with brackets', () => {
         + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> '
         + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
         + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ';
-    
+
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -296,13 +296,14 @@ test('Test link with brackets', () => {
         + 'http://foo.com/(something)?after=parens))) ';
 
     const resultString = '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
-    + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) '
-    + '(<a href="https://google.com/" target="_blank">google</a>) '
-    + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>))) '
-    + '(((<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
-    + '(<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>) '
-    + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> '
-    + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
-    + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ';
+        + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) '
+        + '(<a href="https://google.com/" target="_blank">google</a>) '
+        + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>))) '
+        + '(((<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
+        + '(<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>) '
+        + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> '
+        + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
+        + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ';
+    
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -289,7 +289,9 @@ test('Test link with brackets', () => {
         + '([google](http://google.com/(something)?after=parens)) '
         + '([google](https://google.com/)) '
         + '([google](http://google.com/(something)?after=parens)))) '
+        + '((([google](http://google.com/(something)?after=parens) '
         + '(http://foo.com/(something)?after=parens) '
+        + '(((http://foo.com/(something)?after=parens '
         + '(((http://foo.com/(something)?after=parens))) '
         + 'http://foo.com/(something)?after=parens))) ';
 
@@ -297,7 +299,9 @@ test('Test link with brackets', () => {
     + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) '
     + '(<a href="https://google.com/" target="_blank">google</a>) '
     + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>))) '
+    + '(((<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
     + '(<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>) '
+    + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> '
     + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
     + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ';
     expect(parser.replace(testString)).toBe(resultString);

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -283,3 +283,14 @@ test('Test general email link with various styles', () => {
 
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test link with brackets', () => {
+    const testString = '[google](http://google.com/(something)?after=parens) '
+        + '([google](http://google.com/(something)?after=parens)) '
+        + '([google](https://google.com/)) ';
+
+    const resultString = '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
+    + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) '
+    + '(<a href="https://google.com/" target="_blank">google</a>) ';
+    expect(parser.replace(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -207,7 +207,8 @@ export default class ExpensiMark {
                 match[0] = match[0].substr(0, match[0].length - 1);
                 match[2] = match[2].substr(0, match[2].length - 1);
             }
-            // remove extra brace
+
+            // remove extra ) parentheses
             let brace = 0;
             if (match[2][match[2].length - 1] === ')') {
                 for (let i = 0; i < match[2].length; i++) {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -80,7 +80,7 @@ export default class ExpensiMark {
                         `\\[((?:[\\w\\s\\d!?&#;:\\/\\-\\.\\+=<>,@\\[\\]]|(?:<code>.+<\\/code>))+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
-                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
+                    return this.modifyTextForUrlLinks('link',regex, textToProcess, replacement);
                 },
 
                 // We use a function here to check if there is already a https:// on the link.
@@ -97,7 +97,7 @@ export default class ExpensiMark {
                         `(?![^<]*>|[^<>]*<\\/)([_*~]*?)${URL_REGEX}\\1(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
-                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
+                    return this.modifyTextForUrlLinks('autolink', regex, textToProcess, replacement);
                 },
 
                 // We use a function here to check if there is already a https:// on the link.
@@ -190,7 +190,7 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    modifyTextForUrlLinks(regex, textToCheck, replacement) {
+    modifyTextForUrlLinks(type, regex, textToCheck, replacement) {
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;
@@ -207,7 +207,24 @@ export default class ExpensiMark {
                 match[0] = match[0].substr(0, match[0].length - 1);
                 match[2] = match[2].substr(0, match[2].length - 1);
             }
-
+            if(type === 'link'){
+                // remove extra brace
+                let brace = 0;
+                if (match[2][match[2].length - 1] === ')') {
+                    for (let i = 0; i < match[2].length; i++) {
+                        if (match[2][i] === '(') {
+                            brace++;
+                        }
+                        if (match[2][i] === ')') {
+                            brace--;
+                        }
+                    }
+                    if (brace) {
+                        match[0] = match[0].substr(0, match[0].length - 1);
+                        match[2] = match[2].substr(0, match[2].length - 1);
+                    }
+                }
+            }
             replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
 
             if (abort) {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -80,7 +80,7 @@ export default class ExpensiMark {
                         `\\[((?:[\\w\\s\\d!?&#;:\\/\\-\\.\\+=<>,@\\[\\]]|(?:<code>.+<\\/code>))+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
-                    return this.modifyTextForUrlLinks('link',regex, textToProcess, replacement);
+                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
                 },
 
                 // We use a function here to check if there is already a https:// on the link.
@@ -97,7 +97,7 @@ export default class ExpensiMark {
                         `(?![^<]*>|[^<>]*<\\/)([_*~]*?)${URL_REGEX}\\1(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
-                    return this.modifyTextForUrlLinks('autolink', regex, textToProcess, replacement);
+                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
                 },
 
                 // We use a function here to check if there is already a https:// on the link.
@@ -190,7 +190,7 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    modifyTextForUrlLinks(type, regex, textToCheck, replacement) {
+    modifyTextForUrlLinks(regex, textToCheck, replacement) {
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;
@@ -207,22 +207,20 @@ export default class ExpensiMark {
                 match[0] = match[0].substr(0, match[0].length - 1);
                 match[2] = match[2].substr(0, match[2].length - 1);
             }
-            if(type === 'link'){
-                // remove extra brace
-                let brace = 0;
-                if (match[2][match[2].length - 1] === ')') {
-                    for (let i = 0; i < match[2].length; i++) {
-                        if (match[2][i] === '(') {
-                            brace++;
-                        }
-                        if (match[2][i] === ')') {
-                            brace--;
-                        }
+            // remove extra brace
+            let brace = 0;
+            if (match[2][match[2].length - 1] === ')') {
+                for (let i = 0; i < match[2].length; i++) {
+                    if (match[2][i] === '(') {
+                        brace++;
                     }
-                    if (brace) {
-                        match[0] = match[0].substr(0, match[0].length - 1);
-                        match[2] = match[2].substr(0, match[2].length - 1);
+                    if (match[2][i] === ')') {
+                        brace--;
                     }
+                }
+                if (brace) {
+                    match[0] = match[0].substr(0, match[0].length + brace);
+                    match[2] = match[2].substr(0, match[2].length + brace);
                 }
             }
             replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));


### PR DESCRIPTION
Please review @Beamanator 

Details of the issue can be found here https://github.com/Expensify/Expensify.cash/issues/1656
Explanation of the solution can be found in https://github.com/Expensify/Expensify.cash/issues/1656#issuecomment-816339424 and https://github.com/Expensify/Expensify.cash/issues/1656#issuecomment-816905209 comments.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/1656

# Tests
1. What unit/integration tests cover your change? What auto QA tests cover your change?
I have added more tests to support the logic here.

2. What tests did you perform that validates your changes worked?
I have run the unit tests over the codebase which passed.

# QA
1. What does QA need to do to validate your changes?
  - You can run the unit test and see if they passed. 
  - Or, You can use the latest commit hash of merging branch and use it like
  ```
  "expensify-common": "git+https://github.com/parasharrajat/expensify-common.git#dfe547cac0f1f43ba69fcbbe6c8ddb70f8c0b22d"
   ```
   into Expensify.cash and then following with `npm install`.  Now you can test various URLs in the chat as mentioned in the issue.

2. What areas to they need to test for regressions?

URls in chat messages.
