### PR TITLE
Update stripHTML to actually strip tags

### DIFF
--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -42,3 +42,12 @@ describe('Str.isValidURL', () => {
         expect(Str.isValidURL('test')).toBeFalsy();
     });
 });
+
+describe('Str.stripHTML', () => {
+    it('Correctly identifies valid urls', () => {
+        expect(Str.stripHTML('<strong>hello</strong>')).toBe('hello');
+        expect(Str.stripHTML('<img onerror=\'alert("could run arbitrary JS here")\' src=bogus>')).toBe('');
+        expect(Str.stripHTML('hello')).toBe('hello');
+        expect(Str.stripHTML(0)).toBe('');
+    });
+});

--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -44,7 +44,7 @@ describe('Str.isValidURL', () => {
 });
 
 describe('Str.stripHTML', () => {
-    it('Correctly identifies valid urls', () => {
+    it('Correctly strips HTML/XML tags', () => {
         expect(Str.stripHTML('<strong>hello</strong>')).toBe('hello');
         expect(Str.stripHTML('<img onerror=\'alert("could run arbitrary JS here")\' src=bogus>')).toBe('');
         expect(Str.stripHTML('hello')).toBe('hello');

--- a/lib/str.js
+++ b/lib/str.js
@@ -305,12 +305,15 @@ const Str = {
     /**
      * Gets the textual value of the given string.
      *
-     * @deprecated use htmlDecode() instead
      * @param {String} str The string to fetch the text value from.
      * @return {String} The text from within the HTML string.
      */
     stripHTML(str) {
-        return this.htmlDecode(str);
+        if (!this.isString(str)) {
+            return '';
+        };
+
+        return str.replace(/<[^>]*>?/gm, '');
     },
 
     /**

--- a/lib/str.js
+++ b/lib/str.js
@@ -223,7 +223,8 @@ const Str = {
 
     /**
      * Returns the byte size of a character
-     * @param {String} inputChar You can input more than one character, but it will only return the size of the first one.
+     * @param {String} inputChar You can input more than one character, but it will only return the size of the first
+     * one.
      * @returns {Number} Byte size of the character
      */
     getRawByteSize(inputChar) {
@@ -311,7 +312,7 @@ const Str = {
     stripHTML(str) {
         if (!this.isString(str)) {
             return '';
-        };
+        }
 
         return str.replace(/<[^>]*>?/gm, '');
     },


### PR DESCRIPTION
@roryabraham will you please review this?
cc @tgolen

The way we were using `htmlDecode` in place of `stripHTML` was wrong I believe. Strip means to remove. In any case, the implementation of `htmlDecode` was not actually stripping tags in the first place:
```
>> Str.stripHTML('<strong>hello</strong>')
"<strong>hello</strong>"
>> $('<textarea/>').html('<strong>hello</strong>').text();
"<strong>hello</strong>"
```

### Fixed Issues
None, but using to clean up code mentioned here: https://github.com/Expensify/Expensify.cash/pull/2320/files#r613669999

# Tests
- Added Unit tests
