### PR TITLE
Adding cheerful.com as public domain

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -817,6 +817,7 @@ export const PUBLIC_DOMAINS = [
     'bellsouth.net',
     'bills.expensify.com',
     'btinternet.com',
+    'cheerful.com',
     'chromeexpensify.com',
     'comcast.net',
     'cox.net',


### PR DESCRIPTION
We need to add a new public domain for cheerful.com which seems to be linked to mail.com accounts. 

### Fixed Issues
https://github.com/Expensify/Expensify/issues/161789

# Tests
N/A

# QA
N/A
