### PR TITLE
Add isDomainEmail function to str lib

### DIFF
--- a/lib/str.js
+++ b/lib/str.js
@@ -1038,6 +1038,17 @@ const Str = {
     isImage(url) {
         return _.contains(['jpeg', 'jpg', 'gif', 'png', 'bmp'], this.getExtension(url));
     },
+
+    /**
+     * Checks whether the given string is a +@ domain email account, such as
+     * +@domain.com
+     *
+     * @param {string} email
+     * @return {Boolean} True if is a domain account email, otherwise false.
+     */
+    isDomainEmail(email) {
+        return this.startsWith(email, '+@');
+    },
 };
 
 export default Str;

--- a/lib/str.js
+++ b/lib/str.js
@@ -1043,7 +1043,7 @@ const Str = {
      * Checks whether the given string is a +@ domain email account, such as
      * +@domain.com
      *
-     * @param {string} email
+     * @param {String} email
      * @return {Boolean} True if is a domain account email, otherwise false.
      */
     isDomainEmail(email) {


### PR DESCRIPTION
@MonilBhavsar will you please review this?
cc @roryabraham @Beamanator 

This PR adds a new function for checking if an email is a domain email to be used in E.cash for [this issue](https://github.com/Expensify/Expensify.cash/issues/2441) and for any future uses. This can also replace the [domainUtils](https://github.com/Expensify/Web-Expensify/blob/master/site/lib/domainUtils.js#L291) function in Web-E so the implementation is in one place.

### Fixed Issues
Related to https://github.com/Expensify/Expensify.cash/issues/2441

# Tests
1. Inside the expensify-common directory, I ran `npm link` while on this branch
2. I checked out Web-Expensify master and ran `npm link expensify-common`
3. I ran `grunt watch` in Web-Expensify, and went to `expensify.com.dev` and confirmed that `Str.isDomainEmail` worked in the JS console

# QA
N/A
