### PR TITLE
add claconnect.com as a public domain

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -821,6 +821,7 @@ export const PUBLIC_DOMAINS = [
     'chromeexpensify.com',
     'comcast.net',
     'cox.net',
+    'claconnect.com',
     'cpa.com',
     'evernote.user',
     'expensify.cash',


### PR DESCRIPTION
Add claconnect.com to public domains

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/163835
