### PR TITLE
Allow more lenient code fencing with new lines

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -100,6 +100,9 @@ test('Test code fencing', () => {
 
     codeFenceExampleMarkdown = '```\nconst javaScript = \'javaScript\'```';
     expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
+
+    codeFenceExampleMarkdown = '```const javaScript = \'javaScript\'```';
+    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
 });
 
 test('Test code fencing with spaces and new lines', () => {
@@ -110,6 +113,9 @@ test('Test code fencing with spaces and new lines', () => {
     expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br>&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
 
     codeFenceExample = '```\nconst javaScript = \'javaScript\'\n    const php = \'php\'```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br>&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
+
+    codeFenceExample = '```const javaScript = \'javaScript\'\n    const php = \'php\'```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br>&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
 });
 
@@ -141,6 +147,9 @@ test('Test code fencing with ExpensiMark syntax inside', () => {
     expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
 
     codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
+
+    codeFenceExample = '```This is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
 });
 

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -92,12 +92,24 @@ test('Test period replacements', () => {
 });
 
 test('Test code fencing', () => {
-    const codeFenceExampleMarkdown = '```\nconst javaScript = \'javaScript\'\n```';
+    let codeFenceExampleMarkdown = '```\nconst javaScript = \'javaScript\'\n```';
+    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
+
+    codeFenceExampleMarkdown = '```const javaScript = \'javaScript\'\n```';
+    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
+
+    codeFenceExampleMarkdown = '```\nconst javaScript = \'javaScript\'```';
     expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
 });
 
 test('Test code fencing with spaces and new lines', () => {
-    const codeFenceExample = '```\nconst javaScript = \'javaScript\'\n    const php = \'php\'\n```';
+    let codeFenceExample = '```\nconst javaScript = \'javaScript\'\n    const php = \'php\'\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br>&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
+
+    codeFenceExample = '```const javaScript = \'javaScript\'\n    const php = \'php\'\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br>&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
+
+    codeFenceExample = '```\nconst javaScript = \'javaScript\'\n    const php = \'php\'```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br>&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
 });
 
@@ -122,7 +134,13 @@ test('Test inline code blocks inside ExpensiMark', () => {
 });
 
 test('Test code fencing with ExpensiMark syntax inside', () => {
-    const codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
+    let codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
+
+    codeFenceExample = '```This is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
+
+    codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -25,6 +25,7 @@ export default class ExpensiMark {
 
                 // &#60; is a backtick symbol we are matching on three of them before then after a new line character
                 regex: /(&#x60;&#x60;&#x60;[\n]?)((?:(?![\n]?&#x60;&#x60;&#x60;)[\s\S])+)([\n]?&#x60;&#x60;&#x60;)/g,
+
                 // We're using a function here to perform an additional replace on the content
                 // inside the backticks because Android is not able to use <pre> tags and does
                 // not respect whitespace characters at all like HTML does. We do not want to mess

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -24,16 +24,15 @@ export default class ExpensiMark {
                 name: 'codeFence',
 
                 // &#60; is a backtick symbol we are matching on three of them before then after a new line character
-                regex: /&#x60;&#x60;&#x60;\n((?:(?!&#x60;&#x60;&#x60;)[\s\S])+)\n&#x60;&#x60;&#x60;/g,
-
+                regex: /(&#x60;&#x60;&#x60;[\n]?)((?:(?![\n]?&#x60;&#x60;&#x60;)[\s\S])+)([\n]?&#x60;&#x60;&#x60;)/g,
                 // We're using a function here to perform an additional replace on the content
                 // inside the backticks because Android is not able to use <pre> tags and does
                 // not respect whitespace characters at all like HTML does. We do not want to mess
                 // with the new lines here since they need to be converted into <br>. And we don't
                 // want to do this anywhere else since that would break HTML.
                 // &nbsp; will create styling issues so use &#32;
-                replacement: (match, firstCapturedGroup) => {
-                    const group = firstCapturedGroup.replace(/(?:(?![\n\r])\s)/g, '&#32;');
+                replacement: (match, _, secondCapturedGroup) => {
+                    const group = secondCapturedGroup.replace(/(?:(?![\n\r])\s)/g, '&#32;');
                     return `<pre>${group}</pre>`;
                 },
             },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -32,8 +32,8 @@ export default class ExpensiMark {
                 // with the new lines here since they need to be converted into <br>. And we don't
                 // want to do this anywhere else since that would break HTML.
                 // &nbsp; will create styling issues so use &#32;
-                replacement: (match, _, secondCapturedGroup) => {
-                    const group = secondCapturedGroup.replace(/(?:(?![\n\r])\s)/g, '&#32;');
+                replacement: (match, _, textWithinFences) => {
+                    const group = textWithinFences.replace(/(?:(?![\n\r])\s)/g, '&#32;');
                     return `<pre>${group}</pre>`;
                 },
             },


### PR DESCRIPTION
@bondydaa My local Android build for E.cash is broken. If yours has been working, do you mind copying [the changes](https://github.com/Expensify/expensify-common/pull/376) from `ExpensiMark.js` to `Expensify.cash/node_modules/expensify-common/lib/ExpensiMark.js`, running it on Android, and following the QA steps just to verify that it works? Should be fine, I just know there might be quirks with the Regex parsers for Android.

# Details
Our code fencing previously only worked if there were newlines surrounding the wrapped text. This changes it so that you don't need newlines (just like what Slack offers). See the issue for more context.

e.g:

\```
hi
\```
and \```hi\``` are the same.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3039

# Tests
- Expensimark-test covers all my changes. I've updated each of the tests for code fencing to include each possible case (see QA)


# QA
In Expensify.cash, try to send this as a message, and verify it renders the same as the screenshot:

> \```hi\```
\```hi
\```
\```
hi\```
\```
hi
\```

<img width="821" alt="Screen Shot 2021-05-24 at 8 38 41 PM" src="https://user-images.githubusercontent.com/31285285/119348894-09e2a580-bcd0-11eb-8ef0-3227acfdfb5c.png">

# Screen Captures

## Web
https://user-images.githubusercontent.com/31285285/119344670-84102b80-bcca-11eb-9903-8ac3907aad98.mp4

## Mobile Web
https://user-images.githubusercontent.com/31285285/119344719-90948400-bcca-11eb-80b9-5bc40a1ac858.mp4

## iOS
https://user-images.githubusercontent.com/31285285/119344749-99855580-bcca-11eb-84ac-090692a7aaf6.mp4

## Android

## Desktop
https://user-images.githubusercontent.com/31285285/119344810-af931600-bcca-11eb-908f-69747c4200ff.mp4

