### PR TITLE
[No QA] Added dependabot to the allowlist for CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -36,3 +36,4 @@ jobs:
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
                   lock-pullrequest-aftermerge: false
+                  allowlist: dependabot

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -36,4 +36,4 @@ jobs:
                   remote-organization-name: 'Expensify'
                   remote-repository-name: 'CLA'
                   lock-pullrequest-aftermerge: false
-                  allowlist: dependabot
+                  allowlist: dependabot,snyk-bot


### PR DESCRIPTION
### Related Issues
I noticed that dependabot couldn't pass the CLA in this repo, so I added an allowlist.
Example: https://github.com/Expensify/expensify-common/pull/377

# Tests

N/A

# QA

N/A