### PR TITLE
Revert "add claconnect.com as a public domain"

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -821,7 +821,6 @@ export const PUBLIC_DOMAINS = [
     'chromeexpensify.com',
     'comcast.net',
     'cox.net',
-    'claconnect.com',
     'cpa.com',
     'evernote.user',
     'expensify.cash',


### PR DESCRIPTION
Reverts Expensify/expensify-common#369

for https://github.com/Expensify/Expensify/issues/164401