### PR TITLE
Update react to 16.14.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7368,9 +7368,9 @@
       }
     },
     "react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7378,14 +7378,14 @@
       }
     },
     "react-dom": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.18.0"
+        "scheduler": "^0.19.1"
       }
     },
     "react-is": {
@@ -7960,9 +7960,9 @@
       }
     },
     "scheduler": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jquery": "3.6.0",
     "lodash": "4.17.21",
     "prop-types": "15.7.2",
-    "react": "16.12.0",
+    "react": "^16.14.0",
     "react-dom": "16.12.0",
     "semver": "^7.3.5",
     "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "4.17.21",
     "prop-types": "15.7.2",
     "react": "^16.14.0",
-    "react-dom": "16.12.0",
+    "react-dom": "^16.14.0",
     "semver": "^7.3.5",
     "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
     "underscore": "1.13.1"


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

Snyk made a pull-request to update these libraries in expensify-common, but these changes really need to be tested before they can be released into the wild. 

### Related PRs
$ https://github.com/Expensify/expensify-common/pull/375

# Tests
Need to test general behavior for the following repos that use expensify-common:
1. Expensify.cash
2. Web-Expensify
3. Web-Secure
4. react-native-onyx

Mobile-Expensify also uses expensify-common but not the React portion and can be safely skipped for testing.

# QA
1. Normal regression testing should be enough