### PR TITLE
Changes in quotes

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -338,3 +338,35 @@ test('Test markdown and url links with inconsistent starting and closing parens'
 
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test quotes markdown replacement with text matching inside and outside codefence without spaces', () => {
+    const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\n```\nThe next line should not be quoted\n&gt;Hello,I’mtext\nsince its inside a codefence```';
+
+    const resultString = 'The next line should be quoted<br><blockquote>Hello,I’mtext</blockquote><pre>The&#32;next&#32;line&#32;should&#32;not&#32;be&#32;quoted<br>&gt;Hello,I’mtext<br>since&#32;its&#32;inside&#32;a&#32;codefence</pre>';
+
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with text matching inside and outside codefence at the same line', () => {
+    const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\nThe next line should not be quoted\n```&gt;Hello,I’mtext```\nsince its inside a codefence';
+
+    const resultString = 'The next line should be quoted<br><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted<br><pre>&gt;Hello,I’mtext</pre><br>since its inside a codefence';
+
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with text matching inside and outside codefence at the end of the text', () => {
+    const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\nThe next line should not be quoted\n```&gt;Hello,I’mtext```';
+
+    const resultString = 'The next line should be quoted<br><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted<br><pre>&gt;Hello,I’mtext</pre>';
+
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with text matching inside and outside codefence with quotes at the end of the text', () => {
+    const testString = 'The next line should be quoted\n```&gt;Hello,I’mtext```\nThe next line should not be quoted\n&gt;Hello,I’mtext';
+
+    const resultString = 'The next line should be quoted<br><pre>&gt;Hello,I’mtext</pre><br>The next line should not be quoted<br><blockquote>Hello,I’mtext</blockquote>';
+
+    expect(parser.replace(testString)).toBe(resultString);
+});

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -339,6 +339,33 @@ test('Test markdown and url links with inconsistent starting and closing parens'
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test HTML string with <br/> tags to markdown ', () => {
+    const testString = 'Hello<br/>World,<br/>Welcome<br/>To<br/>Expensify';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test HTML string with inconsistent <br/> closing tags to markdown ', () => {
+    const testString = 'Hello<br>World,<br/>Welcome<br>To<br/>Expensify';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test HTML string with seperate closing tags (<br><br/>) to markdown ', () => {
+    const testString = 'Hello<br>World,<br><br/>Welcome<br/>To<br/>Expensify';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test HTML string with seperate closing tags (<br></br>) to markdown ', () => {
+    const testString = 'Hello<br>World,<br></br>Welcome<br/>To<br/>Expensify';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
 test('Test quotes markdown replacement with text matching inside and outside codefence without spaces', () => {
     const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\n```\nThe next line should not be quoted\n&gt;Hello,I’mtext\nsince its inside a codefence```';
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -164,6 +164,22 @@ export default class ExpensiMark {
                 replacement: '<br>',
             },
         ];
+
+        /**
+         * The list of regex replacements to do on a HTML comment for converting it to markdown.
+         *
+         * @type {Object[]}
+         */
+        this.htmlToMarkdownRules = [
+            {
+                name: 'newline',
+
+                // Replaces open and closing <br><br/> tags with a single <br/>
+                pre: inputString => inputString.replace('<br></br>', '<br/>').replace('<br><br/>', '<br/>'),
+                regex: /<br\s*[/]?>/gi,
+                replacement: '\n'
+            },
+        ];
     }
 
     /**
@@ -256,6 +272,25 @@ export default class ExpensiMark {
         if (startIndex < textToCheck.length) replacedText = replacedText.concat(textToCheck.substr(startIndex));
 
         return replacedText;
+    }
+
+    /**
+     * Replaces HTML with markdown
+     *
+     * @param {String} htmlString
+     *
+     * @returns {String}
+     */
+    htmlToMarkdown(htmlString) {
+        let generatedMarkdown = htmlString;
+        this.htmlToMarkdownRules.forEach((rule) => {
+            // Pre-processes input HTML before applying regex
+            if (rule.pre) {
+                generatedMarkdown = rule.pre(generatedMarkdown);
+            }
+            generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
+        });
+        return generatedMarkdown;
     }
 
     /**

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -367,7 +367,7 @@ export default class ExpensiMark {
             // Replace all the blank lines between quotes, if there are only blank lines between them
             replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, '</blockquote><blockquote>');
         } else {
-            // If we doesnt have matches make sure the function will return the same textToCheck
+            // If we doesn't have matches make sure the function will return the same textToCheck
             replacedText = textToCheck;
         }
         return replacedText;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -306,30 +306,30 @@ export default class ExpensiMark {
         let textToFormat = '';
         const match = textToCheck.match(regex);
 
-        // if there's matches we need to modify the quotes
+        // If there's matches we need to modify the quotes
         if (match !== null) {
             let insideCodefence = false;
 
-            // split the textToCheck in lines
+            // Split the textToCheck in lines
             const textSplitted = textToCheck.split('\n');
 
             for (let i = 0; i < textSplitted.length; i++) {
                 if (!insideCodefence) {
-                    // we need to know when there is a start of codefence so we dont quote
+                    // We need to know when there is a start of codefence so we dont quote
                     insideCodefence = Str.contains(textSplitted[i], '<pre>');
                 }
 
-                // we only want to modify lines starting with &gt; that is not codefence
+                // We only want to modify lines starting with &gt; that is not codefence
                 if (Str.startsWith(textSplitted[i], '&gt;') && !insideCodefence) {
-                    // avoid blank lines starting with &gt;
+                    // Avoid blank lines starting with &gt;
                     if (textSplitted[i].trim() !== '&gt;') {
                         textSplitted[i] = textSplitted[i].substr(4).trim();
                         textSplitted[i] = textSplitted[i].trim();
                         textToFormat += `${textSplitted[i]}\n`;
 
-                        // we need ensure that index i-1 >= 0
+                        // We need ensure that index i-1 >= 0
                     } else if (i > 0) {
-                        // certificate that we will have only one blank row
+                        // Certificate that we will have only one blank row
                         if (textSplitted[i - 1].trim() !== '') {
                             textSplitted[i] = textSplitted[i].substr(4).trim();
                             textSplitted[i] = textSplitted[i].trim();
@@ -337,38 +337,37 @@ export default class ExpensiMark {
                         }
                     }
                 } else {
-                    // make sure we will only modify if we have Text needed to be formatted for quote
+                    // Make sure we will only modify if we have Text needed to be formatted for quote
                     if (textToFormat !== '') {
                         textToFormat = textToFormat.replace(/\n$/, '');
                         replacedText += replacement(textToFormat);
                         textToFormat = '';
                     }
 
-                    // if index === last row
+                    // We dont want a \n after the textSplitted if it is the last row
                     if (i === textSplitted.length - 1) {
-                        // we dont want a \n after the textSplitted if it is the last row
                         replacedText += `${textSplitted[i]}`;
                     } else {
                         replacedText += `${textSplitted[i]}\n`;
                     }
 
-                    // we need to know when we are not inside codefence anymore
+                    // We need to know when we are not inside codefence anymore
                     if (insideCodefence) {
                         insideCodefence = !Str.contains(textSplitted[i], '</pre>');
                     }
                 }
             }
 
-            // when loop ends we need the last quote to be formatted if we have quotes at last rows
+            // When loop ends we need the last quote to be formatted if we have quotes at last rows
             if (textToFormat !== '') {
                 textToFormat = textToFormat.replace(/\n$/, '');
                 replacedText += replacement(textToFormat);
             }
 
-            // replace all the blank lines between quotes, if there are only blank lines between them
+            // Replace all the blank lines between quotes, if there are only blank lines between them
             replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, '</blockquote><blockquote>');
         } else {
-            // if we doesnt have matches make sure the function will return the same textToCheck
+            // If we doesnt have matches make sure the function will return the same textToCheck
             replacedText = textToCheck;
         }
         return replacedText;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -148,9 +148,9 @@ export default class ExpensiMark {
                 // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
-                process: (textToProcess, replacement) => {
+                process: (textToProcess) => {
                     const regex = new RegExp(
-                        `((\n?^&gt; ?(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+))+)`,
+                        '((\n?^&gt; ?(?![^<]*(?:</pre>|</code>))([^\v\n\r]+))+)',
                         'gm'
                     );
                     return this.modifyTextForQuote(regex, textToProcess);
@@ -265,67 +265,59 @@ export default class ExpensiMark {
      * @returns {String}
      */
 
-     modifyTextForQuote(regex, textToCheck) {
-        let replacedText = "";
-        let TextToFormat = "";
-        match = textToCheck.match(regex);
+    modifyTextForQuote(regex, textToCheck) {
+        let replacedText = '';
+        let TextToFormat = '';
+        const match = textToCheck.match(regex);
 
-        //if there's matches we need to modify the quotes
+        // if there's matches we need to modify the quotes
         if (match !== null) {
-            //split the textToCheck in lines
-            let textSplitted = textToCheck.split('\n');
+            // split the textToCheck in lines
+            const textSplitted = textToCheck.split('\n');
             for (let i = 0; i < textSplitted.length; i++) {
-
-                //we only want to modify lines starting with &gt; 
-                if (textSplitted[i].substr(0, 4) == "&gt;") {
-
-                    //avoid blank lines starting with &gt;
-                    if (textSplitted[i].trim() !== "&gt;") {
+                // we only want to modify lines starting with &gt;
+                if (textSplitted[i].substr(0, 4) === '&gt;') {
+                    // avoid blank lines starting with &gt;
+                    if (textSplitted[i].trim() !== '&gt;') {
                         textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
                         textSplitted[i] = textSplitted[i].trim();
-                        TextToFormat += textSplitted[i] + '\n';
-
+                        TextToFormat += `${textSplitted[i]}\n`;
                     } else {
-
-                        //we need ensure that index i-1 >= 0
+                        // we need ensure that index i-1 >= 0
                         if (i > 0) {
-
-                            //certificate that we will have only one blank row 
-                            if (textSplitted[i - 1].trim() !== "") {
+                            // certificate that we will have only one blank row
+                            if (textSplitted[i - 1].trim() !== '') {
                                 textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
                                 textSplitted[i] = textSplitted[i].trim();
-                                TextToFormat += textSplitted[i] + '\n';
+                                TextToFormat += `${textSplitted[i]}\n`;
                             } else {
-
-                            //doesnt append to textToFormat if current index row and current index row -1 was blank
+                                // doesnt append to textToFormat if current index row and current index row -1 was blank
                                 textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
                                 textSplitted[i] = textSplitted[i].trim();
                             }
                         }
                     }
                 } else {
-
-                    //make sure we will only modify if we have Text needed to be formatted for quote
-                    if (TextToFormat != "") {
-                        TextToFormat = TextToFormat.replace(/\n$/, "");
-                        replacedText += "<blockquote>" + TextToFormat + "</blockquote>";
-                        TextToFormat = "";
+                    // make sure we will only modify if we have Text needed to be formatted for quote
+                    if (TextToFormat !== '') {
+                        TextToFormat = TextToFormat.replace(/\n$/, '');
+                        replacedText += `<blockquote>${TextToFormat}</blockquote>`;
+                        TextToFormat = '';
                     }
-                    replacedText += textSplitted[i] + '\n';
+                    replacedText += `${textSplitted[i]}\n`;
                 }
             }
 
-            //when loop ends we need the last quote to be formatted if we have quotes at last rows
-            if (TextToFormat != "") {
-                TextToFormat = TextToFormat.replace(/\n$/, "");
-                replacedText += "<blockquote>" + TextToFormat + "</blockquote>";
+            // when loop ends we need the last quote to be formatted if we have quotes at last rows
+            if (TextToFormat !== '') {
+                TextToFormat = TextToFormat.replace(/\n$/, '');
+                replacedText += `<blockquote>${TextToFormat}</blockquote>`;
             }
 
-            //replace all the blank lines between quotes, if there are only blank lines between them
-            replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, "</blockquote><blockquote>");
-
+            // replace all the blank lines between quotes, if there are only blank lines between them
+            replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, '</blockquote><blockquote>');
         } else {
-        //if we doesnt have matches make sure the function will return the same textToCheck
+        // if we doesnt have matches make sure the function will return the same textToCheck
             replacedText = textToCheck;
         }
         return replacedText;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -265,10 +265,8 @@ export default class ExpensiMark {
      */
 
     modifyTextForQuote(regex, textToCheck) {
-        console.log('tetxttocheck =', textToCheck);
         let replacedText = '';
         let TextToFormat = '';
-        let isCodeFence;
         const codefenceSplitted = [];
         const match = textToCheck.match(regex);
         const match_codefence = textToCheck.match(/<pre>(\s|\S)+<\/pre>/gm);
@@ -284,7 +282,7 @@ export default class ExpensiMark {
             const textSplitted = textToCheck.split('\n');
 
             for (let i = 0; i < textSplitted.length; i++) {
-                isCodeFence = false;
+                let isCodeFence = false;
                 for (let j = 0; j < codefenceSplitted.length; j++) {
                     for (let k = 0; k < codefenceSplitted[j].length; k++) {
                     // we need to know when is codefenced

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -154,9 +154,7 @@ export default class ExpensiMark {
                     );
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
-                replacement: g1 => (
-                    `<blockquote>${g1}</blockquote>`
-                ),
+                replacement: g1 => `<blockquote>${g1}</blockquote>`,
             },
             {
                 name: 'newline',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -148,12 +148,15 @@ export default class ExpensiMark {
                 // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
-                process: (textToProcess) => {
+                process: (textToProcess, replacement) => {
                     const regex = new RegExp(
                         /\n?^&gt; ?(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm
                     );
-                    return this.modifyTextForQuote(regex, textToProcess);
+                    return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
+                replacement: g1 => (
+                    `<blockquote>${g1}</blockquote>`
+                ),
             },
             {
                 name: 'newline',
@@ -260,90 +263,79 @@ export default class ExpensiMark {
      *
      * @param {RegExp} regex
      * @param {String} textToCheck
+     * @param {Function} replacement
      *
      * @returns {String}
      */
 
-    modifyTextForQuote(regex, textToCheck) {
+    modifyTextForQuote(regex, textToCheck, replacement) {
         let replacedText = '';
-        let TextToFormat = '';
-        const codefenceSplitted = [];
+        let textToFormat = '';
         const match = textToCheck.match(regex);
-        const match_codefence = textToCheck.match(/<pre>(\s|\S)+<\/pre>/gm);
 
         // if there's matches we need to modify the quotes
         if (match !== null) {
-            // split all the codefences in lines
-            for (let i = 0; i < match_codefence.length; i++) {
-                codefenceSplitted[i] = match_codefence[i].split('\n');
-            }
+            let insideCodefence = false;
 
             // split the textToCheck in lines
             const textSplitted = textToCheck.split('\n');
 
             for (let i = 0; i < textSplitted.length; i++) {
-                let isCodeFence = false;
-                for (let j = 0; j < codefenceSplitted.length; j++) {
-                    for (let k = 0; k < codefenceSplitted[j].length; k++) {
-                    // we need to know when is codefenced
-                        if (textSplitted[i] === codefenceSplitted[j][k]) {
-                            isCodeFence = true;
-                        }
-                    }
+                if (!insideCodefence) {
+                    // we need to know when there is a start of codefence so we dont quote
+                    insideCodefence = Str.contains(textSplitted[i], '<pre>');
                 }
 
-                // we only want to modify lines starting with &gt that is not codefence;
-                if (textSplitted[i].substr(0, 4) === '&gt;' && !isCodeFence) {
+                // we only want to modify lines starting with &gt; that is not codefence
+                if (Str.startsWith(textSplitted[i], '&gt;') && !insideCodefence) {
                     // avoid blank lines starting with &gt;
                     if (textSplitted[i].trim() !== '&gt;') {
-                        textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                        textSplitted[i] = textSplitted[i].substr(4).trim();
                         textSplitted[i] = textSplitted[i].trim();
-                        TextToFormat += `${textSplitted[i]}\n`;
+                        textToFormat += `${textSplitted[i]}\n`;
 
                         // we need ensure that index i-1 >= 0
                     } else if (i > 0) {
                         // certificate that we will have only one blank row
                         if (textSplitted[i - 1].trim() !== '') {
-                            textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                            textSplitted[i] = textSplitted[i].substr(4).trim();
                             textSplitted[i] = textSplitted[i].trim();
-                            TextToFormat += `${textSplitted[i]}\n`;
-                        } else {
-                            // doesnt append to textToFormat if current index row and current index row -1 was blank
-                            textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
-                            textSplitted[i] = textSplitted[i].trim();
+                            textToFormat += `${textSplitted[i]}\n`;
                         }
                     }
-
-                // we dont want a \n after the textSplitted if it is an end of codefence(it will do the same as the else, but without \n)
-                } else if (isCodeFence && textSplitted[i].substr(textSplitted[i].length - 6, textSplitted[i].length) === '</pre>') {
-                    // make sure we will only modify if we have Text needed to be formatted for quote
-                    if (TextToFormat !== '') {
-                        TextToFormat = TextToFormat.replace(/\n$/, '');
-                        replacedText += `<blockquote>${TextToFormat}</blockquote>`;
-                        TextToFormat = '';
-                    }
-                    replacedText += `${textSplitted[i]}`;
                 } else {
                     // make sure we will only modify if we have Text needed to be formatted for quote
-                    if (TextToFormat !== '') {
-                        TextToFormat = TextToFormat.replace(/\n$/, '');
-                        replacedText += `<blockquote>${TextToFormat}</blockquote>`;
-                        TextToFormat = '';
+                    if (textToFormat !== '') {
+                        textToFormat = textToFormat.replace(/\n$/, '');
+                        replacedText += replacement(textToFormat);
+                        textToFormat = '';
                     }
-                    replacedText += `${textSplitted[i]}\n`;
+
+                    // if index === last row
+                    if (i === textSplitted.length - 1) {
+                        // we dont want a \n after the textSplitted if it is the last row
+                        replacedText += `${textSplitted[i]}`;
+                    } else {
+                        replacedText += `${textSplitted[i]}\n`;
+                    }
+
+                    // we need to know when we are not inside codefence anymore
+                    if (insideCodefence) {
+                        insideCodefence = !Str.contains(textSplitted[i], '</pre>');
+                    }
                 }
             }
 
             // when loop ends we need the last quote to be formatted if we have quotes at last rows
-            if (TextToFormat !== '') {
-                TextToFormat = TextToFormat.replace(/\n$/, '');
-                replacedText += `<blockquote>${TextToFormat}</blockquote>`;
+            if (textToFormat !== '') {
+                textToFormat = textToFormat.replace(/\n$/, '');
+                replacedText += replacement(textToFormat);
             }
 
             // replace all the blank lines between quotes, if there are only blank lines between them
             replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, '</blockquote><blockquote>');
         } else {
-        // if we doesnt have matches make sure the function will return the same textToCheck
+            // if we doesnt have matches make sure the function will return the same textToCheck
             replacedText = textToCheck;
         }
         return replacedText;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -150,8 +150,7 @@ export default class ExpensiMark {
                 // inline code blocks. A single prepending space should be stripped if it exists
                 process: (textToProcess) => {
                     const regex = new RegExp(
-                        '((\n?^&gt; ?(?![^<]*(?:</pre>|</code>))([^\v\n\r]+))+)',
-                        'gm'
+                        /\n?^&gt; ?(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm
                     );
                     return this.modifyTextForQuote(regex, textToProcess);
                 },
@@ -266,37 +265,66 @@ export default class ExpensiMark {
      */
 
     modifyTextForQuote(regex, textToCheck) {
+        console.log('tetxttocheck =', textToCheck);
         let replacedText = '';
         let TextToFormat = '';
+        let isCodeFence;
+        const codefenceSplitted = [];
         const match = textToCheck.match(regex);
+        const match_codefence = textToCheck.match(/<pre>(\s|\S)+<\/pre>/gm);
 
         // if there's matches we need to modify the quotes
         if (match !== null) {
+            // split all the codefences in lines
+            for (let i = 0; i < match_codefence.length; i++) {
+                codefenceSplitted[i] = match_codefence[i].split('\n');
+            }
+
             // split the textToCheck in lines
             const textSplitted = textToCheck.split('\n');
+
             for (let i = 0; i < textSplitted.length; i++) {
-                // we only want to modify lines starting with &gt;
-                if (textSplitted[i].substr(0, 4) === '&gt;') {
+                isCodeFence = false;
+                for (let j = 0; j < codefenceSplitted.length; j++) {
+                    for (let k = 0; k < codefenceSplitted[j].length; k++) {
+                    // we need to know when is codefenced
+                        if (textSplitted[i] === codefenceSplitted[j][k]) {
+                            isCodeFence = true;
+                        }
+                    }
+                }
+
+                // we only want to modify lines starting with &gt that is not codefence;
+                if (textSplitted[i].substr(0, 4) === '&gt;' && !isCodeFence) {
                     // avoid blank lines starting with &gt;
                     if (textSplitted[i].trim() !== '&gt;') {
                         textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
                         textSplitted[i] = textSplitted[i].trim();
                         TextToFormat += `${textSplitted[i]}\n`;
-                    } else {
+
                         // we need ensure that index i-1 >= 0
-                        if (i > 0) {
-                            // certificate that we will have only one blank row
-                            if (textSplitted[i - 1].trim() !== '') {
-                                textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
-                                textSplitted[i] = textSplitted[i].trim();
-                                TextToFormat += `${textSplitted[i]}\n`;
-                            } else {
-                                // doesnt append to textToFormat if current index row and current index row -1 was blank
-                                textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
-                                textSplitted[i] = textSplitted[i].trim();
-                            }
+                    } else if (i > 0) {
+                        // certificate that we will have only one blank row
+                        if (textSplitted[i - 1].trim() !== '') {
+                            textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                            textSplitted[i] = textSplitted[i].trim();
+                            TextToFormat += `${textSplitted[i]}\n`;
+                        } else {
+                            // doesnt append to textToFormat if current index row and current index row -1 was blank
+                            textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                            textSplitted[i] = textSplitted[i].trim();
                         }
                     }
+
+                // we dont want a \n after the textSplitted if it is an end of codefence(it will do the same as the else, but without \n)
+                } else if (isCodeFence && textSplitted[i].substr(textSplitted[i].length - 6, textSplitted[i].length) === '</pre>') {
+                    // make sure we will only modify if we have Text needed to be formatted for quote
+                    if (TextToFormat !== '') {
+                        TextToFormat = TextToFormat.replace(/\n$/, '');
+                        replacedText += `<blockquote>${TextToFormat}</blockquote>`;
+                        TextToFormat = '';
+                    }
+                    replacedText += `${textSplitted[i]}`;
                 } else {
                     // make sure we will only modify if we have Text needed to be formatted for quote
                     if (TextToFormat !== '') {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -148,8 +148,13 @@ export default class ExpensiMark {
                 // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
-                regex: /\n?^&gt; ?(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm,
-                replacement: '<blockquote>$1</blockquote>'
+                process: (textToProcess, replacement) => {
+                    const regex = new RegExp(
+                        `((\n?^&gt; ?(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+))+)`,
+                        'gm'
+                    );
+                    return this.modifyTextForQuote(regex, textToProcess);
+                },
             },
             {
                 name: 'newline',
@@ -248,6 +253,81 @@ export default class ExpensiMark {
         }
         if (startIndex < textToCheck.length) replacedText = replacedText.concat(textToCheck.substr(startIndex));
 
+        return replacedText;
+    }
+
+    /**
+     * Modify text for Quotes replacing chevrons with html elements
+     *
+     * @param {RegExp} regex
+     * @param {String} textToCheck
+     *
+     * @returns {String}
+     */
+
+     modifyTextForQuote(regex, textToCheck) {
+        let replacedText = "";
+        let TextToFormat = "";
+        match = textToCheck.match(regex);
+
+        //if there's matches we need to modify the quotes
+        if (match !== null) {
+            //split the textToCheck in lines
+            let textSplitted = textToCheck.split('\n');
+            for (let i = 0; i < textSplitted.length; i++) {
+
+                //we only want to modify lines starting with &gt; 
+                if (textSplitted[i].substr(0, 4) == "&gt;") {
+
+                    //avoid blank lines starting with &gt;
+                    if (textSplitted[i].trim() !== "&gt;") {
+                        textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                        textSplitted[i] = textSplitted[i].trim();
+                        TextToFormat += textSplitted[i] + '\n';
+
+                    } else {
+
+                        //we need ensure that index i-1 >= 0
+                        if (i > 0) {
+
+                            //certificate that we will have only one blank row 
+                            if (textSplitted[i - 1].trim() !== "") {
+                                textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                                textSplitted[i] = textSplitted[i].trim();
+                                TextToFormat += textSplitted[i] + '\n';
+                            } else {
+
+                            //doesnt append to textToFormat if current index row and current index row -1 was blank
+                                textSplitted[i] = textSplitted[i].substr(4, textSplitted[i].length);
+                                textSplitted[i] = textSplitted[i].trim();
+                            }
+                        }
+                    }
+                } else {
+
+                    //make sure we will only modify if we have Text needed to be formatted for quote
+                    if (TextToFormat != "") {
+                        TextToFormat = TextToFormat.replace(/\n$/, "");
+                        replacedText += "<blockquote>" + TextToFormat + "</blockquote>";
+                        TextToFormat = "";
+                    }
+                    replacedText += textSplitted[i] + '\n';
+                }
+            }
+
+            //when loop ends we need the last quote to be formatted if we have quotes at last rows
+            if (TextToFormat != "") {
+                TextToFormat = TextToFormat.replace(/\n$/, "");
+                replacedText += "<blockquote>" + TextToFormat + "</blockquote>";
+            }
+
+            //replace all the blank lines between quotes, if there are only blank lines between them
+            replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, "</blockquote><blockquote>");
+
+        } else {
+        //if we doesnt have matches make sure the function will return the same textToCheck
+            replacedText = textToCheck;
+        }
         return replacedText;
     }
 }


### PR DESCRIPTION
Created a process to quotes like what is done with `modifyTextForUrlLinks` at [ExpensiMark](https://github.com/Expensify/expensify-common/blob/master/lib/ExpensiMark.js) module having a function to deal with quotes:

### Fixed Issues
https://github.com/Expensify/Expensify.cash/issues/2670

# Tests

1.  Tested in the chat with these inputs:

```
> This is a one line quote

> This is a two line quote
> And this is the second line

> This is a three line quote
>
> With an empty line in the middle that has no space after the chevron

> This is another three line quote
>  
> But this time there's a space after the middle chevron
```
```
> This is another three-line quote
> 
>
>
> But this time there's a space after the middle chevron
```
# QA
1. Type in the keyboard and see that the quote now works correctly

### Tested On

- [ ] Web
- [ ] Mobile Web
- [ ] Desktop
- [ ] iOS
- [x] Android

### Screenshots

**Android**

![print1](https://user-images.githubusercontent.com/56851391/120849024-ea5b4080-c54b-11eb-8bda-49cceacea69b.png)
![print2](https://user-images.githubusercontent.com/56851391/120849026-eb8c6d80-c54b-11eb-9256-ed3f9169bca3.png)




