### PR TITLE
Skip match if there is space after Starting or before ending main symbol in Expensimark [ ~ , _ ,* ] only

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -6,9 +6,9 @@ const parser = new ExpensiMark();
 // Words wrapped in * successfully replaced with <strong></strong>
 test('Test bold markdown replacement', () => {
     const boldTestStartString = 'This is a *sentence,* and it has some *punctuation, words, and spaces*. '
-        + '*test* * testing* test*test*test.';
+        + '*test* * testing* test*test*test. * testing * *testing *';
     const boldTestReplacedString = 'This is a <strong>sentence,</strong> and it has some <strong>punctuation, words, and spaces</strong>. '
-        + '<strong>test</strong> <strong> testing</strong> test*test*test.';
+        + '<strong>test</strong> * testing* test*test*test. * testing * *testing *';
 
     expect(parser.replace(boldTestStartString)).toBe(boldTestReplacedString);
 });
@@ -23,15 +23,15 @@ test('Test quote markdown replacement', () => {
 
 // Words wrapped in _ successfully replaced with <em></em>
 test('Test italic markdown replacement', () => {
-    const italicTestStartString = 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test.';
-    const italicTestReplacedString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> <em> testing</em> test_test_test.';
+    const italicTestStartString = 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _';
+    const italicTestReplacedString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _';
     expect(parser.replace(italicTestStartString)).toBe(italicTestReplacedString);
 });
 
 // Words wrapped in ~ successfully replaced with <del></del>
 test('Test strikethrough markdown replacement', () => {
-    const strikethroughTestStartString = 'This is a ~sentence,~ and it has some ~punctuation, words, and spaces~. ~test~ ~ testing~ test~test~test.';
-    const strikethroughTestReplacedString = 'This is a <del>sentence,</del> and it has some <del>punctuation, words, and spaces</del>. <del>test</del> <del> testing</del> test~test~test.';
+    const strikethroughTestStartString = 'This is a ~sentence,~ and it has some ~punctuation, words, and spaces~. ~test~ ~ testing~ test~test~test. ~ testing ~ ~testing ~';
+    const strikethroughTestReplacedString = 'This is a <del>sentence,</del> and it has some <del>punctuation, words, and spaces</del>. <del>test</del> ~ testing~ test~test~test. ~ testing ~ ~testing ~';
     expect(parser.replace(strikethroughTestStartString)).toBe(strikethroughTestReplacedString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -47,7 +47,7 @@ export default class ExpensiMark {
 
                 // Use the url escaped version of a backtick (`) symbol. Mobile platforms do not support lookbehinds,
                 // so capture the first and third group and place them in the replacement.
-                regex: /(\B|_)&#x60;(.*?[^\s])&#x60;(\B|_)(?![^<]*<\/pre>)/g,
+                regex: /(\B|_)&#x60;(.*?)&#x60;(\B|_)(?![^<]*<\/pre>)/g,
                 replacement: '$1<code>$2</code>$3',
             },
 
@@ -126,7 +126,7 @@ export default class ExpensiMark {
                  * `_https://www.test.com_`
                  */
                 name: 'italic',
-                regex: /(?!_blank">)\b_(.*?[^\s])_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /(?!_blank">)\b_([^\s].*?[^\s])_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<em>$1</em>'
             },
             {
@@ -134,12 +134,12 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*(.*?[^\s])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B\*([^\s].*?[^\s])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<strong>$1</strong>'
             },
             {
                 name: 'strikethrough',
-                regex: /\B~(.*?[^\s])~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B~([^\s].*?[^\s])~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<del>$1</del>'
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -47,7 +47,7 @@ export default class ExpensiMark {
 
                 // Use the url escaped version of a backtick (`) symbol. Mobile platforms do not support lookbehinds,
                 // so capture the first and third group and place them in the replacement.
-                regex: /(\B|_)&#x60;(.*?)&#x60;(\B|_)(?![^<]*<\/pre>)/g,
+                regex: /(\B|_)&#x60;(.*?[^\s])&#x60;(\B|_)(?![^<]*<\/pre>)/g,
                 replacement: '$1<code>$2</code>$3',
             },
 
@@ -126,7 +126,7 @@ export default class ExpensiMark {
                  * `_https://www.test.com_`
                  */
                 name: 'italic',
-                regex: /(?!_blank">)\b_(.*?)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /(?!_blank">)\b_(.*?[^\s])_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<em>$1</em>'
             },
             {
@@ -134,12 +134,12 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*(.*?)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B\*(.*?[^\s])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<strong>$1</strong>'
             },
             {
                 name: 'strikethrough',
-                regex: /\B~(.*?)~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B~(.*?[^\s])~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<del>$1</del>'
             },
             {


### PR DESCRIPTION
@thienlnam will you please review this?

[Explanation of the change or anything fishy that is going on]

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/2846

# Tests
1. What unit/integration tests cover your change? What auto QA tests cover your change?
I have extended the existing tests to cover the Changes.
1. What tests did you perform that validates your changes worked?
Jest test & manual inspection.

# QA
1. What does QA need to do to validate your changes?
 a. Try to parse a message which contains any of the Italic, Strikethrough, bold text.
 b. Only text containing no space after starting or before ending symbol will be parsed and converted to html.
 
1. What areas do they need to test for regressions?
1. Test messages on the E.cash app. If they are rendered as expected or not.
