### PR TITLE
Fix copy icon on multi-level domain emails

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -290,13 +290,15 @@ test('Test markdown style email link with various styles', () => {
         + '_[Expensify](concierge@expensify.com)_ '
         + '*[Expensify](concierge@expensify.com)* '
         + '[Expensify!](no-concierge1@expensify.com) '
-        + '[Expensify?](concierge?@expensify.com) ';
+        + '[Expensify?](concierge?@expensify.com) '
+        + '[Applause](applausetester+qaabecciv@applause.expensifail.com) ';
 
     const resultString = 'Go to <del><a href="mailto:concierge@expensify.com">Expensify</a></del> '
         + '<em><a href="mailto:concierge@expensify.com">Expensify</a></em> '
         + '<strong><a href="mailto:concierge@expensify.com">Expensify</a></strong> '
         + '<a href="mailto:no-concierge1@expensify.com">Expensify!</a> '
-        + '<a href="mailto:concierge?@expensify.com">Expensify?</a> ';
+        + '<a href="mailto:concierge?@expensify.com">Expensify?</a> '
+        + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">Applause</a> ';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -305,12 +307,14 @@ test('Test general email link with various styles', () => {
     const testString = 'Go to concierge@expensify.com '
         + 'no-concierge@expensify.com '
         + 'concierge!@expensify.com '
-        + 'concierge1?@expensify.com ';
+        + 'concierge1?@expensify.com '
+        + 'applausetester+qaabecciv@applause.expensifail.com ';
 
     const resultString = 'Go to <a href="mailto:concierge@expensify.com">concierge@expensify.com</a> '
         + '<a href="mailto:no-concierge@expensify.com">no-concierge@expensify.com</a> '
         + '<a href="mailto:concierge!@expensify.com">concierge!@expensify.com</a> '
-        + '<a href="mailto:concierge1?@expensify.com">concierge1?@expensify.com</a> ';
+        + '<a href="mailto:concierge1?@expensify.com">concierge1?@expensify.com</a> '
+        + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">applausetester+qaabecciv@applause.expensifail.com</a> ';
 
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -58,7 +58,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'email',
-                regex: /\[([\w\\s\\d!?&#;]+)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)\)/gim,
+                regex: /\[([\w\\s\\d!?&#;]+)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,})+)\)/gim,
                 replacement: '<a href="mailto:$2">$1</a>'
             },
 
@@ -91,7 +91,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'autoEmail',
-                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,6})+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
+                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,})+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
                 replacement: '<a href="mailto:$2">$2</a>'
             },
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -58,7 +58,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'email',
-                regex: /\[([\w\\s\\d!?&#;]+)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,})+)\)/gim,
+                regex: /\[([\w\\s\\d!?&#;]+)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]+)+)\)/gim,
                 replacement: '<a href="mailto:$2">$1</a>'
             },
 
@@ -91,7 +91,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'autoEmail',
-                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]{2,})+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
+                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*?)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]+)+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
                 replacement: '<a href="mailto:$2">$2</a>'
             },
 


### PR DESCRIPTION
cc @chiragsalian 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/167534

# Tests
1. Send a concierge message to yourself with a multi-level email domain, e.g. `applausetester+qaabecciv@applause.expensifail.com`
2. Open the chat and verify that the copy icon shows after the email.
<img width="492" alt="Screen Shot 2021-07-07 at 11 04 32 AM" src="https://user-images.githubusercontent.com/22219519/124800655-23078480-df13-11eb-8675-f253ff5523ff.png">


# QA
Tests above.
