### PR TITLE
New Rules added to HTML to markdown parsing [bold, italic, Strikethrough]

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -130,13 +130,13 @@ test('Test inline code blocks with ExpensiMark syntax inside', () => {
 });
 
 test('Test inline code blocks inside ExpensiMark', () => {
-   const testString = '_`test`_'
+    const testString = '_`test`_'
    + '*`test`*'
    + '~`test`~';
-   const resultString = '<em><code>test</code></em>'
+    const resultString = '<em><code>test</code></em>'
    + '<strong><code>test</code></strong>'
    + '<del><code>test</code></del>';
-   expect(parser.replace(testString)).toBe(resultString);
+    expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test code fencing with ExpensiMark syntax inside', () => {
@@ -341,33 +341,6 @@ test('Test markdown and url links with inconsistent starting and closing parens'
         + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ';
 
     expect(parser.replace(testString)).toBe(resultString);
-});
-
-test('Test HTML string with <br/> tags to markdown ', () => {
-    const testString = 'Hello<br/>World,<br/>Welcome<br/>To<br/>Expensify';
-    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
-
-    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
-});
-
-test('Test HTML string with inconsistent <br/> closing tags to markdown ', () => {
-    const testString = 'Hello<br>World,<br/>Welcome<br>To<br/>Expensify';
-    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
-
-    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
-});
-
-test('Test HTML string with seperate closing tags (<br><br/>) to markdown ', () => {
-    const testString = 'Hello<br>World,<br><br/>Welcome<br/>To<br/>Expensify';
-    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
-
-    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
-});
-
-test('Test HTML string with seperate closing tags (<br></br>) to markdown ', () => {
-    const testString = 'Hello<br>World,<br></br>Welcome<br/>To<br/>Expensify';
-    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
-    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test quotes markdown replacement with text matching inside and outside codefence without spaces', () => {

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -57,3 +57,10 @@ test('Test HTML string with seperate closing tags (<br><br/>) to markdown ', () 
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
+
+test('Test HTML string with attributes', () => {
+    const testString = '<em style="color:red;">This is</em> a <button disabled>test</button>. None of <strong data-link=\'bad\'>these strings</strong>.';
+    const resultString = '_This is_ a test. None of *these strings*.';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -1,0 +1,59 @@
+/* eslint-disable max-len */
+import ExpensiMark from '../lib/ExpensiMark';
+
+const parser = new ExpensiMark();
+
+test('Test bold HTML replacement', () => {
+    const boldTestStartString = 'This is a <strong>sentence,</strong> and it has some <strong>punctuation, words, and spaces</strong>. '
+    + '<strong>test</strong> * testing* test*test*test. * testing * *testing * '
+    + 'This is a <b>sentence,</b> and it has some <b>punctuation, words, and spaces</b>. '
+    + '<b>test</b> * testing* test*test*test. * testing * *testing *';
+    const boldTestReplacedString = 'This is a *sentence,* and it has some *punctuation, words, and spaces*. '
+        + '*test* * testing* test*test*test. * testing * *testing * '
+        + 'This is a *sentence,* and it has some *punctuation, words, and spaces*. '
+        + '*test* * testing* test*test*test. * testing * *testing *';
+
+    expect(parser.htmlToMarkdown(boldTestStartString)).toBe(boldTestReplacedString);
+});
+
+test('Test italic HTML replacement', () => {
+    const italicTestStartString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _ '
+    + 'This is a <i>sentence,</i> and it has some <i>punctuation, words, and spaces</i>. <i>test</i> _ testing_ test_test_test. _ test _ _test _';
+    const italicTestReplacedString = 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _ '
+    + 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _';
+    expect(parser.htmlToMarkdown(italicTestStartString)).toBe(italicTestReplacedString);
+});
+
+// Words wrapped in ~ successfully replaced with <del></del>
+test('Test strikethrough HTML replacement', () => {
+    const strikethroughTestStartString = 'This is a <del>sentence,</del> and it has some <del>punctuation, words, and spaces</del>. <del>test</del> ~ testing~ test~test~test. ~ testing ~ ~testing ~';
+    const strikethroughTestReplacedString = 'This is a ~sentence,~ and it has some ~punctuation, words, and spaces~. ~test~ ~ testing~ test~test~test. ~ testing ~ ~testing ~';
+    expect(parser.htmlToMarkdown(strikethroughTestStartString)).toBe(strikethroughTestReplacedString);
+});
+
+test('Test Mixed HTML strings', () => {
+    const rawHTMLTestStartString = '<em>This is</em> a <strong>test</strong>. None of <h1>these strings</h1> should display <del>as</del> <div>HTML</div>.';
+    const rawHTMLTestReplacedString = '_This is_ a *test*. None of these strings should display ~as~ HTML.';
+    expect(parser.htmlToMarkdown(rawHTMLTestStartString)).toBe(rawHTMLTestReplacedString);
+});
+
+test('Test HTML string with <br/> tags to markdown ', () => {
+    const testString = 'Hello<br/>World,<br/>Welcome<br/>To<br/>Expensify';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test HTML string with inconsistent <br/> closing tags to markdown ', () => {
+    const testString = 'Hello<br>World,<br/>Welcome<br>To<br/>Expensify';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test HTML string with seperate closing tags (<br><br/>) to markdown ', () => {
+    const testString = 'Hello<br>World,<br><br/>Welcome<br/>To<br/>Expensify';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -177,6 +177,21 @@ export default class ExpensiMark {
                 regex: /<br\s*[/]?>/gi,
                 replacement: '\n'
             },
+            {
+                name: 'italic',
+                regex: /<(em|i)(?:“[^”]*”|'[^’]*’|[^'”>])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: '_$2_'
+            },
+            {
+                name: 'bold',
+                regex: /<(b|strong)(?:“[^”]*”|'[^’]*’|[^'”>])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: '*$2*'
+            },
+            {
+                name: 'strikethrough',
+                regex: /<(del)(?:“[^”]*”|'[^’]*’|[^'”>])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: '~$2~'
+            },
         ];
     }
 
@@ -288,7 +303,7 @@ export default class ExpensiMark {
             }
             generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
         });
-        return generatedMarkdown;
+        return Str.stripHTML(generatedMarkdown);
     }
 
     /**

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -179,17 +179,17 @@ export default class ExpensiMark {
             },
             {
                 name: 'italic',
-                regex: /<(em|i)(?:“[^”]*”|'[^’]*’|[^'”>])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(em|i)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '_$2_'
             },
             {
                 name: 'bold',
-                regex: /<(b|strong)(?:“[^”]*”|'[^’]*’|[^'”>])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(b|strong)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '*$2*'
             },
             {
                 name: 'strikethrough',
-                regex: /<(del)(?:“[^”]*”|'[^’]*’|[^'”>])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(del)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '~$2~'
             },
         ];


### PR DESCRIPTION
@Jag96 Will you please review this?

[Explanation of the change or anything fishy that is going on]
1. Added more rules to our ExpensiMark HTML to Markdown parser.
2. Created a Separate text file for HTML to Markdown parser.
3. Added a couple of tests.

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/3970

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Covered with Jest Unit tests

1. What tests did you perform that validates your changed worked?
 I used the changes here to E.cash repo to try pasting HTML strings in Composer

# QA
1. What does QA need to do to validate your changes?
 After these changes are merged to E.cash, you can try copy-pasting formatted String to Composer. Otherwise, add more unit Tests and test them.
 
1. What areas do they need to test for regressions?
  Check HTML to markdown parsing of Expensimark
