### PR TITLE
Fix newline parsing in MD to HTML parser

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -38,8 +38,8 @@ test('Test Mixed HTML strings', () => {
 });
 
 test('Test HTML string with <br/> tags to markdown ', () => {
-    const testString = 'Hello<br/>World,<br/>Welcome<br/>To<br/>Expensify';
-    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify';
+    const testString = 'Hello<br/>World,<br/>Welcome<br/>To<br/>\nExpensify<br/>\n\nTwo new lines preceded by br';
+    const resultString = 'Hello\nWorld,\nWelcome\nTo\nExpensify\n\nTwo new lines preceded by br';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -174,7 +174,7 @@ export default class ExpensiMark {
 
                 // Replaces open and closing <br><br/> tags with a single <br/>
                 pre: inputString => inputString.replace('<br></br>', '<br/>').replace('<br><br/>', '<br/>'),
-                regex: /<br\s*[/]?>/gi,
+                regex: /<br\s*[/]?>\n?/gi,
                 replacement: '\n'
             },
             {


### PR DESCRIPTION
@Jag96  will you please review this?

[Explanation of the change or anything fishy that is going on]
If a `br` tag is followed by a newline then we should parse both as single newline. e.g.
` <b>Joe likes to eat <b><br>\n Apple & Doughnut.`


### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/pull/4009#issuecomment-879534328

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
UNit
1. What tests did you perform that validates your changed worked?
Unit

# QA
1. What does QA need to do to validate your changes?
NA
1. What areas to they need to test for regressions?
NA
