### PR TITLE
Fixed lin-break <br> HTML parsing

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -59,8 +59,8 @@ test('Test HTML string with seperate closing tags (<br><br/>) to markdown ', () 
 });
 
 test('Test HTML string with attributes', () => {
-    const testString = '<em style="color:red;">This is</em> a <button disabled>test</button>. None of <strong data-link=\'bad\'>these strings</strong>.';
-    const resultString = '_This is_ a test. None of *these strings*.';
+    const testString = '<em style="color:red;">This is</em><br style="border-color:red;"> a <button disabled>test</button>. None of <strong data-link=\'bad\'>these strings</strong>.';
+    const resultString = '_This is_\n a test. None of *these strings*.';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -174,7 +174,9 @@ export default class ExpensiMark {
 
                 // Replaces open and closing <br><br/> tags with a single <br/>
                 pre: inputString => inputString.replace('<br></br>', '<br/>').replace('<br><br/>', '<br/>'),
-                regex: /<br\s*[/]?>\n?/gi,
+
+                // Include the immediately followed newline as `<br>\n` should be equal to one \n.
+                regex: /<br(?:"[^"]*"|'[^']*'|[^'">])*>(?![^<]*(<\/pre>|<\/code>))\n?/gi,
                 replacement: '\n'
             },
             {


### PR DESCRIPTION
@Jag96  will you please review this?

[Explanation of the change or anything fishy that is going on]

### Fixed Issues
$ https://github.com/Expensify/Expensify.cash/issues/4052

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Unit
1. What tests did you perform that validates your changed worked?
unit

# QA
1. What does QA need to do to validate your changes?
Try to paste a few messages that contains line breaks in E.cash after this is merged.

1. What areas to they need to test for regressions?
E.cash.
