### PR TITLE
Fix: single char match in ExpensiMark

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -374,3 +374,9 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Single char matching', () => {
+    const testString = ' *1* char _1_ char ~1~ char';
+    const resultString = ' <strong>1</strong> char <em>1</em> char <del>1</del> char';
+    expect(parser.replace(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -126,7 +126,7 @@ export default class ExpensiMark {
                  * `_https://www.test.com_`
                  */
                 name: 'italic',
-                regex: /(?!_blank">)\b_([^\s].*?[^\s])_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /(?!_blank">)\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<em>$1</em>'
             },
             {
@@ -134,12 +134,12 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*([^\s].*?[^\s])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<strong>$1</strong>'
             },
             {
                 name: 'strikethrough',
-                regex: /\B~([^\s].*?[^\s])~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B~((?!\s).*?\S)~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<del>$1</del>'
             },
             {


### PR DESCRIPTION
@Jag96 will you please review this?

[Explanation of the change or anything fishy that is going on]

### Fixed Issues
Fixed regression https://github.com/Expensify/Expensify.cash/issues/2846#issuecomment-881660905

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
 Added more Unit test
1. What tests did you perform that validates your changed worked?
 I tested various strings 

# QA
1. What does QA need to do to validate your changes?
 	Send a message with single char in E.cash after this code is merged.
1. What areas do they need to test for regressions?
    E.cash app
