### PR TITLE
Improve Logger class

### DIFF
--- a/__tests__/Logger-test.js
+++ b/__tests__/Logger-test.js
@@ -19,9 +19,17 @@ test('Test Log.info()', () => {
             logPacket: expect.any(String),
         })
     );
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    delete packet[0].timestamp;
+    delete packet[1].timestamp;
+    expect(packet).toEqual([
+        {message: "[info] Test1", parameters: "", },
+        {message: "[info] Test2", parameters: "", },
+    ]);
 });
 
 test('Test Log.alert()', () => {
+    mockServerLoggingCallback.mockClear();
     Log.alert('Test2', {}, false);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith(
@@ -30,9 +38,13 @@ test('Test Log.alert()', () => {
             logPacket: expect.any(String),
         })
     );
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    delete packet[0].timestamp;
+    expect(packet).toEqual([{message: "[alrt] Test2", parameters: {}}]);
 });
 
 test('Test Log.warn()', () => {
+    mockServerLoggingCallback.mockClear();
     Log.warn('Test2');
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith(
@@ -41,10 +53,15 @@ test('Test Log.warn()', () => {
             logPacket: expect.any(String),
         })
     );
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    delete packet[0].timestamp;
+    expect(packet).toEqual([{message: "[warn] Test2", parameters: ''}]);
 });
 
 test('Test Log.hmmm()', () => {
+    mockServerLoggingCallback.mockClear();
     Log.hmmm('Test');
+    Log.info('Test', true);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -52,6 +69,13 @@ test('Test Log.hmmm()', () => {
             logPacket: expect.any(String),
         })
     );
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    delete packet[0].timestamp;
+    delete packet[1].timestamp;
+    expect(packet).toEqual([
+        {message: "[hmmm] Test", parameters: ''},
+        {message: "[info] Test", parameters: ''}
+    ]);
 });
 
 test('Test Log.client()', () => {

--- a/__tests__/Logger-test.js
+++ b/__tests__/Logger-test.js
@@ -14,12 +14,13 @@ test('Test Log.info()', () => {
     Log.info('Test2', true);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.any(Object),
         expect.objectContaining({
             api_setCookie: false,
             logPacket: expect.any(String),
         })
     );
-    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][1].logPacket);
     delete packet[0].timestamp;
     delete packet[1].timestamp;
     expect(packet).toEqual([
@@ -33,12 +34,13 @@ test('Test Log.alert()', () => {
     Log.alert('Test2', {}, false);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.any(Object),
         expect.objectContaining({
             api_setCookie: false,
             logPacket: expect.any(String),
         })
     );
-    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][1].logPacket);
     delete packet[0].timestamp;
     expect(packet).toEqual([{message: "[alrt] Test2", parameters: {}}]);
 });
@@ -48,12 +50,13 @@ test('Test Log.warn()', () => {
     Log.warn('Test2');
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.any(Object),
         expect.objectContaining({
             api_setCookie: false,
             logPacket: expect.any(String),
         })
     );
-    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][1].logPacket);
     delete packet[0].timestamp;
     expect(packet).toEqual([{message: "[warn] Test2", parameters: ''}]);
 });
@@ -64,12 +67,13 @@ test('Test Log.hmmm()', () => {
     Log.info('Test', true);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.any(Object),
         expect.objectContaining({
             api_setCookie: false,
             logPacket: expect.any(String),
         })
     );
-    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][0].logPacket);
+    const packet = JSON.parse(mockServerLoggingCallback.mock.calls[0][1].logPacket);
     delete packet[0].timestamp;
     delete packet[1].timestamp;
     expect(packet).toEqual([

--- a/__tests__/Logger-test.js
+++ b/__tests__/Logger-test.js
@@ -9,42 +9,53 @@ const Log = new Logger({
 });
 
 test('Test Log.info()', () => {
-    Log.info('Test', true);
+    Log.info('Test1', true);
+    Log.info('Test2', true);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        parameters: {},
         api_setCookie: false,
-        message: '[info] Test',
+        logPacket: [
+            {parameters: {}, message: '[info] Test1'},
+            {parameters: {}, message: '[info] Test2'},
+        ],
     });
 });
 
 test('Test Log.alert()', () => {
-    Log.alert('Test', 0, {}, false);
+    Log.alert('Test1', true);
+    Log.alert('Test2', {}, false);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        parameters: {},
         api_setCookie: false,
-        message: '[alrt] Test',
+        logPacket: [
+            {parameters: {}, message: '[alrt] Test1'},
+            {parameters: {}, message: '[alrt] Test2'},
+        ],
     });
 });
 
 test('Test Log.warn()', () => {
-    Log.warn('Test', 0);
+    Log.warn('Test1', true);
+    Log.warn('Test2');
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        parameters: {},
         api_setCookie: false,
-        message: '[warn] Test',
+        logPacket: [
+            {parameters: {}, message: '[warn] Test1'},
+            {parameters: {}, message: '[warn] Test2'},
+        ],
     });
 });
 
 test('Test Log.hmmm()', () => {
-    Log.hmmm('Test', 0);
+    Log.hmmm('Test');
     expect(mockServerLoggingCallback).toHaveBeenCalled();
     expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        parameters: {},
         api_setCookie: false,
-        message: '[hmmm] Test',
+        logPacket: [
+            {parameters: {}, message: '[hmmm] Test1'},
+            {parameters: {}, message: '[hmmm] Test2'},
+        ],
     });
 });
 

--- a/__tests__/Logger-test.js
+++ b/__tests__/Logger-test.js
@@ -9,54 +9,49 @@ const Log = new Logger({
 });
 
 test('Test Log.info()', () => {
-    Log.info('Test1', true);
+    Log.info('Test1', false);
+    expect(mockServerLoggingCallback).toHaveBeenCalledTimes(0);
     Log.info('Test2', true);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
-    expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        api_setCookie: false,
-        logPacket: [
-            {parameters: {}, message: '[info] Test1'},
-            {parameters: {}, message: '[info] Test2'},
-        ],
-    });
+    expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+            api_setCookie: false,
+            logPacket: expect.any(String),
+        })
+    );
 });
 
 test('Test Log.alert()', () => {
-    Log.alert('Test1', true);
     Log.alert('Test2', {}, false);
     expect(mockServerLoggingCallback).toHaveBeenCalled();
-    expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        api_setCookie: false,
-        logPacket: [
-            {parameters: {}, message: '[alrt] Test1'},
-            {parameters: {}, message: '[alrt] Test2'},
-        ],
-    });
+    expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+            api_setCookie: false,
+            logPacket: expect.any(String),
+        })
+    );
 });
 
 test('Test Log.warn()', () => {
-    Log.warn('Test1', true);
     Log.warn('Test2');
     expect(mockServerLoggingCallback).toHaveBeenCalled();
-    expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        api_setCookie: false,
-        logPacket: [
-            {parameters: {}, message: '[warn] Test1'},
-            {parameters: {}, message: '[warn] Test2'},
-        ],
-    });
+    expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+            api_setCookie: false,
+            logPacket: expect.any(String),
+        })
+    );
 });
 
 test('Test Log.hmmm()', () => {
     Log.hmmm('Test');
     expect(mockServerLoggingCallback).toHaveBeenCalled();
-    expect(mockServerLoggingCallback).toHaveBeenCalledWith({
-        api_setCookie: false,
-        logPacket: [
-            {parameters: {}, message: '[hmmm] Test1'},
-            {parameters: {}, message: '[hmmm] Test2'},
-        ],
-    });
+    expect(mockServerLoggingCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+            api_setCookie: false,
+            logPacket: expect.any(String),
+        })
+    );
 });
 
 test('Test Log.client()', () => {

--- a/lib/Log.jsx
+++ b/lib/Log.jsx
@@ -6,12 +6,13 @@ import Logger from './Logger';
 /**
  * Network interface for logger.
  *
+ * @param {Logger} logger
  * @param {Object} params
  * @param {Object} params.parameters
  * @param {String} params.message
  * @return {Promise}
  */
-function serverLoggingCallback(params) {
+function serverLoggingCallback(logger, params) {
     return API(Network('/api.php')).logToServer(params);
 }
 

--- a/lib/Log.jsx
+++ b/lib/Log.jsx
@@ -9,9 +9,10 @@ import Logger from './Logger';
  * @param {Object} params
  * @param {Object} params.parameters
  * @param {String} params.message
+ * @return {Promise}
  */
 function serverLoggingCallback(params) {
-    API(Network('/api.php')).logToServer(params);
+    return API(Network('/api.php')).logToServer(params);
 }
 
 /**

--- a/lib/Logger.jsx
+++ b/lib/Logger.jsx
@@ -82,7 +82,7 @@ export default class Logger {
      * @param {Boolean} sendNow if true, the message will be sent right away.
      * @param {Object|String} parameters The parameters to send along with the message
      */
-    info(message, sendNow, parameters) {
+    info(message, sendNow = false, parameters= '') {
         if (sendNow) {
             const msg = `[info] ${message}`;
             this.logToServer(msg, 0, parameters);
@@ -99,7 +99,7 @@ export default class Logger {
      * @param {Object|String} parameters The parameters to send along with the message
      * @param {Boolean} includeStackTrace Must be disabled for testing
      */
-    alert(message, recentMessages, parameters = {}, includeStackTrace = true) {
+    alert(message, recentMessages = 0, parameters = {}, includeStackTrace = true) {
         const msg = `[alrt] ${message}`;
         const params = parameters;
 
@@ -118,7 +118,7 @@ export default class Logger {
      * @param {Number} recentMessages A number of recent messages to append as context
      * @param {Object|String} parameters The parameters to send along with the message
      */
-    warn(message, recentMessages, parameters) {
+    warn(message, recentMessages = 0, parameters = '') {
         const msg = `[warn] ${message}`;
         this.logToServer(msg, recentMessages, parameters);
         this.add(msg, parameters);
@@ -131,7 +131,7 @@ export default class Logger {
      * @param {Number} recentMessages A number of recent messages to append as context
      * @param {Object|String} parameters The parameters to send along with the message
      */
-    hmmm(message, recentMessages, parameters) {
+    hmmm(message, recentMessages = 0, parameters= '') {
         const msg = `[hmmm] ${message}`;
         this.logToServer(msg, recentMessages, parameters);
         this.add(msg, parameters);

--- a/lib/Logger.jsx
+++ b/lib/Logger.jsx
@@ -23,13 +23,17 @@ export default class Logger {
     * Ask the server to write the log message
     */
     logToServer() {
-        // We do not want to call the server with an empty list or if all the lines has onlyFlushWithOthers=false
-        if (!_.any(this.logLines, l => !l.onlyFlushWithOthers)) {
+        // We do not want to call the server with an empty list or if all the lines has onlyFlushWithOthers=true
+        if (!this.logLines.length || _.all(this.logLines, l => l.onlyFlushWithOthers)) {
             return;
         }
 
         // We don't care about log setting web cookies so let's define it as false
-        const promise = this.serverLoggingCallback({api_setCookie: false, logPacket: JSON.stringify(this.logLines)});
+        const linesToLog = _.map(this.logLines, l => {
+            delete l.onlyFlushWithOthers;
+            return l;
+        });
+        const promise = this.serverLoggingCallback({api_setCookie: false, logPacket: JSON.stringify(linesToLog)});
         this.logLines = [];
         if (!promise) {
             return;

--- a/lib/Logger.jsx
+++ b/lib/Logger.jsx
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-const TEMP_LOG_LINES_TO_KEEP = 50;
+const MAX_LOG_LINES_BEFORE_FLUSH = 50;
 export default class Logger {
     constructor({serverLoggingCallback, isDebug, clientLoggingCallback}) {
         // An array of log lines that limits itself to a certain number of entries (deleting the oldest)
@@ -21,10 +21,6 @@ export default class Logger {
 
     /**
     * Ask the server to write the log message
-    *
-    * @param {String} message The message to write
-    * @param {Number} recentMessages A number of recent messages to append as context
-    * @param {Object|String} parameters The parameters to send along with the message
     */
     logToServer() {
         // Since we will always have the previous requestID log line, we want to skip sending logs if that's the only line
@@ -34,6 +30,7 @@ export default class Logger {
 
         // We don't care about log setting web cookies so let's define it as false
         const promise = this.serverLoggingCallback({api_setCookie: false, logPacket: JSON.stringify(this.logLines)});
+        this.logLines = [];
         if (!promise) {
             return;
         }
@@ -62,9 +59,8 @@ export default class Logger {
         }
 
         // If we're over the limit, flush the logs
-        if (length > TEMP_LOG_LINES_TO_KEEP || forceFlushToServer) {
+        if (length > MAX_LOG_LINES_BEFORE_FLUSH || forceFlushToServer) {
             this.logToServer()
-            this.logLines = [];
         }
     }
 

--- a/lib/Logger.jsx
+++ b/lib/Logger.jsx
@@ -112,7 +112,7 @@ export default class Logger {
      * @param {String} message The message to hmmm.
      * @param {Object|String} parameters The parameters to send along with the message
      */
-    hmmm(message, parameters= '') {
+    hmmm(message, parameters = '') {
         const msg = `[hmmm] ${message}`;
         this.add(msg, parameters, false);
     }

--- a/lib/Logger.jsx
+++ b/lib/Logger.jsx
@@ -27,6 +27,11 @@ export default class Logger {
     * @param {Object|String} parameters The parameters to send along with the message
     */
     logToServer() {
+        // Since we will always have the previous requestID log line, we want to skip sending logs if that's the only line
+        if (this.logLines.length <= 1) {
+            return;
+        }
+
         // We don't care about log setting web cookies so let's define it as false
         const promise = this.serverLoggingCallback({api_setCookie: false, logPacket: JSON.stringify(this.logLines)});
         if (!promise) {

--- a/lib/Logger.jsx
+++ b/lib/Logger.jsx
@@ -34,7 +34,7 @@ export default class Logger {
             return l;
         });
         this.logLines = [];
-        const promise = this.serverLoggingCallback({api_setCookie: false, logPacket: JSON.stringify(linesToLog)});
+        const promise = this.serverLoggingCallback(this, {api_setCookie: false, logPacket: JSON.stringify(linesToLog)});
         if (!promise) {
             return;
         }

--- a/lib/Logger.jsx
+++ b/lib/Logger.jsx
@@ -33,8 +33,8 @@ export default class Logger {
             delete l.onlyFlushWithOthers;
             return l;
         });
-        const promise = this.serverLoggingCallback({api_setCookie: false, logPacket: JSON.stringify(linesToLog)});
         this.logLines = [];
+        const promise = this.serverLoggingCallback({api_setCookie: false, logPacket: JSON.stringify(linesToLog)});
         if (!promise) {
             return;
         }


### PR DESCRIPTION
Alright, please give this a review. You can see it being used in the draft PRs tied to the issue.
I basically revamped how the logging class works, mainly:
- All logs are saved in a queue
- alert, warn and hmmm automatically flush the queue to the server (this is basically unchanged)
- info can chose to flush or not (this is basically unchanged)
- Whenever we flush the queue, we flush it all
- I removed the "extraneous" recentMessages params from alert, warn, hmmm since now they will always flush the entire queue
- Made it so that each queue flush includes the previous queue flush requestID so you can go to the past events of one flush

This is an example of what we log in App (there's 2 requests there to see the previous requestID thingy):
```
2021-07-23T16:53:45.731933+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] Processing 'Log' for 'expensify.com' from '10.2.2.1'  ~~ command: 'Log' api_setCookie: 'false' logPacket: '[{"message":"[info] [NetworkConnection] listenForReconnect called","parameters":"","onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:58.741Z"},{"message":"[info] [NetworkConnection] NetInfo isConnected: true","parameters":"","onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:58.898Z"},{"message":"[info] [NetworkConnection] NetInfo isConnected: true","parameters":"","onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.532Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":[242]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.594Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-1"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.638Z"},{"message":"[info] [PusherConnectionManager] connected event","parameters":"","onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.639Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-user-accountID-2"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.639Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":[44]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.733Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":[42]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.779Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":[102]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.881Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":[50]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.900Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":[143]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.919Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":[21]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:52:59.932Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-1"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:00.069Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-user-accountID-2"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:00.072Z"},{"message":"[info] [Report] successfully fetched report data","parameters":{"chatList":["1","2","78","79","80","109","110","114","117","118","120"]},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:00.073Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:23.671Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:25.320Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:26.023Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/118"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:28.687Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-118"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:29.519Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-118"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:31.422Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/118"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:32.350Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/126"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:32.860Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-126"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:33.201Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-126"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:33.587Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/117"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:33.770Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-117"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:33.977Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/120"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:34.245Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-117"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:34.405Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-120"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:34.471Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-120"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:34.752Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:35.896Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:36.106Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:36.323Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/1"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:36.540Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-1"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:36.745Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-1"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:36.977Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:41.242Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:41.459Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-report-reportID-114"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:41.654Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/117"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:42.377Z"},{"message":"[info] Navigating to route","parameters":{"route":"r\/126"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:43.819Z"},{"message":"[info] [PusherConnectionManager] Attempting to authorize Pusher","parameters":{"channelName":"private-report-reportID-126"},"onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:53:44.032Z"},{"message":"[info] [PusherConnectionManager] Pusher authenticated successfully","parameters":{"channelName":"private-re
2021-07-23T16:53:45.732227+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [dbug] _send( expensidev2004.web.api.command.Log:1|c )
2021-07-23T16:53:45.733686+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [NetworkConnection] listenForReconnect called ~~ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.734544+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [NetworkConnection] NetInfo isConnected: true ~~ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.735178+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [NetworkConnection] NetInfo isConnected: true ~~ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736109+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '242']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736256+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-1' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736429+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] connected event ~~ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736506+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-user-accountID-2' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736551+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '44']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736774+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '42']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736867+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '102']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.736966+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '50']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737035+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '143']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737145+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '21']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737205+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-1' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737259+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-user-accountID-2' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737340+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [Report] successfully fetched report data ~~ chatList: '[0: '1' 1: '2' 2: '78' 3: '79' 4: '80' 5: '109' 6: '110' 7: '114' 8: '117' 9: '118' 10: '120']' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737407+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737553+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.737607+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.738100+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/118' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.738388+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-118' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.738925+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-118' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.739099+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/118' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.739380+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/126' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.739949+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-126' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.740051+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-126' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.740113+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/117' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.740153+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-117' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.740199+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/120' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.740243+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-117' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.740757+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-120' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.740888+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-120' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.741191+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.743286+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.743446+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.744656+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/1' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.745197+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-1' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.746073+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-1' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.747482+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.747882+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.748042+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-114' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.749278+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/117' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.749690+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Navigating to route ~~ route: 'r/126' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.749813+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Attempting to authorize Pusher ~~ channelName: 'private-report-reportID-126' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.750048+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] [PusherConnectionManager] Pusher authenticated successfully ~~ channelName: 'private-report-reportID-126' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.750265+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Flushing logs as app is going inactive ~~ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.750471+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info]  ~~ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:53:45.750577+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] StoreUtils - Clearing all the stores.
2021-07-23T16:53:45.750846+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] TransactionStore cache fully cleared
2021-07-23T16:53:45.750947+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] ReportStore cache cleared
2021-07-23T16:53:45.751137+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] NVPStore - clear cache
2021-07-23T16:53:45.751494+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] NVPStore - clear cache
2021-07-23T16:53:45.751955+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] SharedInNVPStore - clear cache
2021-07-23T16:53:45.752206+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] ReportDuplicatedTransactionsStore - Cache cleared
2021-07-23T16:53:45.752403+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [dbug] _send( expensidev2004.web.api.result.success.200:1|c )
2021-07-23T16:53:45.752456+00:00 expensidev2004 php-fpm: Xdebug: [Step Debug] Could not connect to debugging client. Tried: 10.0.2.2:9000 (through xdebug.client_host/xdebug.client_port) :-(
2021-07-23T16:53:45.752611+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] Profile ~~ {"total":22,"cmd":"Log","jsonCode":200,"output":{"size":57,"gzip":1,"ratio":154},"gzip":57,"PHP":{"total":21,"%":95,"boot":8,"proc":13,"pack":0,"mem":2}}
2021-07-23T16:53:45.752805+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [info] Timing: cmd= Log totalTime= 22 authTotalTime=  authRunTime= 0
2021-07-23T16:53:45.752986+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [dbug] _send( expensidev2004.web.api.Log:22|ms )
2021-07-23T16:53:45.753039+00:00 expensidev2004 php-fpm: nMxTXg /api.php ionatan@expensify.com !ecash! ?api? [dbug] _send( global.web.api.Log:22|ms )
2021-07-23T16:53:45.753173+00:00 expensidev2004 php-fpm: Xdebug: [Step Debug] Could not connect to debugging client. Tried: 10.0.2.2:9000 (through xdebug.client_host/xdebug.client_port) :-(
2021-07-23T16:53:45.753335+00:00 expensidev2004 nginx: remote_addr=10.2.2.1 host=www.expensify.com.dev remote_user=- [23/Jul/2021:16:53:45 +0000] request_method=POST request=/api?<stripped> server_protocol=HTTP/2.0 http_status=200 body_bytes_sent=57 http_user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36" upstream_status=200 request_time=0.060 upstream_response_time=0.060 upstream_connect_time=0.000 upstream_header_time=0.060
2021-07-23T16:53:47.463176+00:00 expensidev2004 bedrock: xxxxxx (SQLiteNode.cpp:555) update [sync] [info] {auth/LEADING} [performance] Network stats: 10017 ms elapsed.
2021-07-23T16:53:48.478508+00:00 expensidev2004 bedrock: xxxxxx (main.cpp:380) main [main] [info] [performance] main poll loop timing: 10528 ms elapsed. 10481 ms in poll. 45 ms in postPoll.
2021-07-23T16:53:51.478662+00:00 expensidev2004 bedrock: xxxxxx (main.cpp:380) main [main] [info] [performance] main poll loop timing: 10031 ms elapsed. 10030 ms in poll. 1 ms in postPoll.
2021-07-23T16:53:53.475563+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread poll): 10025/10028 ms timed, 99.97%
2021-07-23T16:53:53.476121+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (STCPNode::append): 0/10028 ms timed, 0.00%
2021-07-23T16:53:54.480186+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread poll): 10029/10031 ms timed, 99.98%
2021-07-23T16:53:54.480418+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (STCPNode::append): 0/10031 ms timed, 0.00%
2021-07-23T16:53:54.480533+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread PostPoll): 1/10032 ms timed, 0.01%
2021-07-23T16:53:54.480620+00:00 expensidev2004 bedrock: xxxxxx (SQLiteNode.cpp:555) update [sync] [info] {bedrock/LEADING} [performance] Network stats: 10032 ms elapsed.
2021-07-23T16:53:54.480738+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread escalate loop): 0/10032 ms timed, 0.00%
2021-07-23T16:53:55.497010+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread PostPoll): 0/10035 ms timed, 0.00%
2021-07-23T16:53:55.497160+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread escalate loop): 0/10035 ms timed, 0.00%
2021-07-23T16:53:57.497835+00:00 expensidev2004 bedrock: xxxxxx (SQLiteNode.cpp:555) update [sync] [info] {auth/LEADING} [performance] Network stats: 10035 ms elapsed.
2021-07-23T16:53:58.644569+00:00 expensidev2004 bedrock: xxxxxx (main.cpp:380) main [main] [info] [performance] main poll loop timing: 10165 ms elapsed. 10163 ms in poll. 2 ms in postPoll.
2021-07-23T16:54:01.503135+00:00 expensidev2004 bedrock: xxxxxx (main.cpp:380) main [main] [info] [performance] main poll loop timing: 10024 ms elapsed. 10023 ms in poll. 1 ms in postPoll.
2021-07-23T16:54:03.504259+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread poll): 10026/10029 ms timed, 99.97%
2021-07-23T16:54:03.504498+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (STCPNode::append): 0/10028 ms timed, 0.00%
2021-07-23T16:54:04.505888+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread poll): 10023/10026 ms timed, 99.97%
2021-07-23T16:54:04.506669+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (STCPNode::append): 0/10026 ms timed, 0.00%
2021-07-23T16:54:04.506772+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread PostPoll): 1/10026 ms timed, 0.01%
2021-07-23T16:54:04.506829+00:00 expensidev2004 bedrock: xxxxxx (SQLiteNode.cpp:555) update [sync] [info] {bedrock/LEADING} [performance] Network stats: 10026 ms elapsed.
2021-07-23T16:54:04.506883+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread escalate loop): 0/10026 ms timed, 0.00%
2021-07-23T16:54:05.507420+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread PostPoll): 1/10010 ms timed, 0.01%
2021-07-23T16:54:05.507661+00:00 expensidev2004 bedrock: xxxxxx (STCPNode.h:24) stop [sync] [info] [performance] AutoTimer (sync thread escalate loop): 0/10010 ms timed, 0.00%
2021-07-23T16:54:07.514086+00:00 expensidev2004 bedrock: xxxxxx (SQLiteNode.cpp:555) update [sync] [info] {auth/LEADING} [performance] Network stats: 10016 ms elapsed.
2021-07-23T16:54:08.673926+00:00 expensidev2004 bedrock: xxxxxx (main.cpp:380) main [main] [info] [performance] main poll loop timing: 10028 ms elapsed. 10023 ms in poll. 5 ms in postPoll.
2021-07-23T16:54:11.520372+00:00 expensidev2004 bedrock: xxxxxx (main.cpp:380) main [main] [info] [performance] main poll loop timing: 10017 ms elapsed. 10016 ms in poll. 0 ms in postPoll.
2021-07-23T16:54:12.665209+00:00 expensidev2004 php-fpm: Xdebug: [Step Debug] Could not connect to debugging client. Tried: 10.0.2.2:9000 (through xdebug.client_host/xdebug.client_port) :-(
2021-07-23T16:54:12.709009+00:00 expensidev2004 php-fpm: BBQdxV /api.php ionatan@expensify.com !ecash! ?api? [info] ACHTUNG debug mode is ON
2021-07-23T16:54:12.712159+00:00 expensidev2004 php-fpm: BBQdxV /api.php ionatan@expensify.com !ecash! ?api? [info] PID ~~ 114118
2021-07-23T16:54:12.713507+00:00 expensidev2004 php-fpm: BBQdxV /api.php ionatan@expensify.com !ecash! ?api? [dbug] [10.2.2.1->/api.php] Unexpected REQUEST 'forceNetworkRequest' => 'true'
2021-07-23T16:54:12.714938+00:00 expensidev2004 php-fpm: Xdebug: [Step Debug] Could not connect to debugging client. Tried: 10.0.2.2:9000 (through xdebug.client_host/xdebug.client_port) :-(
2021-07-23T16:54:12.716384+00:00 expensidev2004 php-fpm: BBQdxV /api.php ionatan@expensify.com !ecash! ?api? [info] Processing 'Log' for 'expensify.com' from '10.2.2.1'  ~~ command: 'Log' api_setCookie: 'false' logPacket: '[{"message":"[info] Previous log requestID","parameters":{"requestID":"nMxTXg"},"onlyFlushWithOthers":true,"timestamp":"2021-07-23T16:53:45.618Z"},{"message":"[info] Caca for testing!","parameters":"","onlyFlushWithOthers":false,"timestamp":"2021-07-23T16:54:12.525Z"}]' expensifyCashAppVersion: 'expensifyCash[web]1.0.79-3' email: 'ionatan@expensify.com' referer: 'ecash' browserGUID: '60faf434ae9cd' partnerName: 'expensify.com'
2021-07-23T16:54:12.716991+00:00 expensidev2004 php-fpm: BBQdxV /api.php ionatan@expensify.com !ecash! ?api? [dbug] _send( expensidev2004.web.api.command.Log:1|c )
2021-07-23T16:54:12.717400+00:00 expensidev2004 php-fpm: BBQdxV /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Previous log requestID ~~ requestID: 'nMxTXg' userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
2021-07-23T16:54:12.717644+00:00 expensidev2004 php-fpm: BBQdxV /api.php ionatan@expensify.com !ecash! ?api? [info] [info] Caca for testing! ~~ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.164 Safari/537.36'
```

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/171640

# Tests
1. See other PRs

# QA
1. No