### PR TITLE
Quote support for HTML => MD Conversion 

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -114,3 +114,13 @@ test('Test HTML string with encoded entities', () => {
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
+
+
+test('Test HTML string with blockquote', () => {
+    const testString = '<blockquote><p>This GH seems to assume that there will be something in the paste\nbuffer when you copy block-quoted text out of slack. But when I dump\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\nbuffer, then dump it into terminal, there\'s nothing. And if I dump it </blockquote>'
+    + '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>';
+    const resultString = '\n> This GH seems to assume that there will be something in the paste\n> buffer when you copy block-quoted text out of slack. But when I dump\n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> buffer, then dump it into terminal, there\'s nothing. And if I dump it\n'
+    + '\n> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -118,9 +118,12 @@ test('Test HTML string with encoded entities', () => {
 
 test('Test HTML string with blockquote', () => {
     const testString = '<blockquote><p>This GH seems to assume that there will be something in the paste\nbuffer when you copy block-quoted text out of slack. But when I dump\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\nbuffer, then dump it into terminal, there\'s nothing. And if I dump it </blockquote>'
-    + '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>';
+    + '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>'
+    + '<blockquote style="color:red;" data-label="note">line1 <em>lorem ipsum</em></blockquote>';
+
     const resultString = '\n> This GH seems to assume that there will be something in the paste\n> buffer when you copy block-quoted text out of slack. But when I dump\n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> buffer, then dump it into terminal, there\'s nothing. And if I dump it\n'
-    + '\n> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n';
+    + '\n> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n'
+    + '\n> line1 _lorem ipsum_\n';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -214,6 +214,14 @@ export default class ExpensiMark {
                 regex: /<(del)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '~$2~'
             },
+            {
+                name: 'quote',
+                regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: (match, g1, g2) => {
+                    const resultString = g2.trim().split('\n').map(m => `> ${m}`).join('\n');
+                    return `\n${resultString}\n`;
+                }
+            },
         ];
     }
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -218,7 +218,7 @@ export default class ExpensiMark {
                 name: 'quote',
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
-                    const resultString = g2.trim().split('\n').map(m => `> ${m || ''}`).join('\n');
+                    const resultString = g2.trim().split('\n').map(m => `> ${m}`).join('\n');
                     return `\n${resultString}\n`;
                 }
             },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -218,7 +218,7 @@ export default class ExpensiMark {
                 name: 'quote',
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
-                    const resultString = g2.trim().split('\n').map(m => `> ${m}`).join('\n');
+                    const resultString = g2.trim().split('\n').map(m => `> ${m || ''}`).join('\n');
                     return `\n${resultString}\n`;
                 }
             },


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

[Explanation of the change or anything fishy that is going on]
Added support for HTML quote parsing in HTML to MD conversion.
1. It first grabs the whole string between `<blockquote>` tags.
2. we divide each new line in the text with `> line text`
3. if line Text is `\n` we skip this char to remove the extra line and conversion would be `> `.

 
### Fixed Issues
$ https://github.com/Expensify/App/issues/4188

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
   I have added Unit tests that cover cases where Quotes can also contain other HTML tags or newlines.

1. What tests did you perform that validates your changes worked?
    I used a couple of quoted texts and paste them into the Composer in the E.cash to test my solution. 

# QA
1. What does QA need to do to validate your changes?
  Try to paste copied quotes from other websites to the E.cash.

1. What areas do they need to test for regressions?
   Messaging on E.cash.
