### PR TITLE
inlineCodeBlock html -> markdown

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -127,3 +127,11 @@ test('Test HTML string with blockquote', () => {
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
+
+test('Test HTML string with InlineCodeBlock', () => {
+    const testString = 'This is a <code>InlineCodeBlock</code> text';
+
+    const resultString = 'This is a `InlineCodeBlock` text';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -222,6 +222,11 @@ export default class ExpensiMark {
                     return `\n${resultString}\n`;
                 }
             },
+            {
+                name: 'inlineCodeBlock',
+                regex: /<(code)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: '`$2`'
+            },
         ];
     }
 


### PR DESCRIPTION
@AndrewGable will you please review this?

Creation of html -> markdown conversion of inlineCodeBlock

### Fixed Issues
[#4185](https://github.com/Expensify/App/issues/4185)

# Tests

https://user-images.githubusercontent.com/56851391/127571638-4ae748f9-3947-4a00-a6f8-988f7de4d5ae.mp4

Unit test were added to [__tests__/ExpensiMark-Markdown-test.js](https://github.com/Expensify/expensify-common/blob/master/__tests__/ExpensiMark-Markdown-test.js)

# QA
1. Enter a message with inline code block
2. Try to edit it
3. Verify it will keep the inline code block markdown
