### PR TITLE
Code fence HTML to markdown conversion

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -140,4 +140,8 @@ test('Test HTML string with code fence', () => {
     const testString = '<pre id="code1">class Expensify extends PureComponent {\n    constructor(props) {\n        super(props);\n    }\n}</pre>';
     const resultString = '```\nclass Expensify extends PureComponent {\n    constructor(props) {\n        super(props);\n    }\n}\n```';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+
+    const testStringWithBrTag = '<pre id="code1">class Expensify extends PureComponent {<br />    constructor(props) {<br />        super(props);<br />    }<br />}</pre>';
+    const resultStringForBrTag = '```\nclass Expensify extends PureComponent {\n    constructor(props) {\n        super(props);\n    }\n}\n```';
+    expect(parser.htmlToMarkdown(testStringWithBrTag)).toBe(resultStringForBrTag);
 });

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -144,4 +144,11 @@ test('Test HTML string with code fence', () => {
     const testStringWithBrTag = '<pre id="code1">class Expensify extends PureComponent {<br />    constructor(props) {<br />        super(props);<br />    }<br />}</pre>';
     const resultStringForBrTag = '```\nclass Expensify extends PureComponent {\n    constructor(props) {\n        super(props);\n    }\n}\n```';
     expect(parser.htmlToMarkdown(testStringWithBrTag)).toBe(resultStringForBrTag);
+
+    const testStringWithNewLinesFromSlack = '<pre class="c-mrkdwn__pre" data-stringify-type="pre" >line1'
+    + '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;">'
+    + '</span>line3<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>'
+    + '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>line6</pre>';
+    const resultStringWithNewLinesFromSlack = '```\nline1\n\nline3\n\n\nline6\n```';
+    expect(parser.htmlToMarkdown(testStringWithNewLinesFromSlack)).toBe(resultStringWithNewLinesFromSlack);
 });

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -135,3 +135,9 @@ test('Test HTML string with InlineCodeBlock', () => {
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
+
+test('Test HTML string with code fence', () => {
+    const testString = '<pre id="code1">class Expensify extends PureComponent {\n    constructor(props) {\n        super(props);\n    }\n}</pre>';
+    const resultString = '```\nclass Expensify extends PureComponent {\n    constructor(props) {\n        super(props);\n    }\n}\n```';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -196,7 +196,7 @@ export default class ExpensiMark {
                 pre: inputString => inputString.replace('<br></br>', '<br/>').replace('<br><br/>', '<br/>'),
 
                 // Include the immediately followed newline as `<br>\n` should be equal to one \n.
-                regex: /<br(?:"[^"]*"|'[^']*'|[^'"><])*>(?![^<]*(<\/pre>|<\/code>))\n?/gi,
+                regex: /<br(?:"[^"]*"|'[^']*'|[^'"><])*>\n?/gi,
                 replacement: '\n'
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -227,6 +227,11 @@ export default class ExpensiMark {
                 regex: /<(code)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '`$2`'
             },
+            {
+                name: 'codeFence',
+                regex: /<(pre)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: '```\n$2\n```'
+            },
         ];
     }
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -8,6 +8,7 @@ const URL_PATH_REGEX = `(?:\\/${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEsca
 const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_]')}+)?`;
 const URL_FRAGMENT_REGEX = `(?:#${addEscapedChar('[-\\w$@.+!*()[\\],=%;\\/:~]')}*)?`;
 const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
+const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
 export default class ExpensiMark {
     constructor() {
@@ -193,7 +194,9 @@ export default class ExpensiMark {
                 name: 'newline',
 
                 // Replaces open and closing <br><br/> tags with a single <br/>
-                pre: inputString => inputString.replace('<br></br>', '<br/>').replace('<br><br/>', '<br/>'),
+                // Slack uses special <span> tag for empty lines instead of <br> tag
+                pre: inputString => inputString.replace('<br></br>', '<br/>').replace('<br><br/>', '<br/>')
+                    .replace(SLACK_SPAN_NEW_LINE_TAG + SLACK_SPAN_NEW_LINE_TAG, '<br/><br/><br/>').replace(SLACK_SPAN_NEW_LINE_TAG, '<br/><br/>'),
 
                 // Include the immediately followed newline as `<br>\n` should be equal to one \n.
                 regex: /<br(?:"[^"]*"|'[^']*'|[^'"><])*>\n?/gi,


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

Added regex rule for code fence HTML to markdown conversion.

### Fixed Issues
$ https://github.com/Expensify/App/issues/4184

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
I added unit test for this regex rule.
1. What tests did you perform that validates your changed worked?
I run E.cash with updated Expensify-common package from this PR.
Copy/pasted sample code pieces from Slack to E.cash.
Used edit feature on E.cash to make sure code fences are converted to markdown properly.


https://user-images.githubusercontent.com/3853003/127780267-88f46d9d-0389-45d9-9d9d-d81bcfab8bf0.mov



# QA
1. What does QA need to do to validate your changes?
Copy/paste code blocks from Slack to E.cash
Edit code block messages and save again.
Make sure there is no change after edit.
1. What areas to they need to test for regressions?
Make sure other HTML markdown changes are not broken
