### PR TITLE
Links support to HTML => MD conversion

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -118,12 +118,12 @@ test('Test HTML string with encoded entities', () => {
 
 test('Test HTML string with blockquote', () => {
     const testString = '<blockquote><p>This GH seems to assume that there will be something in the paste\nbuffer when you copy block-quoted text out of slack. But when I dump\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\nbuffer, then dump it into terminal, there\'s nothing. And if I dump it </blockquote>'
-    + '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>'
-    + '<blockquote style="color:red;" data-label="note">line1 <em>lorem ipsum</em></blockquote>';
+        + '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>'
+        + '<blockquote style="color:red;" data-label="note">line1 <em>lorem ipsum</em></blockquote>';
 
     const resultString = '\n> This GH seems to assume that there will be something in the paste\n> buffer when you copy block-quoted text out of slack. But when I dump\n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> buffer, then dump it into terminal, there\'s nothing. And if I dump it\n'
-    + '\n> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n'
-    + '\n> line1 _lorem ipsum_\n';
+        + '\n> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n'
+        + '\n> line1 _lorem ipsum_\n';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
@@ -134,4 +134,195 @@ test('Test HTML string with InlineCodeBlock', () => {
     const resultString = 'This is a `InlineCodeBlock` text';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test wrapped anchor tags', () => {
+    const wrappedUrlTestStartString = '<del><a href="https://www.example.com" target="_blank">https://www.example.com</a></del> <em><a href="http://www.test.com" target="_blank">http://www.test.com</a></em>'
+        + ' <strong><a href="http://www.asdf.com/_test" target="_blank">http://www.asdf.com/_test</a></strong>';
+    const wrappedUrlTestReplacedString = '~https://www.example.com~ _http://www.test.com_ *http://www.asdf.com/_test*';
+    expect(parser.htmlToMarkdown(wrappedUrlTestStartString)).toBe(wrappedUrlTestReplacedString);
+});
+
+test('Test acnchor tags convesion to markdown style link with various styles', () => {
+    const testString = 'Go to <del><a href="https://www.expensify.com" target="_blank">Expensify</a></del> '
+        + '<em><a href="https://www.expensify.com" target="_blank">Expensify</a></em> '
+        + '<strong><a href="https://www.expensify.com" target="_blank">Expensify</a></strong> '
+        + '<a href="https://www.expensify.com" target="_blank">Expensify!</a> '
+        + '<a href="https://www.expensify.com" target="_blank">Expensify?</a> '
+        + '<a href="https://www.expensify-test.com" target="_blank">Expensify</a> '
+        + '<a href="https://www.expensify.com/settings?param={%22section%22:%22account%22}" target="_blank">Expensify</a> '
+        + '<a href="https://www.expensify.com/settings?param=(%22section%22+%22account%22)" target="_blank">Expensify</a> '
+        + '<a href="https://www.expensify.com/settings?param=[%22section%22:%22account%22]" target="_blank">Expensify</a>';
+
+    const resultString = 'Go to ~[Expensify](https://www.expensify.com)~ '
+        + '_[Expensify](https://www.expensify.com)_ '
+        + '*[Expensify](https://www.expensify.com)* '
+        + '[Expensify!](https://www.expensify.com) '
+        + '[Expensify?](https://www.expensify.com) '
+        + '[Expensify](https://www.expensify-test.com) '
+        + '[Expensify](https://www.expensify.com/settings?param={%22section%22:%22account%22}) '
+        + '[Expensify](https://www.expensify.com/settings?param=(%22section%22+%22account%22)) '
+        + '[Expensify](https://www.expensify.com/settings?param=[%22section%22:%22account%22])';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags where links end in a comma', () => {
+    const testString = '<a href="https://github.com/Expensify/Expensify/issues/143231" target="_blank">https://github.com/Expensify/Expensify/issues/143231</a>,';
+    const resultString = 'https://github.com/Expensify/Expensify/issues/143231,';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags where links have a period at the end', () => {
+    const testString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/645</a>.';
+    const resultString = 'https://github.com/Expensify/ReactNativeChat/pull/645.';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags where links ending with a question mark', () => {
+    const testString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/645</a>?';
+    const resultString = 'https://github.com/Expensify/ReactNativeChat/pull/645?';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags where links ending with a closing parentheses', () => {
+    const testString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/645</a>)';
+    const resultString = 'https://github.com/Expensify/ReactNativeChat/pull/645)';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags where links are markdown style email link with various styles', () => {
+    const testString = 'Go to <del><a href="mailto:concierge@expensify.com">Expensify</a></del> '
+        + '<em><a href="mailto:concierge@expensify.com">Expensify</a></em> '
+        + '<strong><a href="mailto:concierge@expensify.com">Expensify</a></strong> '
+        + '<a href="mailto:no-concierge1@expensify.com">Expensify!</a> '
+        + '<a href="mailto:concierge?@expensify.com">Expensify?</a> '
+        + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">Applause</a> ';
+
+    const resultString = 'Go to ~[Expensify](concierge@expensify.com)~ '
+        + '_[Expensify](concierge@expensify.com)_ '
+        + '*[Expensify](concierge@expensify.com)* '
+        + '[Expensify!](no-concierge1@expensify.com) '
+        + '[Expensify?](concierge?@expensify.com) '
+        + '[Applause](applausetester+qaabecciv@applause.expensifail.com) ';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags with general email link', () => {
+    const testString = 'Go to <a href="mailto:concierge@expensify.com">concierge@expensify.com</a> '
+        + '<a href="mailto:no-concierge@expensify.com">no-concierge@expensify.com</a> '
+        + '<a href="mailto:concierge!@expensify.com">concierge!@expensify.com</a> '
+        + '<a href="mailto:concierge1?@expensify.com">concierge1?@expensify.com</a> '
+        + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">applausetester+qaabecciv@applause.expensifail.com</a> ';
+    const resultString = 'Go to concierge@expensify.com '
+        + 'no-concierge@expensify.com '
+        + 'concierge!@expensify.com '
+        + 'concierge1?@expensify.com '
+        + 'applausetester+qaabecciv@applause.expensifail.com ';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags where links have inconsistent starting and closing parens', () => {
+    const testString = '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
+        + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) '
+        + '(<a href="https://google.com/" target="_blank">google</a>) '
+        + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>))) '
+        + '(((<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
+        + '(<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>) '
+        + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> '
+        + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
+        + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
+        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat)</a> '
+        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click here to see a cool cat)</a> '
+        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat</a> '
+        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click * $ &amp; here to see a cool cat</a> ';
+
+    const resultString = '[google](http://google.com/(something)?after=parens) '
+        + '([google](http://google.com/(something)?after=parens)) '
+        + '([google](https://google.com/)) '
+        + '([google](http://google.com/(something)?after=parens)))) '
+        + '((([google](http://google.com/(something)?after=parens) '
+        + '(http://foo.com/(something)?after=parens) '
+        + '(((http://foo.com/(something)?after=parens '
+        + '(((http://foo.com/(something)?after=parens))) '
+        + 'http://foo.com/(something)?after=parens))) '
+        + '[Yo (click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
+        + '[Yo click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
+        + '[Yo (click here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
+        + '[Yo click * $ & here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) ';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test anchor tags replacements', () => {
+    const urlTestStartString = 'Testing '
+        + '<a href="http://foo.com" target="_blank">foo.com</a> \n'
+        + '<a href="http://www.foo.com" target="_blank">www.foo.com</a> \n'
+        + '<a href="http://www.foo.com" target="_blank">http://www.foo.com</a> \n'
+        + '<a href="http://foo.com/blah_blah" target="_blank">http://foo.com/blah_blah</a> \n'
+        + '<a href="http://foo.com/blah_blah/" target="_blank">http://foo.com/blah_blah/</a> \n'
+        + '<a href="http://foo.com/blah_blah_(wikipedia)" target="_blank">http://foo.com/blah_blah_(wikipedia)</a> \n'
+        + '<a href="http://www.example.com/wpstyle/?p=364" target="_blank">http://www.example.com/wpstyle/?p=364</a> \n'
+        + '<a href="https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux" target="_blank">https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux</a> \n'
+        + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> \n'
+        + '<a href="http://code.google.com/events/#&amp;product=browser" target="_blank">http://code.google.com/events/#&amp;product=browser</a> \n'
+        + '<a href="http://foo.bar/?q=Test%20URL-encoded%20stuff" target="_blank">http://foo.bar/?q=Test%20URL-encoded%20stuff</a> \n'
+        + '<a href="http://www.test.com/path?param=123#123" target="_blank">http://www.test.com/path?param=123#123</a> \n'
+        + '<a href="http://1337.net" target="_blank">http://1337.net</a> \n'
+        + '<a href="http://a.b-c.de/" target="_blank">http://a.b-c.de/</a> \n'
+        + '<a href="https://sd1.sd2.docs.google.com/" target="_blank">https://sd1.sd2.docs.google.com/</a> \n'
+        + '<a href="https://expensify.cash/#/r/1234" target="_blank">https://expensify.cash/#/r/1234</a> \n'
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/6.45" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/6.45</a> \n'
+        + '<a href="https://github.com/Expensify/Expensify/issues/143,231" target="_blank">https://github.com/Expensify/Expensify/issues/143,231</a> \n'
+        + '<a href="http://testRareTLDs.beer" target="_blank">testRareTLDs.beer</a> \n'
+        + '<a href="mailto:test@expensify.com">test@expensify.com</a> \n'
+        + 'test.completelyFakeTLD \n'
+        + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878</a>) \n'
+        + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled</a> \n'
+        + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> \n'
+        + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> \n'
+        + 'mm..food \n'
+        + '<a href="http://upwork.com/jobs/~016781e062ce860b84" target="_blank">upwork.com/jobs/~016781e062ce860b84</a> \n'
+        + '<a href="https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))" target="_blank">https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))</a> \n'
+        + '<a href="http://google.com/maps/place/The+Flying&#x27;+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121" target="_blank">google.com/maps/place/The+Flying&#x27;+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121</a> \n'
+        + '<a href="http://google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843" target="_blank">google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843</a> \n'
+        + '<a href="https://www.google.com/maps/place/Taj+Mahal+@is~&quot;Awesome&quot;/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422" target="_blank">https://www.google.com/maps/place/Taj+Mahal+@is~&quot;Awesome&quot;/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422</a>';
+
+    const urlTestReplacedString = 'Testing '
+        + '[foo.com](http://foo.com) \n'
+        + '[www.foo.com](http://www.foo.com) \n'
+        + 'http://www.foo.com \n'
+        + 'http://foo.com/blah_blah \n'
+        + 'http://foo.com/blah_blah/ \n'
+        + 'http://foo.com/blah_blah_(wikipedia) \n'
+        + 'http://www.example.com/wpstyle/?p=364 \n'
+        + 'https://www.example.com/foo/?bar=baz&inga=42&quux \n'
+        + 'http://foo.com/(something)?after=parens \n'
+        + 'http://code.google.com/events/#&product=browser \n'
+        + 'http://foo.bar/?q=Test%20URL-encoded%20stuff \n'
+        + 'http://www.test.com/path?param=123#123 \n'
+        + 'http://1337.net \n'
+        + 'http://a.b-c.de/ \n'
+        + 'https://sd1.sd2.docs.google.com/ \n'
+        + 'https://expensify.cash/#/r/1234 \n'
+        + 'https://github.com/Expensify/ReactNativeChat/pull/6.45 \n'
+        + 'https://github.com/Expensify/Expensify/issues/143,231 \n'
+        + '[testRareTLDs.beer](http://testRareTLDs.beer) \n'
+        + 'test@expensify.com \n'
+        + 'test.completelyFakeTLD \n'
+        + 'https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878) \n'
+        + 'http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled \n'
+        + 'https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash \n'
+        + 'https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash \n'
+        + 'mm..food \n'
+        + '[upwork.com/jobs/~016781e062ce860b84](http://upwork.com/jobs/~016781e062ce860b84) \n'
+        + 'https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:\'2125cbe0-28a9-11e9-a79c-3de0157ed580\',interval:auto,query:(language:lucene,query:\'\'),sort:!(timestamp,desc)) \n'
+
+        + '[google.com/maps/place/The+Flying\'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121](http://google.com/maps/place/The+Flying\'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121) \n'
+
+        + '[google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843](http://google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843) \n'
+        + 'https://www.google.com/maps/place/Taj+Mahal+@is~"Awesome"/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422';
+
+    expect(parser.htmlToMarkdown(urlTestStartString)).toBe(urlTestReplacedString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -227,6 +227,17 @@ export default class ExpensiMark {
                 regex: /<(code)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '`$2`'
             },
+            {
+                name: 'anchor',
+                regex: /<(a)[^><]*href\s*=\s*(['"])(.*?)\2(?:".*?"|'.*?'|[^'"><])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: (match, g1, g2, g3, g4) => {
+                    const link = g3.startsWith('mailto:') ? g3.slice(7) : g3;
+                    if (link !== g4) {
+                        return `[${g4}](${link})`;
+                    }
+                    return link;
+                }
+            },
         ];
     }
 
@@ -330,8 +341,7 @@ export default class ExpensiMark {
      * @returns {String}
      */
     htmlToMarkdown(htmlString) {
-        let generatedMarkdown = _.unescape(htmlString);
-
+        let generatedMarkdown = htmlString;
         this.htmlToMarkdownRules.forEach((rule) => {
             // Pre-processes input HTML before applying regex
             if (rule.pre) {
@@ -339,7 +349,7 @@ export default class ExpensiMark {
             }
             generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
         });
-        return Str.stripHTML(generatedMarkdown);
+        return _.unescape(Str.stripHTML(generatedMarkdown));
     }
 
     /**


### PR DESCRIPTION
[Explanation of the change or anything fishy that is going on]
1. Firstly, it parses the Anchor tags.
2. Now based on found groups in the match. It first picks links that start with `mailto:` and then if text and URL are not the same. It would be converted to Markdown style links `[]()`.
3. At last, if step 2 is not a pass, then it would be a normal link.

I noticed that it's unsafe to unescape the HTML before matching tags. for example, if a tag is escaped then it means it was not HTML and thus I moved the `_.unscape` after all the parsing is done.

### Fixed Issues
$ Fixes https://github.com/Expensify/App/issues/4187

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
I have a lot of Unit tests.
1. What tests did you perform that validates your changes worked?
I used dummy html text to test the conversion.

# QA
1. What does QA need to do to validate your changes?
  Pasting a link on NotDot should be converted to MD-style links.

1. What areas do they need to test for regressions?
  NewDot Message composing.
