### PR TITLE
Fix MD Hyperlink Regex for nested cases

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -338,7 +338,8 @@ test('Test markdown and url links with inconsistent starting and closing parens'
         + '[Yo (click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
         + '[Yo click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
         + '[Yo (click here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
-        + '[Yo click * $ & here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) ';
+        + '[Yo click * $ & here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
+        + '[Text text] more text ([link here](www.google.com))';
 
 
     const resultString = '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
@@ -353,7 +354,8 @@ test('Test markdown and url links with inconsistent starting and closing parens'
         + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat)</a> '
         + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click here to see a cool cat)</a> '
         + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat</a> '
-        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click * $ &amp; here to see a cool cat</a> ';
+        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click * $ &amp; here to see a cool cat</a> '
+        + '[Text text] more text (<a href="http://www.google.com" target="_blank">link here</a>)';
 
 
     expect(parser.replace(testString)).toBe(resultString);

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -339,7 +339,14 @@ test('Test markdown and url links with inconsistent starting and closing parens'
         + '[Yo click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
         + '[Yo (click here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
         + '[Yo click * $ & here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
-        + '[Text text] more text ([link here](www.google.com))';
+        + '[Text text] more text ([link here](www.google.com))'
+        + '[Text text] more text ([link [square brackets within] here](www.google.com))'
+        + '[Text text] more text ([link (parenthesis within) here](www.google.com))'
+        + '[Text text] more text [link here](www.google.com)'
+        + '[Text text] more text ([link here  ](www.google.com))'
+        + '[Text text] more text (([link here](www.google.com)))'
+        + '[Text text] more text [([link here](www.google.com))]'
+        + '[Text text] more text ([link here](www.google.com))[Text text] more text ([link here](www.google.com))';
 
 
     const resultString = '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
@@ -355,7 +362,14 @@ test('Test markdown and url links with inconsistent starting and closing parens'
         + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click here to see a cool cat)</a> '
         + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat</a> '
         + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click * $ &amp; here to see a cool cat</a> '
-        + '[Text text] more text (<a href="http://www.google.com" target="_blank">link here</a>)';
+        + '[Text text] more text (<a href="http://www.google.com" target="_blank">link here</a>)'
+        + '[Text text] more text (<a href="http://www.google.com" target="_blank">link [square brackets within] here</a>)'
+        + '[Text text] more text (<a href="http://www.google.com" target="_blank">link (parenthesis within) here</a>)'
+        + '[Text text] more text <a href="http://www.google.com" target="_blank">link here</a>'
+        + '[Text text] more text (<a href="http://www.google.com" target="_blank">link here  </a>)'
+        + '[Text text] more text ((<a href="http://www.google.com" target="_blank">link here</a>))'
+        + '[Text text] more text [(<a href="http://www.google.com" target="_blank">link here</a>)]'
+        + '[Text text] more text (<a href="http://www.google.com" target="_blank">link here</a>)[Text text] more text (<a href="http://www.google.com" target="_blank">link here</a>)'
 
 
     expect(parser.replace(testString)).toBe(resultString);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -70,10 +70,9 @@ export default class ExpensiMark {
              */
             {
                 name: 'link',
-
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `\\[([^\\]][^\\[]+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
+                        `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -73,7 +73,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `\\[(.+?)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
+                        `\\[([^\\]][^\\[]+)\\]\\(${URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
                         'gi'
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);


### PR DESCRIPTION
@tgolen  will you please review this?

Updated markdown regex to avoid nested cases

### Fixed Issues
$ [Expensify/App](https://github.com/Expensify/App/issues/4526)

# Tests
1. Test url replacements
2. Test markdown style link with various styles
3. Test critical markdown style links
4. Test markdown and url links with inconsistent starting and closing parens

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
