### PR TITLE
fix extra spaces in HTML to markdown

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -166,16 +166,10 @@ export default class ExpensiMark {
 
         /**
          * The list of regex replacements to do on a HTML comment for converting it to markdown.
-         *
+         * Order of rules is important
          * @type {Object[]}
          */
         this.htmlToMarkdownRules = [
-            {
-                name: 'Strip Special Tags',
-                regex: /(\n|\r\n)?<\/?(html|body)(?:"[^"]*"|'[^']*'|[^'"><])*>(?![^<]*(<\/pre>|<\/code>))(\n|\r\n)?/gim,
-                replacement: ''
-            },
-
             // Used to Exclude tags
             {
                 name: 'exclude',
@@ -348,6 +342,14 @@ export default class ExpensiMark {
      */
     htmlToMarkdown(htmlString) {
         let generatedMarkdown = htmlString;
+        const body = /<(body)(?:"[^"]*"|'[^']*'|[^'"><])*>(?:\n|\r\n)?([\s\S]*?)(?:\n|\r\n)?<\/\1>(?![^<]*(<\/pre>|<\/code>))/im;
+        const parseBodyTag = generatedMarkdown.match(body);
+
+        // If body tag is found then use the content of body rather than the whole HTML
+        if (parseBodyTag) {
+            generatedMarkdown = parseBodyTag[2];
+        }
+
         this.htmlToMarkdownRules.forEach((rule) => {
             // Pre-processes input HTML before applying regex
             if (rule.pre) {


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

[Explanation of the change or anything fishy that is going on]
https://github.com/Expensify/App/issues/4484#issuecomment-903352516

### Fixed Issues
$ https://github.com/Expensify/App/issues/4484

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
 There are existing tests https://github.com/Expensify/expensify-common/blob/e5a22b54cde72ff3b9b6b085ea4374144e8937b2/__tests__/ExpensiMark-Markdown-test.js#L68
1. What tests did you perform that validates your changes worked?
   I copied-pasted content from Mac Notes.app into our web app in chrome browser where this issue was reported.

# QA
1. What does QA need to do to validate your changes?
  Follow the steps on the linked issue.
1. What areas to they need to test for regressions?
   NewDot.
