### PR TITLE
[No QA] Update invalid approver/sharee email list and rename constant

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -483,11 +483,11 @@ export const CONST = {
     ],
 
      /**
-     * Emails that the user shouldn't submit reports to
+     * Emails that the user shouldn't submit reports to nor share reports with
      * Any changes here should be reflected in the PHP constant,
-     * which is located in _constant.php and also named INVALID_SUBMIT_EMAILS
+     * which is located in _constant.php and also named INVALID_APPROVER_AND_SHAREE_EMAILS
      */
-    INVALID_SUBMIT_EMAILS: [
+    INVALID_APPROVER_AND_SHAREE_EMAILS: [
         'concierge@expensify.com',
         'help@expensify.com',
         'receipts@expensify.com',
@@ -497,7 +497,6 @@ export const CONST = {
         'firstresponders@expensify.com',
         'qa+travisreceipts@expensify.com',
         'bills@expensify.com',
-        'svfg@expensify.com',
     ],
 
     /**


### PR DESCRIPTION
Rename constant that contains list of invalid report approvers/sharees and remove svfg@expensify.com from this blacklist

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/175079

# Tests
Will be covered in the related Web PR: https://github.com/Expensify/Web-Expensify/pull/31805

# QA
No QA
