### PR TITLE
Add new API call for fetching agent's accuracy in Expensiworks

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -716,7 +716,7 @@ export default function API(network, args) {
              *
              * @returns {APIDeferred}
              */
-             getUserLoungeDetails(parameters) {
+            getUserLoungeDetails(parameters) {
                 const commandName = 'GetLoungeDetails';
                 requireParameters(['chatID'], parameters, commandName);
                 return performPOSTRequest(commandName, parameters);
@@ -731,7 +731,7 @@ export default function API(network, args) {
              *
              * @returns {APIDeferred}
              */
-             setUserLoungeDetails(parameters) {
+            setUserLoungeDetails(parameters) {
                 const commandName = 'SetLoungeDetails';
                 requireParameters(['chatID', 'details'], parameters, commandName);
                 return performPOSTRequest(commandName, parameters);

--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -596,6 +596,17 @@ export default function API(network, args) {
 
         expensiworks: {
             /**
+             * Get the logged in agent's accuracy fields
+             *
+             * @returns {APIDeferred}
+             */
+            getAgentAccuracy() {
+                const commandName = 'Expensiworks_GetAgentAccuracy';
+
+                return performPOSTRequest(commandName);
+            },
+
+            /**
              * Get a job to work on
              *
              * @param {Object} parameters
@@ -728,10 +739,10 @@ export default function API(network, args) {
 
             /**
              * Checks if the domain is public
-             * 
+             *
              * @param {Object} parameters
              * @param {String} parameters.email
-             * 
+             *
              * @returns {APIDeferred}
              */
             isFromPublicDomain(parameters) {


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

Add a new API call - `Expensiworks_getAgentAccuracy()` to smoothly remove `SSDos_getAgentAccuracy()` [here](https://github.com/Expensify/expensify-common/blob/b5d9167a26cfd40beebdfb79958b3bbed1af7b64/lib/API.jsx#L662)

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/177284
Required for https://github.com/Expensify/Web-Expensify/pull/31924

# Tests

1. What unit/integration tests cover your change? What autoQA tests cover your change?
2. What tests did you perform that validates your changed worked?

None, will be tested with https://github.com/Expensify/Web-Expensify/pull/31924

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?

No regression, as it just introduces new function that is not invoked
Will be QA'ed with https://github.com/Expensify/Web-Expensify/pull/31924
