### PR TITLE
Remove unused API method

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -473,8 +473,8 @@ export default function API(network, args) {
          *
          * @returns {APIDeferred}
          */
-        getShortLivedAuthToken: function () {
-            var commandName = 'GetShortLivedAuthToken';
+        getShortLivedAuthToken() {
+            const commandName = 'GetShortLivedAuthToken';
             return performPOSTRequest(commandName);
         },
 
@@ -672,17 +672,6 @@ export default function API(network, args) {
              */
             getCurrencyList() {
                 const commandName = 'SSDos_GetCurrencyList';
-                return performPOSTRequest(commandName);
-            },
-
-            /**
-             * Get the logged in agent's accuracy fields
-             *
-             * @returns {APIDeferred}
-             */
-            getAgentAccuracy() {
-                const commandName = 'SSDos_GetAgentAccuracy';
-
                 return performPOSTRequest(commandName);
             },
         },


### PR DESCRIPTION
@TomatoToaster will you please review this?

We added a new API call in PR https://github.com/Expensify/expensify-common/pull/418
and updated Web-E to use the updated API method. So we can now safely remove this method

### Fixed Issues
Follow up for https://github.com/Expensify/Expensify/issues/162098

# Tests
N/A

# QA
N/A
