### PR TITLE
Fix combobox searching

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -162,6 +162,12 @@ export default class ExpensiMark {
                 regex: /\n/g,
                 replacement: '<br>',
             },
+            {
+                // Regex taken from this StackOverflow https://stackoverflow.com/questions/43242440/javascript-unicode-emoji-regular-expressions#comment107943203_45138005
+                name: 'emoji',
+                regex: /([\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}])/gu,
+                replacement: '<span class="testtesttest">$1</span>'
+            }
         ];
 
         /**

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -162,12 +162,6 @@ export default class ExpensiMark {
                 regex: /\n/g,
                 replacement: '<br>',
             },
-            {
-                // Regex taken from this StackOverflow https://stackoverflow.com/questions/43242440/javascript-unicode-emoji-regular-expressions#comment107943203_45138005
-                name: 'emoji',
-                regex: /([\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}])/gu,
-                replacement: '<span class="testtesttest">$1</span>'
-            }
         ];
 
         /**

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -768,7 +768,7 @@ class Combobox extends React.Component {
                     // Don't include the disabled options that match the regex unless we specified we want them to show.
                     // If we want them to show then add them whether they match the regex or not.
                     if ((!isDisabled && isMatch)
-                        || (isDisabled && this.props.showDisabledOptionsInResults)) {
+                        || (isDisabled && this.props.showDisabledOptionsInResults && isMatch)) {
                         matches.add(option);
                     }
 

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -767,8 +767,7 @@ class Combobox extends React.Component {
 
                     // Don't include the disabled options that match the regex unless we specified we want them to show.
                     // If we want them to show then add them whether they match the regex or not.
-                    if ((!isDisabled && isMatch)
-                        || (isDisabled && this.props.showDisabledOptionsInResults && isMatch)) {
+                    if ((!isDisabled && isMatch) || (isDisabled && this.props.showDisabledOptionsInResults && isMatch)) {
                         matches.add(option);
                     }
 


### PR DESCRIPTION
We were adding non-matches to searches when `this.props.showDisabledOptionsInResults` was true. This was causing the search to not work for very large policies.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/147788

# Tests/QA
1. Make this change in Web-Expensify 
    - i.e. open `./Web-Expensify/node_modules/expensify-common/lib/components/form/element/combobox.js`, apply the diff from this PR, and run `grunt` in `./Web-Expensify`
2. Turn on local js for prod
3. Supportal into ops@kruzeconsulting.com
4. Go to domains -> wellapp.com -> company cards
5. Click "Edit exports" on one of the users
6. Under QBO where it says "Default Card" search for whatever you want
7. Make sure the results actually match what you type

