### PR TITLE
Update comment on EXPENSIFY_EMAILS constant to mention new dot

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -463,8 +463,10 @@ export const CONST = {
     /**
      * Emails that the user shouldn't be interacting with from the front-end interface
      * Trying to add these emails as a delegate, onto a policy, or as an approver is considered invalid
-     * Any changes here should be reflected in the PHP constant,
-     * which is located in _constant.php and also named EXPENSIFY_EMAILS
+     * Any changes here should be reflected in the PHP constant in web-expensify,
+     * which is located in _constant.php and also named EXPENSIFY_EMAILS.
+     * And should also be reflected in the constant in expensify/app,
+     * which is located in src/CONST.js and also named EXPENSIFY_EMAILS.
      */
     EXPENSIFY_EMAILS: [
         'concierge@expensify.com',


### PR DESCRIPTION
I updated the comment to mention that we need to keep this constant up to date in two places now. In both the web-expensify and app repos now that we have new dot. 

I found this while working on https://github.com/Expensify/Expensify/issues/174181. 

# Tests
No tests, just updated a comment. 

# QA
No QA, just updated a comment. 