### PR TITLE
str: htmlDecode/Encode update jQuery check and usage

### DIFF
--- a/lib/str.js
+++ b/lib/str.js
@@ -83,8 +83,8 @@ const Str = {
      */
     htmlDecode(s) {
         // Use jQuery if it exists or else use html-entities
-        if (typeof $ !== 'undefined') {
-            return $('<textarea/>').html(s).text();
+        if (typeof jQuery !== 'undefined') {
+            return jQuery('<textarea/>').html(s).text();
         }
         return AllHtmlEntities.decode(s);
     },
@@ -97,8 +97,8 @@ const Str = {
      */
     htmlEncode(s) {
         // Use jQuery if it exists or else use html-entities
-        if (typeof $ !== 'undefined') {
-            return $('<textarea/>').text(s).html();
+        if (typeof jQuery !== 'undefined') {
+            return jQuery('<textarea/>').text(s).html();
         }
         return AllHtmlEntities.encode(s);
     },


### PR DESCRIPTION
@roryabraham will you please review this?

Invoking scripts through Chrome dev tools causes the code here to mistakenly assume that `$` is `jQuery` 
`$` is Chrome's command line API when the dev console is running

SO high ranking answer on the matter: https://stackoverflow.com/a/6973954/4834103

### Fixed Issues
$ n/a

# Tests
Existing unit tests covering `Str.htmlDecode` in `ExpensiMark-Markdown-test.js` still pass...

I've tested my changes using `npm link` and Expensify/App
![image](https://user-images.githubusercontent.com/12156624/142503680-c942f5fc-6fab-482d-bf6c-886d7d3ffcee.png)
- This used to cause an error

# QA
n/a
