### PR TITLE
[No QA] Fix tabbing out of "To" field in "reports send dropdown"

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -589,7 +589,7 @@ class Combobox extends React.Component {
      */
     closeDropdownOnTabOut(e) {
         if (e.which === 9) {
-            this.closeDropdown();
+            this.handleClick(this.state.currentValue);
         }
     }
 


### PR DESCRIPTION
Saves current value when user tabs out of the `To` field.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/186694

# Tests
Will be tested once Web-E PR is merged. But here are some testing steps for Web-E:

1. Open the Reports page and click on a report.
2. Click on `Send` and enter a value in the `To` field.
3. Tab out of the input and verify that the value remains.

Additionally, I tested a lot of other usages of `React.c.FormElementCombobox` and they worked as expected.

# QA
No QA.