### PR TITLE
Remove extra line under codeblock

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -386,7 +386,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence at the same line', () => {
     const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\nThe next line should not be quoted\n```&gt;Hello,I’mtext```\nsince its inside a codefence';
 
-    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted<br /><pre>&gt;Hello,I’mtext</pre><br />since its inside a codefence';
+    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted<br /><pre>&gt;Hello,I’mtext</pre>since its inside a codefence';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -402,7 +402,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence with quotes at the end of the text', () => {
     const testString = 'The next line should be quoted\n```&gt;Hello,I’mtext```\nThe next line should not be quoted\n&gt;Hello,I’mtext';
 
-    const resultString = 'The next line should be quoted<br /><pre>&gt;Hello,I’mtext</pre><br />The next line should not be quoted<br /><blockquote>Hello,I’mtext</blockquote>';
+    const resultString = 'The next line should be quoted<br /><pre>&gt;Hello,I’mtext</pre>The next line should not be quoted<br /><blockquote>Hello,I’mtext</blockquote>';
 
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -162,6 +162,12 @@ export default class ExpensiMark {
                 regex: /\n/g,
                 replacement: '<br />',
             },
+            {
+                // when <pre> and <br /> occur together extra line is added so removing <br />
+                name: 'replacepre',
+                regex: /<\/pre>\s*<br\s*[/]?>/gi,
+                replacement: '</pre>',
+            },
         ];
 
         /**
@@ -171,6 +177,11 @@ export default class ExpensiMark {
          */
         this.htmlToMarkdownRules = [
             // Used to Exclude tags
+            {
+                name: 'replacepre',
+                regex: /<\/pre>(.)/gi,
+                replacement: '</pre><br />$1',
+            },
             {
                 name: 'exclude',
                 regex: new RegExp(


### PR DESCRIPTION
@Beamanator @rushatgabhane will you please review this?

Code block is wrapped by `<pre>` `</pre>` tags. And When new line is added `<br />` tag is also added. So, In turn, `</pre> <br />` tags get added in the html. 
Here, `</pre>` tag changes the line and `<br />` add another line. So there is extra line. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/7496
# Tests
1. Send some code blocks in chat like
    
    Here is come code
    
    ```
    const myLineOfCode = 'some code';
   ```
   
    And that was my code!
2. There should not be an extra line below the codeblock.


# QA
1. Send some code blocks in chat like
    
    Here is come code
    
    ```
    const myLineOfCode = 'some code';
   ```
   
    And that was my code!
2. There should not be an extra line below the codeblock.

## Screenshots
### Web
<img width="1440" alt="Screen Shot 2022-02-10 at 18 04 02" src="https://user-images.githubusercontent.com/25876548/153437475-b4df9a37-09b4-4df1-b63c-25240214dd41.png">

### Desktop
<img width="1440" alt="Screen Shot 2022-02-10 at 19 50 24" src="https://user-images.githubusercontent.com/25876548/153438271-d529f80a-c64f-45e6-ab2b-6acef41ed3e1.png">

### Android
<img src="https://user-images.githubusercontent.com/25876548/153438571-b8439ec1-b06b-4627-ac8d-6b357482c92c.png" alt="" width="350px">

### IOS
<img src="https://user-images.githubusercontent.com/25876548/153438711-dc36c7d4-b112-44b5-bfce-1284e65a5d53.png" alt="" width="350px">

### mWeb
<img src="https://user-images.githubusercontent.com/25876548/153438737-91dc3d83-8bd0-424a-bc4e-83bddd947003.png" alt="" width="350px">
