### PR TITLE
fixed bug: Adding some text just after the closing backtick  doesn't …

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -49,7 +49,7 @@ export default class ExpensiMark {
 
                 // Use the url escaped version of a backtick (`) symbol. Mobile platforms do not support lookbehinds,
                 // so capture the first and third group and place them in the replacement.
-                regex: /(\B|_)&#x60;(.*?)&#x60;(\B|_)(?![^<]*<\/pre>)/g,
+                regex: /(\B|_|)&#x60;(.*?)&#x60;(\B|_|)(?![^<]*<\/pre>)/g,
                 replacement: '$1<code>$2</code>$3',
             },
 


### PR DESCRIPTION
…quote the text inside the backticks  #8288 

TAG_REVIEWER will you please review this?

[Explanation of the change or anything fishy that is going on]
Modified the regex to handle quotes with text as prefix or suffix : 
https://github.com/Expensify/expensify-common/blob/f77bb4710c13d01153716df7fb087b637ba3b8bd/lib/ExpensiMark.js#L52

### Fixed Issues
 https://github.com/Expensify/App/issues/8288#issuecomment-1087962508

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?

1. What tests did you perform that validates your changed worked?
I tried submitting the text below from report compose:
```"`a`"``` a and a```"`b"```

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
Mostly just from compose and edit the submitted text. 
