### PR TITLE
Replace underscore.uniq by lodash.uniqBy for performance

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -5,6 +5,7 @@ import cn from 'classnames';
 import _ from 'underscore';
 import get from 'lodash/get';
 import has from 'lodash/has';
+import uniqBy from 'lodash/uniqBy';
 import Str from '../../../str';
 import DropDown from './dropdown';
 
@@ -756,7 +757,7 @@ class Combobox extends React.Component {
         ];
         let hasMoreResults = false;
         let matches = new Set();
-        const searchOptions = _.uniq(this.options, 'value');
+        const searchOptions = uniqBy(this.options, 'value');
 
         for (let i = 0; i < matchRegexes.length; i++) {
             if (matches.size < this.props.maxSearchResults) {


### PR DESCRIPTION
Underscore's `uniq` function is slow as **** in comparison with lodash's `uniqBy`. This performance issue was causing the browser to freeze when used on a big array (205141 elements in this case)

Doing tests locally, `underscore.uniq` just freezes, don't know how long it really takes, meanwhile, `lodash.uniqBy` returns in around 200 ms

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/204905

# Tests
1. Do the same changes this PR is doing in `node_modules/expensify-common/lib/components/form/element/combobox.js` (Web-E)
2. Use `grunt watch` to rebuild everything
3. Use this [SO](https://stackoverflow.com/c/expensify/questions/29) to use your local JS in production
4. Follow the QA Steps

# QA
1. Supportal into accounting@alayacare.com
5. Type something in this combobox to filter the results:
![image](https://user-images.githubusercontent.com/87341702/161790082-1ad9c85a-9467-4450-9285-dfb34c1c82ad.png)
6. Should not freeze (it may be slow, but not freeze!)
