### PR TITLE
convert html to flat text for LHN uses

### DIFF
--- a/__tests__/ExpensiMark-FlatText-test.js
+++ b/__tests__/ExpensiMark-FlatText-test.js
@@ -1,0 +1,25 @@
+/* eslint-disable max-len */
+import ExpensiMark from '../lib/ExpensiMark';
+
+const parser = new ExpensiMark();
+
+test('Test space replacement on breakline', () => {
+    const html = '1<br />2<br />3';
+    const text = '1 2 3';
+
+    expect(parser.htmlToFlatText(html)).toBe(text);
+});
+
+test('Test space replacement on blockquote close tag', () => {
+    const html = '<blockquote>Confusing stuff</blockquote>Tell me about it';
+    const text = 'Confusing stuff Tell me about it';
+
+    expect(parser.htmlToFlatText(html)).toBe(text);
+});
+
+test('Test replacement on html', () => {
+    const html = 'First Line<br /><blockquote>Quoted line <code>code</code></blockquote>3<br /><blockquote>4</blockquote>Five';
+    const text = 'First Line Quoted line code 3 4 Five';
+
+    expect(parser.htmlToFlatText(html)).toBe(text);
+});

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -7,19 +7,19 @@ test('Test space replacement on breakline', () => {
     const html = '1<br />2<br />3';
     const text = '1 2 3';
 
-    expect(parser.htmlToFlatText(html)).toBe(text);
+    expect(parser.htmlToText(html)).toBe(text);
 });
 
 test('Test space replacement on blockquote close tag', () => {
     const html = '<blockquote>Confusing stuff</blockquote>Tell me about it';
     const text = 'Confusing stuff Tell me about it';
 
-    expect(parser.htmlToFlatText(html)).toBe(text);
+    expect(parser.htmlToText(html)).toBe(text);
 });
 
 test('Test replacement on html', () => {
     const html = 'First Line<br /><blockquote>Quoted line <code>code</code></blockquote>3<br /><blockquote>4</blockquote>Five';
     const text = 'First Line Quoted line code 3 4 Five';
 
-    expect(parser.htmlToFlatText(html)).toBe(text);
+    expect(parser.htmlToText(html)).toBe(text);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -250,6 +250,29 @@ export default class ExpensiMark {
                 }
             },
         ];
+
+        /**
+         * The list of regex replacements to do on a HTML comment for LHN text uses.
+         * Order of rules is important
+         * @type {Object[]}
+         */
+        this.htmlToFlatTextRules = [
+            {
+                name: 'breakline',
+                regex: /((<br[^>]*>)+)/gi,
+                replacement: ' ',
+            },
+            {
+                name: 'blockquote',
+                regex: /<\/blockquote>/gm,
+                replacement: ' ',
+            },
+            {
+                name: 'tag',
+                regex: /(<([^>]+)>)/gi,
+                replacement: '',
+            },
+        ];
     }
 
     /**
@@ -371,6 +394,22 @@ export default class ExpensiMark {
             generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
         });
         return Str.htmlDecode(Str.stripHTML(generatedMarkdown));
+    }
+
+    /**
+     * Replaces HTML with text
+     *
+     * @param {String} htmlString
+     * @returns {String}
+     */
+    htmlToFlatText(htmlString) {
+        let replacedText = htmlString;
+
+        this.htmlToFlatTextRules.forEach((rule) => {
+            replacedText = replacedText.replace(rule.regex, rule.replacement);
+        });
+
+        return replacedText;
     }
 
     /**

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -252,7 +252,7 @@ export default class ExpensiMark {
         ];
 
         /**
-         * The list of regex replacements to do on a HTML comment for LHN text uses.
+         * The list of rules to covert the HTML to text.
          * Order of rules is important
          * @type {Object[]}
          */

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -268,7 +268,7 @@ export default class ExpensiMark {
                 replacement: ' ',
             },
             {
-                name: 'tag',
+                name: 'stripTag',
                 regex: /(<([^>]+)>)/gi,
                 replacement: '',
             },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -397,7 +397,7 @@ export default class ExpensiMark {
     }
 
     /**
-     * Replaces HTML with text
+     * Convert HTML to text
      *
      * @param {String} htmlString
      * @returns {String}

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -402,7 +402,7 @@ export default class ExpensiMark {
      * @param {String} htmlString
      * @returns {String}
      */
-    htmlToFlatText(htmlString) {
+    htmlToText(htmlString) {
         let replacedText = htmlString;
 
         this.htmlToFlatTextRules.forEach((rule) => {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -256,7 +256,7 @@ export default class ExpensiMark {
          * Order of rules is important
          * @type {Object[]}
          */
-        this.htmlToFlatTextRules = [
+        this.htmlToTextRules = [
             {
                 name: 'breakline',
                 regex: /((<br[^>]*>)+)/gi,
@@ -405,7 +405,7 @@ export default class ExpensiMark {
     htmlToText(htmlString) {
         let replacedText = htmlString;
 
-        this.htmlToFlatTextRules.forEach((rule) => {
+        this.htmlToTextRules.forEach((rule) => {
             replacedText = replacedText.replace(rule.regex, rule.replacement);
         });
 


### PR DESCRIPTION
@parasharrajat @Luke9389  will you please review this?

[Explanation of the change or anything fishy that is going on]
I'm adding a new function to replace the HTML report message that use for showing text on LHN.

### Fixed Issues
$ https://github.com/Expensify/App/issues/8134

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
`__tests__/ExpensiMark-FlatText-test.js`
1. What tests did you perform that validates your changed worked?
```
> Confusing stuff
Tell me about it
```
Type above text and should be converted to text `Confusing stuff Tell me about it`

# QA
1. What does QA need to do to validate your changes?
Verify that `__tests__/ExpensiMark-FlatText-test.js` is pass.
1. What areas to they need to test for regressions?
The function created is used on showing the converted html last message on LHN.
