### PR TITLE
Update QBD Sync Manager filename to new version

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -352,7 +352,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_220329.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_220518.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },


### PR DESCRIPTION
### Changes
Update the constant used to download the QBD Sync Manager, which has been updated to a new version. The new installer was already uploaded to static [here](https://github.com/Expensify/Web-Static/pull/105). 

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/209252

### Tests
This will be tested and QAed when we update Web-E to use the new expensify-common version.