### PR TITLE
Afonseca fix lowercase selected combo

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -786,7 +786,7 @@ class Combobox extends React.Component {
 
         const options = _(matches).map(option => ({
             focused: false,
-            isSelected: _.isEqual(option.value, value) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
+            isSelected: _.isEqual(option.value, value.toUpperCase()) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
             ...option,
         }));
 

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -786,7 +786,7 @@ class Combobox extends React.Component {
 
         const options = _(matches).map(option => ({
             focused: false,
-            isSelected: _.isEqual(option.value, value.toUpperCase()) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
+            isSelected: _.isEqual(option.value.toUpperCase(), value.toUpperCase()) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
             ...option,
         }));
 


### PR DESCRIPTION
The comparation to selected was not taking into account lower cases inserted by the user.
It should

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/208426

# Tests
1. Create an expense (New Expense)
1. Edit the currency
2. Write lowercase `usd`
3. verify that the USD $ choice gets checkmarked
2. Write uppercase `USD`
3. verify that the USD $ choice gets checkmarked
4. Try the same with another currency of your choice

# QA
Same as Tests
