### PR TITLE
Fix combobox click non existing value

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -841,8 +841,17 @@ class Combobox extends React.Component {
 
         // Select the new item, set our new indexes, close the dropdown
         // Unselect all other options
-        const newSelectedIndex = _(this.options).findIndex({value: selectedValue});
-        const currentlySelectedOption = _(this.options).findWhere({value: selectedValue});
+        let newSelectedIndex = _(this.options).findIndex({value: selectedValue});
+        let currentlySelectedOption = _(this.options).findWhere({value: selectedValue});
+
+        // if allowAnyValue is true and currentValue is absent then set it manually to what the user has entered
+        if (newSelectedIndex === -1 && this.props.allowAnyValue && selectedValue) {
+            newSelectedIndex = 0;
+            currentlySelectedOption = {
+                text: selectedValue,
+                value: selectedValue
+            };
+        }
 
         // Get the scroll position of the currently selected value
         this.scrollPosition = this.dropDown.scrollTop;

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -844,7 +844,7 @@ class Combobox extends React.Component {
         let newSelectedIndex = _(this.options).findIndex({value: selectedValue});
         let currentlySelectedOption = _(this.options).findWhere({value: selectedValue});
 
-        // if allowAnyValue is true and currentValue is absent then set it manually to what the user has entered
+        // If allowAnyValue is true and currentValue is absent then set it manually to what the user has entered.
         if (newSelectedIndex === -1 && this.props.allowAnyValue && selectedValue) {
             newSelectedIndex = 0;
             currentlySelectedOption = {


### PR DESCRIPTION
Clicking an option that doesn't exist when  `allowAnyValue = true` doesn't stick.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/215741

# Tests

1. Checkout this PR: https://github.com/Expensify/Web-Expensify/pull/34070
1. Go to expenses page
2. Type an option that doesn't exist in the Tag filter
3. Click the option appearing with the text you typed
4. Check that the dropdown closes and the input still has the text you typed
2. Type another option that doesn't exist in the Tag filter
3. Press Enter key
5. Check that the dropdown closes and the input still has the text you typed

