### PR TITLE
Prevent failing to merge expenses

### DIFF
--- a/lib/PubSub.jsx
+++ b/lib/PubSub.jsx
@@ -28,7 +28,7 @@ const generateID = (eventName) => {
 * @param {string} eventID
 * @return {String}
 */
-const extractEventName = eventID => eventID.substr(0, eventID.indexOf('@#@'));
+const extractEventName = (eventID = '') => eventID.substring(0, eventID.indexOf('@#@'));
 
 const PubSubModule = {
     ERROR: 'ev_error',


### PR DESCRIPTION
Found [here](https://github.com/Expensify/Expensify/issues/218385#issuecomment-1181677243) that we were getting an empty `eventID` passed in, causing an error that didn't allow merging receipts via the "Attach" paper clip icon

Also replaced `substr` with `substring` b/c `substr` is deprecated (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)

### Related Issues
$ Related to https://github.com/Expensify/Expensify/issues/218385

# Tests
1. Open a report
2. Add 2 very similar expenses
3. In the report, click "Details"
4. Click "Edit Expenses"
5. Edit one expense by clicking the pencil icon when hovering over an expense
6. Click "Merge" when looking at the expense
7. At this point you'll probably see a pretty empty dialog box (this error is being resolved in another PR)
8. Close the "Merge an expense" modal
9. Now you should see something like:
    - ![Screen Shot 2022-07-12 at 2 38 32 PM](https://user-images.githubusercontent.com/3885503/178491637-44d05b05-691c-4413-b06b-38681981f6b3.png)
10. Hover over this expense, click the Paper clip icon on the left
11. You should now be taken to "Merge Expenses" dialog:
    - ![Screen Shot 2022-07-12 at 2 39 02 PM](https://user-images.githubusercontent.com/3885503/178491704-755c41a3-9ebc-446f-9746-24bc50d277d0.png)

# QA
Same as above
