### PR TITLE
draft pr - removed capitalizing

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -783,7 +783,7 @@ class Combobox extends React.Component {
             }
         }
         matches = Array.from(matches);
-
+        //comment
         const options = _(matches).map(option => ({
             focused: false,
             isSelected: _.isEqual(option.value, value) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -786,7 +786,7 @@ class Combobox extends React.Component {
         
         const options = _(matches).map(option => ({
             focused: false,
-            isSelected: _.isEqual(option.value, value) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
+            isSelected: _.isEqual(option.value ? option.value.toUpperCase : '', value.toUpperCase()) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
             ...option,
         }));
 

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -786,7 +786,7 @@ class Combobox extends React.Component {
 
         const options = _(matches).map(option => ({
             focused: false,
-            isSelected: _.isEqual(option.value.toUpperCase(), value.toUpperCase()) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
+            isSelected: _.isEqual(option.value, value) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),
             ...option,
         }));
 

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -783,7 +783,7 @@ class Combobox extends React.Component {
             }
         }
         matches = Array.from(matches);
-        //comment
+        
         const options = _(matches).map(option => ({
             focused: false,
             isSelected: _.isEqual(option.value, value) || Boolean(_.findWhere(this.props.alreadySelectedOptions, {value: option.value})),


### PR DESCRIPTION
Explanation of change:

Changing the report an expense is attached to by typing it in causes an error because we check for capitalization. Removed that check.

Fixes this issue:
<img width="1511" alt="Screen Shot 2022-07-18 at 7 33 26 PM" src="https://user-images.githubusercontent.com/48188732/179634018-dada734d-7927-462c-90fb-f021ed318be3.png">

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/218805

# Tests
1. Open old dot
2. Navigate to the reports tab
3. Create a report titled "abc"
4. Navigate to the expenses tab
5. Click on an expense that is in the open category
6. Clear the report field
7. Type in "a"
8. Ensure that the letter populates and no error appears in the js console.

# QA
Same as Tests
