### PR TITLE
Markdown issue resolved

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -145,7 +145,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'strikethrough',
-                regex: /\B~((?!\s).*?\S)~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<del>$1</del>',
             },
             {


### PR DESCRIPTION
TAG_REVIEWER will you please review this?
@rushatgabhane @sketchydroide 

[Explanation of the change or anything fishy that is going on]
- There was no way to write ~~~~ in our current code block. After fixing the markdown issue user can now write ~~~~.

### Fixed Issues
$ https://github.com/Expensify/App/issues/9826

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
- No changes are need to be done in this test.

2. What tests did you perform that validates your changed worked?
- Tested with `npm run test`.
<img width="1439" alt="178452857-2cf4bc71-b4cc-4f53-ae1f-c13713d7ee85" src="https://user-images.githubusercontent.com/78416198/183006469-69664ce8-0e17-4da2-99bd-48b0a651c973.png">

# QA
1. What does QA need to do to validate your changes?
- Go to any chat -> then try writing ~~~~ and send in message the text should remain same without any striked out text.

<img width="282" alt="Screenshot 2022-08-05 at 10 51 10 AM" src="https://user-images.githubusercontent.com/78416198/183007058-351fe9d8-8cfd-4e62-a418-d1001d376ebf.png">

- First message contains old code and unexpected output. And second message contains expected out which was sent with the fixed code.

2. What areas do they need to test for regressions?
- QA need to test strikethrough text testing with different scenarios.
- The developers can test using current `npm run test`.

