### PR TITLE
handle asterisk (*) after backtick (`)

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -140,8 +140,8 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: '<strong>$1</strong>',
+                regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: (match, g1, g2) => g1 ? match : `<strong>${g2}</strong>`,
             },
             {
                 name: 'strikethrough',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -141,7 +141,7 @@ export default class ExpensiMark {
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
                 regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (match, g1, g2) => g1 ? match : `<strong>${g2}</strong>`,
+                replacement: (match, g1, g2) => (g1 ? match : `<strong>${g2}</strong>`),
             },
             {
                 name: 'strikethrough',


### PR DESCRIPTION
@rushatgabhane @chiragsalian will you please review this?

https://github.com/Expensify/App/issues/9822#issuecomment-1239426453
This was original proposal but I updated logic below because some browsers (i.e. safari) do not support negative lookbehind 
 regex (`?<!`) (details here: https://javascript.info/regexp-lookahead-lookbehind)

Updated logic:
- update regex to still validate true if `<pre>` or `<code>` or `<a>` exists as a prefix (if not exist, of course validated as before)
- In `replacement` callback, if prefix is `<pre>` or `<code>` or `<a>`, don't convert considering as not `bold`. If not, consider as `bold` and convert as before
So actually the idea is same as original proposal

### Fixed Issues
$ https://github.com/Expensify/App/issues/9822

# Tests
1. Open any chat
2. In the chat input, enter some text inside the backticks (`) to quote it
3. After each backtick, append an asterisk like this:
```
`*test`*
```
4. Send the message
5. Verify that message is displayed correctly as `*test`*

# QA
1. Open any chat
2. In the chat input, enter some text inside the backticks (`) to quote it
3. After each backtick, append an asterisk like this:
```
`*test`*
```
4. Send the message
5. Verify that message is displayed correctly as `*test`*


### Screenshots

```
1. quote only: `test`
2. asterisk only: *test*
3. asterisk after quote: `*test`*
4. quote after asterisk: *`test*`
5. *`test`* and `*test*`
```

#### Web
<img width="1397" alt="web" src="https://user-images.githubusercontent.com/96077027/189048009-ef8ae4bb-6654-4183-b569-49ade3f4724d.png">



#### Mobile Web
<img width="369" alt="mweb" src="https://user-images.githubusercontent.com/96077027/189048029-1717bcc7-3390-4dbd-b7a5-a4e6c97938c3.png">



#### Desktop
<img width="821" alt="desktop" src="https://user-images.githubusercontent.com/96077027/189048041-31c2ac13-3913-40f7-b9be-fe0f7626c668.png">



#### iOS
<img width="371" alt="ios" src="https://user-images.githubusercontent.com/96077027/189048054-3988d5b6-720e-4492-8ac1-76097fcd3ef1.png">


#### Android
<img width="396" alt="android" src="https://user-images.githubusercontent.com/96077027/189048071-13bc89b9-40da-4b4c-ac60-f271a1209947.png">
