### PR TITLE
Update QBD Sync Manager installer filename

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -354,7 +354,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_220518.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_220929381.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },


### PR DESCRIPTION
### Changes
Update the constant used to download the QBD Sync Manager, which has been updated to a new version. The new installer was already uploaded to static [here](https://github.com/Expensify/Web-Static/pull/117). 

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/231991

### Tests
This will be tested and QAed when we update Web-E to use the new expensify-common version.