### PR TITLE
Add h1 markdown

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -32,7 +32,7 @@ test('Test strikethrough HTML replacement', () => {
 });
 
 test('Test Mixed HTML strings', () => {
-    const rawHTMLTestStartString = '<em>This is</em> a <strong>test</strong>. None of <h1>these strings</h1> should display <del>as</del> <div>HTML</div>.';
+    const rawHTMLTestStartString = '<em>This is</em> a <strong>test</strong>. None of <h2>these strings</h2> should display <del>as</del> <div>HTML</div>.';
     const rawHTMLTestReplacedString = '_This is_ a *test*. None of \nthese strings\n should display ~as~ \nHTML\n.';
     expect(parser.htmlToMarkdown(rawHTMLTestStartString)).toBe(rawHTMLTestReplacedString);
 });
@@ -412,7 +412,7 @@ test('map div with bold and italics', () => {
 });
 
 test('map div with mixed html strings', () => {
-    const testString = '<div><em>This is</em> a <strong>test</strong>. None of <h1>these strings</h1> should display <del>as</del><div>HTML</div><div></div><em>line 3</em></div>';
+    const testString = '<div><em>This is</em> a <strong>test</strong>. None of <h2>these strings</h2> should display <del>as</del><div>HTML</div><div></div><em>line 3</em></div>';
     const resultString = '_This is_ a *test*. None of \nthese strings\n should display ~as~\nHTML\n_line 3_';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -466,3 +466,17 @@ test('Test heading1 markdown replacement', () => {
     + 'this line has no special therefore it cannot be a heading1';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test html string to heading1 markdown', () => {
+    const testString = '<h1>This is a heading1 because starts with # followed by a space</h1><br />'
+    + '<h1>This is also a heading1 because starts with # followed by a space</h1><br />'
+    + 'this is not a heading1 because does not start with #<br />'
+    + '#This is not a heading1 either because starts with a # but has no space after it<br />'
+    + 'this line has no special therefore it cannot be a heading1';
+    const resultString = '# This is a heading1 because starts with # followed by a space\n'
+    + '# This is also a heading1 because starts with # followed by a space\n'
+        + 'this is not a heading1 because does not start with #\n'
+        + '#This is not a heading1 either because starts with a # but has no space after it\n'
+        + 'this line has no special therefore it cannot be a heading1';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -454,16 +454,26 @@ test('map real message with quotes', () => {
 });
 
 test('Test heading1 markdown replacement', () => {
-    const testString = '# This is a heading1 because starts with # followed by a space\n'
-    + '#    This is also a heading1 because starts with # followed by a space\n'
-        + 'this is not a heading1 because does not start with #\n'
-        + '#This is not a heading1 either because starts with a # but has no space after it\n'
-        + 'this line has no special therefore it cannot be a heading1';
-    const resultString = '<h1>This is a heading1 because starts with # followed by a space</h1><br />'
-    + '<h1>This is also a heading1 because starts with # followed by a space</h1><br />'
-    + 'this is not a heading1 because does not start with #<br />'
-    + '#This is not a heading1 either because starts with a # but has no space after it<br />'
-    + 'this line has no special therefore it cannot be a heading1';
+    const testString = '# This is a heading1 because starts with # followed by a space\n';
+    const resultString = '<h1>This is a heading1 because starts with # followed by a space</h1><br />';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test heading1 markdown replacement when # is followed by multiple spaces', () => {
+    const testString = '#    This is also a heading1 because starts with # followed by a space\n';
+    const resultString = '<h1>This is also a heading1 because starts with # followed by a space</h1><br />';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test heading1 markdown when # is not followed by a space', () => {
+    const testString = '#This is not a heading1 because starts with a # but has no space after it\n';
+    const resultString = '#This is not a heading1 because starts with a # but has no space after it<br />';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test heading1 markdown when # is in the middle of the line', () => {
+    const testString = 'This is not # a heading1\n';
+    const resultString = 'This is not # a heading1<br />';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -452,3 +452,17 @@ test('map real message with quotes', () => {
     const resultString = '\n> hi\n\n\n> hi\n\n';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
+
+test('Test heading1 markdown replacement', () => {
+    const testString = '# This is a heading1 because starts with # followed by a space\n'
+    + '#    This is also a heading1 because starts with # followed by a space\n'
+        + 'this is not a heading1 because does not start with #\n'
+        + '#This is not a heading1 either because starts with a # but has no space after it\n'
+        + 'this line has no special therefore it cannot be a heading1';
+    const resultString = '<h1>This is a heading1 because starts with # followed by a space</h1><br />'
+    + '<h1>This is also a heading1 because starts with # followed by a space</h1><br />'
+    + 'this is not a heading1 because does not start with #<br />'
+    + '#This is not a heading1 either because starts with a # but has no space after it<br />'
+    + 'this line has no special therefore it cannot be a heading1';
+    expect(parser.replace(testString)).toBe(resultString);
+});

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -478,18 +478,20 @@ test('Test heading1 markdown when # is in the middle of the line', () => {
 });
 
 test('Test html string to heading1 markdown', () => {
-    const testString = '<h1>This is a heading1 because starts with # followed by a space</h1><br />'
-    + '<h1>This is also a heading1 because starts with # followed by a space</h1><br />'
-    + 'this is not a <strong>heading1</strong> because does not start with #<br />'
-    + '#This is not a <em>heading1</em> either because starts with a # but has no space after it<br />'
-    + 'this line has no special therefore it cannot be a heading1<br />'
-    + 'this line has a <h1>heading1</h1> in the middle of the line';
-    const resultString = '\n# This is a heading1 because starts with # followed by a space\n'
-    + '\n# This is also a heading1 because starts with # followed by a space\n'
-    + 'this is not a *heading1* because does not start with #\n'
-    + '#This is not a _heading1_ either because starts with a # but has no space after it\n'
-    + 'this line has no special therefore it cannot be a heading1\n'
-    + 'this line has a\n'
+    const testString = '<h1>This is a heading1</h1><br />';
+    const resultString = '\n# This is a heading1\n';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test html to heading1 markdown when there are other tags inside h1 tag', () => {
+    const testString = '<h1>This is a <strong>heading1</strong></h1>';
+    const resultString = '\n# This is a *heading1*\n';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test html to heading1 markdown when h1 tags are in the middle of the line', () => {
+    const testString = 'this line has a <h1>heading1</h1> in the middle of the line';
+    const resultString = 'this line has a\n'
     + '# heading1\n'
     + 'in the middle of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -470,13 +470,17 @@ test('Test heading1 markdown replacement', () => {
 test('Test html string to heading1 markdown', () => {
     const testString = '<h1>This is a heading1 because starts with # followed by a space</h1><br />'
     + '<h1>This is also a heading1 because starts with # followed by a space</h1><br />'
-    + 'this is not a heading1 because does not start with #<br />'
-    + '#This is not a heading1 either because starts with a # but has no space after it<br />'
-    + 'this line has no special therefore it cannot be a heading1';
-    const resultString = '# This is a heading1 because starts with # followed by a space\n'
-    + '# This is also a heading1 because starts with # followed by a space\n'
-        + 'this is not a heading1 because does not start with #\n'
-        + '#This is not a heading1 either because starts with a # but has no space after it\n'
-        + 'this line has no special therefore it cannot be a heading1';
+    + 'this is not a <strong>heading1</strong> because does not start with #<br />'
+    + '#This is not a <em>heading1</em> either because starts with a # but has no space after it<br />'
+    + 'this line has no special therefore it cannot be a heading1<br />'
+    + 'this line has a <h1>heading1</h1> in the middle of the line';
+    const resultString = '\n# This is a heading1 because starts with # followed by a space\n'
+    + '\n# This is also a heading1 because starts with # followed by a space\n'
+    + 'this is not a *heading1* because does not start with #\n'
+    + '#This is not a _heading1_ either because starts with a # but has no space after it\n'
+    + 'this line has no special therefore it cannot be a heading1\n'
+    + 'this line has a\n'
+    + '# heading1\n'
+    + 'in the middle of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -163,6 +163,11 @@ export default class ExpensiMark {
                 replacement: g1 => `<blockquote>${g1}</blockquote>`,
             },
             {
+                name: 'heading1',
+                regex: /^#(?!#) +(.*)$/gm,
+                replacement: '<h1>$1</h1>',
+            },
+            {
                 name: 'newline',
                 regex: /\n/g,
                 replacement: '<br />',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -230,7 +230,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex:/\s*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
+                regex: /\s*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
                 replacement: '\n# $2\n',
             },
             {
@@ -475,8 +475,7 @@ export default class ExpensiMark {
             }
             generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
         });
-        generatedMarkdown = generatedMarkdown
-        .replace(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>/gm, '[block]');
+        generatedMarkdown = generatedMarkdown.replace(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>/gm, '[block]');
         return Str.htmlDecode(this.replaceBlockWithNewLine(Str.stripHTML(generatedMarkdown)));
     }
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -476,7 +476,7 @@ export default class ExpensiMark {
             generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
         });
         generatedMarkdown = generatedMarkdown
-            .replace(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>/gm, '[block]');
+        .replace(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>/gm, '[block]');
         return Str.htmlDecode(this.replaceBlockWithNewLine(Str.stripHTML(generatedMarkdown)));
     }
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -230,8 +230,8 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
-                replacement: '# $2',
+                regex:/\s*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
+                replacement: '\n# $2\n',
             },
             {
                 name: 'italic',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -229,6 +229,11 @@ export default class ExpensiMark {
                 replacement: '\n',
             },
             {
+                name: 'heading1',
+                regex: /<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: '# $2',
+            },
+            {
                 name: 'italic',
                 regex: /<(em|i)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '_$2_',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -164,7 +164,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /^#(?!#) +(.*)$/gm,
+                regex: /^#(?!#) +(.+)$/gm,
                 replacement: '<h1>$1</h1>',
             },
             {


### PR DESCRIPTION
Part of [this DesignDoc](https://docs.google.com/document/d/1YJmMi9NjnstCAP2Ibo_IZdT2T16Res2jdhWr2WSrk50).
Adds support for heading markdown. A line which starts with # and a space (`# `) is wrapped with `<h1></h1>` tag.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/225615

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
- there are 2 new automated tests added which checks that markdown is replaced with html tags and vice versa.

1. What tests did you perform that validates your changes worked?
- Link the `expensify-common` local repository by following [these steps](https://docs.google.com/document/d/1YJmMi9NjnstCAP2Ibo_IZdT2T16Res2jdhWr2WSrk50)
- Run the app
- Open any chat and send a text message containing lines starting with a # and a space and then text.
- Check that the lines from the previous step are rendered as headings
- copy the message to the clipboard and paste it into the composer (input text area)
- check that the message is parsed correctly and that the headings are pasted as lines starting with # and space

# QA
1. What does QA need to do to validate your changes?
- Run the app
- Open any chat and send a text message containing lines starting with a # and a space and then text.
- Check that the lines from the previous step are rendered as headings
- copy the message to the clipboard and paste it into the composer (input text area)
- check that the message is parsed correctly and that the headings are pasted as lines starting with # and space

1. What areas to they need to test for regressions?
- Sending messages with all the markdowns should be tested to check that the markdown rules are applied correctly in different markdown combinations
- Copy-Paste the above messages to check that they are correctly converted back from html to markdown
