### PR TITLE
Allow new param, don't require old param.

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -762,10 +762,12 @@ export default function API(network, args) {
 
         card: {
             /**
-             * Set the limit of an expensify card
+             * Set the limit of an expensify card. We need to pass either `email` or `cardUserEmail`.
+             * `cardUserEmail` is correct, but email is still supported across the rollout to `cardUserEmail`.
              *
              * @param {Object} parameters
-             * @param {String} parameters.email who the card is assigned to
+             * @param {String} [parameters.email] who the card is assigned to
+             * @param {String} [parameters.cardUserEmail] who the card is assigned to
              * @param {Boolean} parameters.hasCustomLimit whether or not the card has a custom limit
              * @param {Number} [parameters.cardID]
              * @param {Number} [parameters.limit] should be in positive cents
@@ -775,7 +777,7 @@ export default function API(network, args) {
              */
             setLimit(parameters) {
                 const commandName = 'Card_setLimit';
-                requireParameters(['email', 'hasCustomLimit', 'domainName'], parameters, commandName);
+                requireParameters(['hasCustomLimit', 'domainName'], parameters, commandName);
                 return performPOSTRequest(commandName, parameters);
             },
         },


### PR DESCRIPTION
TAG_REVIEWER will you please review this?

Passing `email` as the cardholder's email instead of the logged-in user's email breaks the logging for this request.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/232931

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
