### PR TITLE
trim link title when convert markdown to html

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -394,7 +394,7 @@ test('Test markdown and url links with inconsistent starting and closing parens'
         + '[Text text] more text (<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link [square brackets within] here</a>)'
         + '[Text text] more text (<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link (parenthesis within) here</a>)'
         + '[Text text] more text <a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link here</a>'
-        + '[Text text] more text (<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link here  </a>)'
+        + '[Text text] more text (<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link here</a>)'
         + '[Text text] more text ((<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link here</a>))'
         + '[Text text] more text [(<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link here</a>)]'
         + '[Text text] more text (<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link here</a>)[Text text] more text (<a href="https://www.google.com" target="_blank" rel="noreferrer noopener">link here</a>)';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -87,7 +87,7 @@ export default class ExpensiMark {
                         return match;
                     }
 
-                    return `<a href="${g3 && g3.includes('http') ? '' : 'https://'}${g2}" target="_blank" rel="noreferrer noopener">${g1}</a>`;
+                    return `<a href="${g3 && g3.includes('http') ? '' : 'https://'}${g2}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
                 },
             },
 


### PR DESCRIPTION
@rushatgabhane @neil-marcellini will you please review this?

https://github.com/Expensify/expensify-common/blob/805a4c34debc7e27b14e33847ac4df4d59b6d878/lib/ExpensiMark.js#L68-L92
```diff
-                   return `<a href="${g3 && g3.includes('http') ? '' : 'https://'}${g2}" target="_blank" rel="noreferrer noopener">${g1}</a>`;
+                   return `<a href="${g3 && g3.includes('http') ? '' : 'https://'}${g2}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
```

### Fixed Issues
$ https://github.com/Expensify/App/issues/12511

# Tests
1. Login with any account
2. Go to any chat room
3. Send a link on markdown with trailing spaces for its URL title (for example, `[  test    ](google.com)`)
4. Verify that URL title is trimmed (for example, [test](google.com))

# QA
1. Login with any account
2. Go to any chat room
3. Send a link on markdown with trailing spaces for its URL title (for example, `[  test    ](google.com)`)
4. Verify that URL title is trimmed (for example, [test](google.com))

### Screenshots

#### Web

https://user-images.githubusercontent.com/97473779/201399364-36d05183-14ef-4aa4-bb70-122710056172.mov


#### Mobile Web - Chrome

https://user-images.githubusercontent.com/97473779/201399290-d82ed598-758e-4f4e-bd85-6520d7439b0a.mp4


#### Mobile Web - Safari

https://user-images.githubusercontent.com/97473779/201399313-b6f916ce-f857-4e95-b030-a91b4ef50f60.mp4


#### Desktop

https://user-images.githubusercontent.com/97473779/201399102-1251284b-5d64-4e5a-ab98-6e2189e94877.mov


#### iOS

https://user-images.githubusercontent.com/97473779/201399164-8ee475e2-8947-4f7f-924a-a92c04127c05.mp4


#### Android

https://user-images.githubusercontent.com/97473779/201399003-ea6f6321-02f6-47d2-b8a4-55394b907cd3.mp4



I have read the CLA Document and I hereby sign the CLA