### PR TITLE
Avoid duplicate empty line when converting header1 markdown to html

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -455,13 +455,13 @@ test('map real message with quotes', () => {
 
 test('Test heading1 markdown replacement', () => {
     const testString = '# This is a heading1 because starts with # followed by a space\n';
-    const resultString = '<h1>This is a heading1 because starts with # followed by a space</h1><br />';
+    const resultString = '<h1>This is a heading1 because starts with # followed by a space</h1>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test heading1 markdown replacement when # is followed by multiple spaces', () => {
     const testString = '#    This is also a heading1 because starts with # followed by a space\n';
-    const resultString = '<h1>This is also a heading1 because starts with # followed by a space</h1><br />';
+    const resultString = '<h1>This is also a heading1 because starts with # followed by a space</h1>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -478,7 +478,7 @@ test('Test heading1 markdown when # is in the middle of the line', () => {
 });
 
 test('Test html string to heading1 markdown', () => {
-    const testString = '<h1>This is a heading1</h1><br />';
+    const testString = '<h1>This is a heading1</h1>';
     const resultString = '\n# This is a heading1\n';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -164,7 +164,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /^#(?!#) +(.+)$/gm,
+                regex: /^#(?!#) +(.+)$\s*/gm,
                 replacement: '<h1>$1</h1>',
             },
             {


### PR DESCRIPTION
`<h1>` tags break the line anyway, there is no need to add a `<br />` when converting `#` markdown to html. This is needed to make header1 look nicer.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/238874

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
- there are automated tests added which check that the markdown converts to html as expected.

1. What tests did you perform that validates your changes worked?
- Link the `expensify-common` local repository by following [these steps](https://docs.google.com/document/d/1YJmMi9NjnstCAP2Ibo_IZdT2T16Res2jdhWr2WSrk50)
- Run the app
- Open any chat and send a custom subject message like following:
    `# Custom subject`
    `The message body`
- Check that there is no empty lines between the header and the message body
<img width="526" alt="Screenshot 2022-11-10 at 00 00 12" src="https://user-images.githubusercontent.com/18078393/200953370-593339e8-5a2b-4bda-9ca0-981d7977e1e6.png">


# QA
1. What does QA need to do to validate your changes?
- Run the app
- Open any chat and send a custom subject message like following:
    `# Custom subject`
    `The message body`
- Check that there is no empty lines between the header and the message body
<img width="526" alt="Screenshot 2022-11-10 at 00 00 12" src="https://user-images.githubusercontent.com/18078393/200953370-593339e8-5a2b-4bda-9ca0-981d7977e1e6.png">
