### PR TITLE
fix: export url website regex

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -577,3 +577,7 @@ export default class ExpensiMark {
         return replacedText;
     }
 }
+
+export {
+    URL_WEBSITE_REGEX
+}


### PR DESCRIPTION
@parasharrajat @MonilBhavsar 
I'll export URL_WEBSITE_REGEX from ExpensiMark

### Fixed Issues
$ https://github.com/Expensify/App/issues/11810

# Tests

# QA
