### PR TITLE
Remove tag on the first line of PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-TAG_REVIEWER will you please review this?
-
-[Explanation of the change or anything fishy that is going on]
+<!-- Add an explanation of the change or anything fishy that is going on -->
 
 ### Fixed Issues
 $ GH_LINK


### PR DESCRIPTION
Removes this
```
TAG_REVIEWER will you please review this?

[Explanation of the change or anything fishy that is going on]
```

### Fixed Issues
None, I just noticed this is outdated while submitting this PR https://github.com/Expensify/expensify-common/pull/476

# Tests
None

# QA
None