### PR TITLE
Correctly apply styles to email links

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -48,6 +48,32 @@ export default class ExpensiMark {
                 replacement: '$1<code>$2</code>$3',
             },
 
+            {
+                /**
+                 * Use \b in this case because it will match on words, letters,
+                 * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
+                 * The !_blank is to prevent the `target="_blank">` section of the
+                 * link replacement from being captured Additionally, something like
+                 * `\b\_([^<>]*?)\_\b` doesn't work because it won't replace
+                 * `_https://www.test.com_`
+                 */
+                name: 'italic',
+                regex: /(?!_blank")\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<em>$1</em>',
+            },
+            {
+                // Use \B in this case because \b doesn't match * or ~.
+                // \B will match everything that \b doesn't, so it works
+                // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
+                name: 'bold',
+                regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: (match, g1, g2) => (g1 ? match : `<strong>${g2}</strong>`),
+            },
+            {
+                name: 'strikethrough',
+                regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<del>$1</del>',
+            },
             /**
              * Converts markdown style links to anchor tags e.g. [Expensify](concierge@expensify.com)
              * We need to convert before the auto email link rule and the manual link rule since it will not try to create a link
@@ -115,32 +141,6 @@ export default class ExpensiMark {
                 replacement: (match, g1, g2, g3) => (
                     `${g1}<a href="${g3 && g3.includes('http') ? '' : 'https://'}${g2}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`
                 ),
-            },
-            {
-                /**
-                 * Use \b in this case because it will match on words, letters,
-                 * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
-                 * The !_blank is to prevent the `target="_blank">` section of the
-                 * link replacement from being captured Additionally, something like
-                 * `\b\_([^<>]*?)\_\b` doesn't work because it won't replace
-                 * `_https://www.test.com_`
-                 */
-                name: 'italic',
-                regex: /(?!_blank")\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: '<em>$1</em>',
-            },
-            {
-                // Use \B in this case because \b doesn't match * or ~.
-                // \B will match everything that \b doesn't, so it works
-                // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
-                name: 'bold',
-                regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (match, g1, g2) => (g1 ? match : `<strong>${g2}</strong>`),
-            },
-            {
-                name: 'strikethrough',
-                regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: '<del>$1</del>',
             },
             {
                 name: 'quote',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -47,7 +47,6 @@ export default class ExpensiMark {
                 regex: /(\B|_|)&#x60;(.*?\S.*?)&#x60;(\B|_|)(?![^<]*<\/pre>)/g,
                 replacement: '$1<code>$2</code>$3',
             },
-
             {
                 /**
                  * Use \b in this case because it will match on words, letters,
@@ -74,6 +73,7 @@ export default class ExpensiMark {
                 regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: '<del>$1</del>',
             },
+
             /**
              * Converts markdown style links to anchor tags e.g. [Expensify](concierge@expensify.com)
              * We need to convert before the auto email link rule and the manual link rule since it will not try to create a link

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -427,6 +427,7 @@ export default class ExpensiMark {
         let replacedText = '';
         let startIndex = 0;
 
+        replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
         while (match !== null) {
             // `match[1]` contains the text inside []. Text is already escaped due to the rules
             // that precede the link rule (eg, codeFence, inlineCodeBlock, email).

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -57,7 +57,8 @@ export default class ExpensiMark {
                 name: 'email',
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `/\[([^[\]]*)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_\`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]+)+)\)`, 'gim',);
+                        '\\[([^[\\]]*)]\\(([a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z]+?(\\.[a-zA-Z]+)+)\\)', 'gim'
+                    );
                     return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
                 },
 
@@ -425,7 +426,6 @@ export default class ExpensiMark {
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;
-        let abort = false;
 
         while (match !== null) {
             // `match[1]` contains the text inside []. Text is already escaped due to the rules
@@ -434,7 +434,7 @@ export default class ExpensiMark {
                 filterRules: ['bold', 'strikethrough', 'italic'],
                 shouldEscapeText: false,
             });
-            replacedText = replacedText.concat(replacement(match[0], linkText, match[2], match[3]));
+            replacedText = replacedText.concat(replacement(match[0], linkText, match[1]));
             startIndex = match.index + (match[0].length);
 
             // Now we move to the next match that the js regex found in the text

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -434,7 +434,7 @@ export default class ExpensiMark {
                 filterRules: ['bold', 'strikethrough', 'italic'],
                 shouldEscapeText: false,
             });
-            replacedText = replacedText.concat(replacement(match[0], linkText, match[1]));
+            replacedText = replacedText.concat(replacement(match[0], linkText, match[2]));
             startIndex = match.index + (match[0].length);
 
             // Now we move to the next match that the js regex found in the text

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -427,8 +427,9 @@ export default class ExpensiMark {
         let replacedText = '';
         let startIndex = 0;
 
-        replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
         while (match !== null) {
+            replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
+
             // `match[1]` contains the text inside []. Text is already escaped due to the rules
             // that precede the link rule (eg, codeFence, inlineCodeBlock, email).
             const linkText = this.replace(match[1], {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -68,11 +68,6 @@ export default class ExpensiMark {
                 regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: (match, g1, g2) => (g1 ? match : `<strong>${g2}</strong>`),
             },
-            {
-                name: 'strikethrough',
-                regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: '<del>$1</del>',
-            },
 
             /**
              * Converts markdown style links to anchor tags e.g. [Expensify](concierge@expensify.com)
@@ -141,6 +136,11 @@ export default class ExpensiMark {
                 replacement: (match, g1, g2, g3) => (
                     `${g1}<a href="${g3 && g3.includes('http') ? '' : 'https://'}${g2}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`
                 ),
+            },
+            {
+                name: 'strikethrough',
+                regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<del>$1</del>',
             },
             {
                 name: 'quote',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -47,27 +47,6 @@ export default class ExpensiMark {
                 regex: /(\B|_|)&#x60;(.*?\S.*?)&#x60;(\B|_|)(?![^<]*<\/pre>)/g,
                 replacement: '$1<code>$2</code>$3',
             },
-            {
-                /**
-                 * Use \b in this case because it will match on words, letters,
-                 * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
-                 * The !_blank is to prevent the `target="_blank">` section of the
-                 * link replacement from being captured Additionally, something like
-                 * `\b\_([^<>]*?)\_\b` doesn't work because it won't replace
-                 * `_https://www.test.com_`
-                 */
-                name: 'italic',
-                regex: /(?!_blank")\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: '<em>$1</em>',
-            },
-            {
-                // Use \B in this case because \b doesn't match * or ~.
-                // \B will match everything that \b doesn't, so it works
-                // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
-                name: 'bold',
-                regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (match, g1, g2) => (g1 ? match : `<strong>${g2}</strong>`),
-            },
 
             /**
              * Converts markdown style links to anchor tags e.g. [Expensify](concierge@expensify.com)
@@ -76,7 +55,12 @@ export default class ExpensiMark {
              */
             {
                 name: 'email',
-                regex: /\[([^[\]]*)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]+)+)\)/gim,
+                process: (textToProcess, replacement) => {
+                    const regex = new RegExp(
+                        `/\[([^[\]]*)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_\`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]+)+)\)`, 'gim',);
+                    return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
+                },
+
                 replacement: (match, g1, g2) => `<a href="mailto:${g2}">${g1.trim()}</a>`,
             },
 
@@ -136,6 +120,27 @@ export default class ExpensiMark {
                 replacement: (match, g1, g2, g3) => (
                     `${g1}<a href="${g3 && g3.includes('http') ? '' : 'https://'}${g2}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`
                 ),
+            },
+            {
+                /**
+                 * Use \b in this case because it will match on words, letters,
+                 * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
+                 * The !_blank is to prevent the `target="_blank">` section of the
+                 * link replacement from being captured Additionally, something like
+                 * `\b\_([^<>]*?)\_\b` doesn't work because it won't replace
+                 * `_https://www.test.com_`
+                 */
+                name: 'italic',
+                regex: /(?!_blank")\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<em>$1</em>',
+            },
+            {
+                // Use \B in this case because \b doesn't match * or ~.
+                // \B will match everything that \b doesn't, so it works
+                // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
+                name: 'bold',
+                regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: (match, g1, g2) => (g1 ? match : `<strong>${g2}</strong>`),
             },
             {
                 name: 'strikethrough',
@@ -404,6 +409,40 @@ export default class ExpensiMark {
             replacedText = replacedText.concat(textToCheck.substr(startIndex));
         }
 
+        return replacedText;
+    }
+
+    /**
+     * Checks matched Emails for validity and replace valid links with html elements
+     *
+     * @param {RegExp} regex
+     * @param {String} textToCheck
+     * @param {Function} replacement
+     *
+     * @returns {String}
+     */
+    modifyTextForEmailLinks(regex, textToCheck, replacement) {
+        let match = regex.exec(textToCheck);
+        let replacedText = '';
+        let startIndex = 0;
+        let abort = false;
+
+        while (match !== null) {
+            // `match[1]` contains the text inside []. Text is already escaped due to the rules
+            // that precede the link rule (eg, codeFence, inlineCodeBlock, email).
+            const linkText = this.replace(match[1], {
+                filterRules: ['bold', 'strikethrough', 'italic'],
+                shouldEscapeText: false,
+            });
+            replacedText = replacedText.concat(replacement(match[0], linkText, match[2], match[3]));
+            startIndex = match.index + (match[0].length);
+
+            // Now we move to the next match that the js regex found in the text
+            match = regex.exec(textToCheck);
+        }
+        if (startIndex < textToCheck.length) {
+            replacedText = replacedText.concat(textToCheck.substr(startIndex));
+        }
         return replacedText;
     }
 


### PR DESCRIPTION
cc @stitesExpensify 

There's a bit of duplicate code, but I thought this was better than an if/else where link and email handling share the code. I can be convinced otherwise, though

### Fixed Issues
$ https://github.com/Expensify/App/issues/13423

# Tests
1. Log into your account in NewDot and open a chat
2. Send `[my *web*](www.google.es)`
3. Confirm the word `web` is bold
4. Send `[my *email*](alberto@expensify.com)`
5. Confirm `email` is bold
6. Send `*[my email](alberto@expensify.com)*`
7. Confirm `my email` is bold

# QA
Same as tests
