### PR TITLE
Also filter out _blank with a negative look ahead to avoid em in links

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -337,6 +337,12 @@ test('Test markdown style email link with various styles', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test a url with multiple underscores', () => {
+    const testString = '[_example link_](https://www.facebook.com/hashtag/__main/?__eep__=6)';
+    const resultString = '<a href="https://www.facebook.com/hashtag/__main/?__eep__=6" target="_blank" rel="noreferrer noopener"><em>example link</em></a>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test general email link with various styles', () => {
     const testString = 'Go to concierge@expensify.com '
         + 'no-concierge@expensify.com '

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -126,7 +126,7 @@ export default class ExpensiMark {
                  * `_https://www.test.com_`
                  */
                 name: 'italic',
-                regex: /(?!_blank")\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /(?!_blank")\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>|_blank))/g,
                 replacement: '<em>$1</em>',
             },
             {


### PR DESCRIPTION
### Fixed Issues
https://github.com/Expensify/App/issues/13405

# Tests
1. Automated test added
2. Installed this on App
3. Sent a message with a link with two underscores `[_example link_](https://www.facebook.com/hashtag/__main/?__eep__=6)`
4. _Verified_ the underscores were not replaced
<img width="315" alt="image" src="https://user-images.githubusercontent.com/22447860/206810506-e2513bfa-4264-44d4-a52c-269812d8dd51.png">


# QA
1. N/a, part of the version bump prs