### PR TITLE
Allow numbers and dash in domain names

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -57,7 +57,7 @@ export default class ExpensiMark {
                 name: 'email',
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        '\\[([^[\\]]*)]\\(([a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z]+?(\\.[a-zA-Z]+)+)\\)', 'gim'
+                        '\\[([^[\\]]*)]\\(([a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9-]+?(\\.[a-zA-Z]+)+)\\)', 'gim'
                     );
                     return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
                 },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -55,7 +55,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'email',
-                regex: /\[([^[\]]*)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]+)+)\)/gim,
+                regex: /\[([^[\]]*)\]\(([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)\)/gim,
                 replacement: (match, g1, g2) => `<a href="mailto:${g2}">${g1.trim()}</a>`,
             },
 
@@ -91,7 +91,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'autoEmail',
-                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*)([_*~]*)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z]+?(\.[a-zA-Z]+)+)\2\1(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
+                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*)([_*~]*)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)\2\1(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
                 replacement: (match, g1, g2, g3) => `${g1}${g2}<a href="mailto:${g3}">${g3}</a>${g2}${g1}`,
             },
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/248976

# Tests
1. From newdot, send a message in a chat including an email address with numbers and dashes in the domain, like `alberto@exp3nsi-fy1.com`
2. Confirm it is displayed as a mailto link:
<img width="344" alt="Screenshot 2022-12-14 at 12 35 56 PM" src="https://user-images.githubusercontent.com/19366280/207585362-dcbc4c95-b30d-4860-a177-af519ad28793.png">

3. Now, do the same as a markup link: `[email](alberto@exp3nsi-fy1.com)`. 
4. Confirm it displays as a mailto link:
<img width="299" alt="Screenshot 2022-12-14 at 12 36 14 PM" src="https://user-images.githubusercontent.com/19366280/207585475-e98e5eea-6083-428b-9d78-aef38f1f4fc4.png">


# QA
Same as tests
