### PR TITLE
Don't require password as a param for SignIn

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -354,13 +354,14 @@ export default function API(network, args) {
         /**
          * @param {Object} parameters
          * @param {String} parameters.email
-         * @param {String} parameters.password
+         * @param {String} [parameters.password]
          * @param {String} [parameters.promoCode]
+         * @param {String} [parameters.validateCode]
          * @returns {APIDeferred}
          */
         signIn(parameters) {
             const commandName = 'SignIn';
-            requireParameters(['email', 'password'], parameters, commandName);
+            requireParameters(['email'], parameters, commandName);
             return performPOSTRequest(commandName, parameters);
         },
 


### PR DESCRIPTION
cc: @johnmlee101 

With our new authentication logic we don't always send passwords across when signing in, so remove that param as a requirement. 
 
### Fixed Issues
$ Tied to https://github.com/Expensify/Expensify/issues/249359

# Tests
Tested in https://github.com/Expensify/Web-Expensify/pull/35889

# QA
Tested in https://github.com/Expensify/Web-Expensify/pull/35889
