### PR TITLE
Parse multi-line bold and strikethrough markdown

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -43,6 +43,15 @@ test('Test strikethrough markdown replacement', () => {
     expect(parser.replace(strikethroughTestStartString)).toBe(strikethroughTestReplacedString);
 });
 
+
+// Multi-line text wrapped in ~ is successfully replaced with <del></del>
+test('Test multi-line strikethrough markdown replacement', () => {
+    const testString = '~Here is a multi-line\ncomment that should\nhave strikethrough applied~';
+    const replacedString = '<del>Here is a multi-line<br />comment that should<br />have strikethrough applied</del>';
+
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 // Markdown style links replaced successfully
 test('Test markdown style links', () => {
     const testString = 'Go to [Expensify](https://www.expensify.com) to learn more. [Expensify](www.expensify.com) [Expensify](expensify.com) [It\'s really the coolest](expensify.com) [`Some` Special cases - + . = , \'](expensify.com/some?query=par|am)';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -13,6 +13,14 @@ test('Test bold markdown replacement', () => {
     expect(parser.replace(boldTestStartString)).toBe(boldTestReplacedString);
 });
 
+// Multi-line text wrapped in * is successfully replaced with <strong></strong>
+test('Test multi-line bold markdown replacement', () => {
+    const testString = '*Here is a multi-line\ncomment that should\nbe bold*';
+    const replacedString = '<strong>Here is a multi-line<br />comment that should<br />be bold</strong>';
+
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 // Sections starting with > are successfully wrapped with <blockquote></blockquote>
 test('Test quote markdown replacement', () => {
     const quoteTestStartString = '&gt;This is a *quote* that started on a new line.\nHere is a &gt;quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -13,7 +13,7 @@ test('Test bold markdown replacement', () => {
     expect(parser.replace(boldTestStartString)).toBe(boldTestReplacedString);
 });
 
-// Words wrapped in * successfully replaced with <strong></strong>
+// Sections starting with > are successfully wrapped with <blockquote></blockquote>
 test('Test quote markdown replacement', () => {
     const quoteTestStartString = '&gt;This is a *quote* that started on a new line.\nHere is a &gt;quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
     const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted</pre>';

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -38,6 +38,13 @@ test('Test strikethrough HTML replacement', () => {
     expect(parser.htmlToMarkdown(strikethroughTestStartString)).toBe(strikethroughTestReplacedString);
 });
 
+test('Test multi-line strikethrough HTML replacement', () => {
+    const testString = '<del>Here is a multi-line<br />comment that should<br />have strikethrough applied</del>';
+    const replacedString = '~Here is a multi-line\ncomment that should\nhave strikethrough applied~';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
+});
+
 test('Test Mixed HTML strings', () => {
     const rawHTMLTestStartString = '<em>This is</em> a <strong>test</strong>. None of <h2>these strings</h2> should display <del>as</del> <div>HTML</div>.';
     const rawHTMLTestReplacedString = '_This is_ a *test*. None of \nthese strings\n should display ~as~ \nHTML\n.';

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -16,6 +16,13 @@ test('Test bold HTML replacement', () => {
     expect(parser.htmlToMarkdown(boldTestStartString)).toBe(boldTestReplacedString);
 });
 
+test('Test multi-line bold HTML replacement', () => {
+    const testString = '<strong>Here is a multi-line<br />comment that should<br />be bold</strong>';
+    const replacedString = '*Here is a multi-line\ncomment that should\nbe bold*';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
+});
+
 test('Test italic HTML replacement', () => {
     const italicTestStartString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _ '
         + 'This is a <i>sentence,</i> and it has some <i>punctuation, words, and spaces</i>. <i>test</i> _ testing_ test_test_test. _ test _ _test _';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -240,7 +240,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'bold',
-                regex: /<(b|strong)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(b|strong)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '*$2*',
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -140,8 +140,8 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /(<pre>|<code>|<a>)*\B\*((?!\s).*?\S)\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (match, g1, g2) => (g1 ? match : `<strong>${g2}</strong>`),
+                regex: /\B\*((?=\S)(([^\s*]|\s(?!\*))+?))\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: '<strong>$1</strong>',
             },
             {
                 name: 'strikethrough',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -245,7 +245,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'strikethrough',
-                regex: /<(del)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(del)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '~$2~',
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
### Details
In App we want to be able to send multi-line Markdown comments with **bold** or ~strikethrough~ style. Currently, only strikethrough works to send a multi-line comment, and neither works when editing the comment. I have added tests for both styles and I have updated the regexes (regi? 😂 ) to make all the tests pass.

I made the bold Markdown to html regex very similar to the one for strikethrough. Hopefully I didn't break any untested features in that process. Next, I modified the html to Markdown regexes to match everything inside the tags including whitespace.

@parasharrajat, @aimane-chnaif, @marcaaron I would love to have your eyes on this as well so I don't break anything.

### Related Issues
$ https://github.com/Expensify/App/issues/13727

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Idk what autoQA is, but here's the tests to run.
```
npm test -- __tests__/ExpensiMark-HTML-test.js
```
```
npm test -- __tests__/ExpensiMark-Markdown-test.js
```
2. What tests did you perform that validates your changed worked?
I have tested in the corresponding App PR https://github.com/Expensify/App/pull/14009.

# QA
1. What does QA need to do to validate your changes?
Run the QA in the App PR https://github.com/Expensify/App/pull/14009.
1. What areas to they need to test for regressions?
General Markdown parsing in App?
