### PR TITLE
Update CodeFence Regex to allow more edge case backticks

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -188,6 +188,9 @@ test('Test code fencing with additional backticks inside', () => {
     nestedBackticks = '````````';
     expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;&#x60;</pre>');
 
+    nestedBackticks = '````\n````';
+    expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;<br />&#x60;</pre>');
+
     nestedBackticks = '```````````';
     expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;&#x60;&#x60;&#x60;&#x60;</pre>');
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -178,6 +178,23 @@ test('Test code fencing with ExpensiMark syntax inside', () => {
     expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
 });
 
+test('Test code fencing with additional backticks inside', () => {
+    let nestedBackticks = '````test````';
+    expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;test&#x60;</pre>');
+
+    nestedBackticks = '````\ntest\n````';
+    expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;<br />test<br />&#x60;</pre>');
+
+    nestedBackticks = '````````';
+    expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;&#x60;</pre>');
+
+    nestedBackticks = '```````````';
+    expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;&#x60;&#x60;&#x60;&#x60;</pre>');
+
+    nestedBackticks = '````This is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)````';
+    expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)&#x60;</pre>');
+});
+
 test('Test combination replacements', () => {
     const urlTestStartString = '<em>Here</em> is a _combination test_ that <marquee>sees</marquee> if ~https://www.example.com~ https://otherexample.com links get rendered first followed by *other markup* or if _*two work together*_ as well. This sentence also has a newline \n Yep just had one.';
     const urlTestReplacedString = '&lt;em&gt;Here&lt;/em&gt; is a <em>combination test</em> that &lt;marquee&gt;sees&lt;/marquee&gt; if <del><a href="https://www.example.com" target="_blank" rel="noreferrer noopener">https://www.example.com</a></del> <a href="https://otherexample.com"'

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -383,6 +383,26 @@ test('Test HTML string with code fence', () => {
     expect(parser.htmlToMarkdown(testStringWithNewLinesFromSlack)).toBe(resultStringWithNewLinesFromSlack);
 });
 
+test('Test code fence and extra backticks', () => {
+    let nestedBackticks = '<pre>&#x60;test&#x60;</pre>';
+    expect(parser.htmlToMarkdown(nestedBackticks)).toBe('```\n`test`\n```');
+
+    nestedBackticks = '<pre>&#x60;<br />test<br />&#x60;</pre>';
+    expect(parser.htmlToMarkdown(nestedBackticks)).toBe('```\n`\ntest\n`\n```');
+
+    nestedBackticks = '<pre>&#x60;&#x60;</pre>';
+    expect(parser.htmlToMarkdown(nestedBackticks)).toBe('```\n``\n```');
+
+    nestedBackticks = '<pre>&#x60;<br />&#x60;</pre>';
+    expect(parser.htmlToMarkdown(nestedBackticks)).toBe('```\n`\n`\n```');
+
+    nestedBackticks = '<pre>&#x60;&#x60;&#x60;&#x60;&#x60;</pre>';
+    expect(parser.htmlToMarkdown(nestedBackticks)).toBe('```\n`````\n```');
+
+    nestedBackticks = '<pre>&#x60;This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)&#x60;</pre>';
+    expect(parser.htmlToMarkdown(nestedBackticks)).toBe('```\n`This is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)`\n```');
+});
+
 test('HTML Entities', () => {
     const testString = '&nbsp; &amp; &dollar; &colon; &gt; &quot;';
     const resultString = `${String.fromCharCode(160)} & $ : > "`;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -21,7 +21,7 @@ export default class ExpensiMark {
                 name: 'codeFence',
 
                 // &#60; is a backtick symbol we are matching on three of them before then after a new line character
-                regex: /(&#x60;&#x60;&#x60;[\n]?)((?:\s*?(?![\n]?&#x60;&#x60;&#x60;)[\S])+\s*?)([\n]?&#x60;&#x60;&#x60;)/g,
+                regex: /(&#x60;&#x60;&#x60;[\n]?)((?:\s*?(?![\n]?&#x60;&#x60;&#x60;(?!&#x60;))[\S])+\s*?)([\n]?&#x60;&#x60;&#x60;)/g,
 
                 // We're using a function here to perform an additional replace on the content
                 // inside the backticks because Android is not able to use <pre> tags and does


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
Updates the regex that looks for backticks to convert to `<pre>` tags in newDot chats. This change fixes the behavior for more than three backticks in a row. You can see the adjustments [here](https://github.com/Expensify/App/issues/14030#issuecomment-1375783961)

### Fixed Issues
$ https://github.com/Expensify/App/issues/14030

# Tests
1. Checked in the App, as well as separately, to make sure the new regex appropriately converted chats with backticks into html, both old and new patterns.

# QA
1. Open any chat in App
3. Send four backticks, a new line, and four more backticks.
4. No error should appear, sent chat should resemble:
```
`
`
```