### PR TITLE
Fix/14060: Bug: Link with multiline text loses markdown when edited

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -530,3 +530,9 @@ test('Test html to heading1 markdown when h1 tags are in the middle of the line'
     + 'in the middle of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
+
+test('Test link with multiline text do not loses markdown', () => {
+    const testString = '<a href="https://google.com/">multiline\ntext</a>';
+    const resultString = '[multiline\ntext](https://google.com/)'
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -267,7 +267,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'anchor',
-                regex: /<(a)[^><]*href\s*=\s*(['"])(.*?)\2(?:".*?"|'.*?'|[^'"><])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(a)[^><]*href\s*=\s*(['"])(.*?)\2(?:".*?"|'.*?'|[^'"><])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gis,
                 replacement: (match, g1, g2, g3, g4) => {
                     const email = g3.startsWith('mailto:') ? g3.slice(7) : '';
                     if (email === g4) {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -267,7 +267,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'anchor',
-                regex: /<(a)[^><]*href\s*=\s*(['"])(.*?)\2(?:".*?"|'.*?'|[^'"><])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gis,
+                regex: /<(a)[^><]*href\s*=\s*(['"])(.*?)\2(?:".*?"|'.*?'|[^'"><])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2, g3, g4) => {
                     const email = g3.startsWith('mailto:') ? g3.slice(7) : '';
                     if (email === g4) {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/14060

# Tests
1. Login with any account and go to any chat room
2. Send this message:
```
[multiline
text](https://google.com/)
```
3. Edit this message

# QA
1. Login with any account and go to any chat room
2. Send this message:
```
[multiline
text](https://google.com/)
```
3. Edit this message
4. Verify that when editing, the original message should be auto-filled
```
[multiline
text](https://google.com/)
```
