### PR TITLE
Preserve code fence line breaks and ensure backticks occupy a separate line

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -24,7 +24,7 @@ test('Test multi-line bold markdown replacement', () => {
 // Sections starting with > are successfully wrapped with <blockquote></blockquote>
 test('Test quote markdown replacement', () => {
     const quoteTestStartString = '&gt;This is a *quote* that started on a new line.\nHere is a &gt;quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted</pre>';
+    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
 
     expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
 });
@@ -118,10 +118,10 @@ test('Test period replacements', () => {
 
 test('Test code fencing', () => {
     let codeFenceExampleMarkdown = '```\nconst javaScript = \'javaScript\'\n```';
-    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
+    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br /></pre>');
 
     codeFenceExampleMarkdown = '```const javaScript = \'javaScript\'\n```';
-    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
+    expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br /></pre>');
 
     codeFenceExampleMarkdown = '```\nconst javaScript = \'javaScript\'```';
     expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;</pre>');
@@ -132,10 +132,10 @@ test('Test code fencing', () => {
 
 test('Test code fencing with spaces and new lines', () => {
     let codeFenceExample = '```\nconst javaScript = \'javaScript\'\n    const php = \'php\'\n```';
-    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
+    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;<br /></pre>');
 
     codeFenceExample = '```const javaScript = \'javaScript\'\n    const php = \'php\'\n```';
-    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
+    expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;<br /></pre>');
 
     codeFenceExample = '```\nconst javaScript = \'javaScript\'\n    const php = \'php\'```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
@@ -166,10 +166,10 @@ test('Test inline code blocks inside ExpensiMark', () => {
 
 test('Test code fencing with ExpensiMark syntax inside', () => {
     let codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
-    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
+    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)<br /></pre>');
 
     codeFenceExample = '```This is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
-    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
+    expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)<br /></pre>');
 
     codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -533,7 +533,7 @@ test('Test html to heading1 markdown when h1 tags are in the middle of the line'
 
 test('Test link with multiline text do not loses markdown', () => {
     const testString = '<a href="https://google.com/">multiline\ntext</a>';
-    const resultString = '[multiline\ntext](https://google.com/)'
+    const resultString = '[multiline\ntext](https://google.com/)';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
@@ -559,4 +559,15 @@ test('Test list item replacement when there is an anchor tag inside <li> tag', (
     const testString = '<ul><li><a href="https://example.com">Coffee</a> -- Coffee</li><li><a href="https://example.com">Tea</a> -- Tea</li><li><a href="https://example.com">Milk</a> -- Milk</li></ul>';
     const resultString = '  [Coffee](https://example.com) -- Coffee\n  [Tea](https://example.com) -- Tea\n  [Milk](https://example.com) -- Milk';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test codeFence backticks occupying a separate line while not introducing redundant lines', () => {
+    let testInput = '<pre>test</pre>';
+    expect(parser.htmlToMarkdown(testInput)).toBe('```\ntest\n```');
+
+    testInput = '<pre>\ntest\n</pre>';
+    expect(parser.htmlToMarkdown(testInput)).toBe('```\ntest\n```');
+
+    testInput = '<pre>test\n\n</pre>';
+    expect(parser.htmlToMarkdown(testInput)).toBe('```\ntest\n\n```');
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -21,7 +21,7 @@ export default class ExpensiMark {
                 name: 'codeFence',
 
                 // &#60; is a backtick symbol we are matching on three of them before then after a new line character
-                regex: /(&#x60;&#x60;&#x60;[\n]?)((?:\s*?(?![\n]?&#x60;&#x60;&#x60;(?!&#x60;))[\S])+\s*?)([\n]?&#x60;&#x60;&#x60;)/g,
+                regex: /(&#x60;&#x60;&#x60;[\n]?)((?:\s*?(?![\n]?&#x60;&#x60;&#x60;(?!&#x60;))[\S])+\s*?)((?=\n?)&#x60;&#x60;&#x60;)/g,
 
                 // We're using a function here to perform an additional replace on the content
                 // inside the backticks because Android is not able to use <pre> tags and does
@@ -267,8 +267,8 @@ export default class ExpensiMark {
             },
             {
                 name: 'codeFence',
-                regex: /<(pre)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
-                replacement: '```\n$2\n```',
+                regex: /<(pre)(?:"[^"]*"|'[^']*'|[^'">])*>(\n?)([\s\S]*?)(\n?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: (match, g1, g2, g3, g4) => `\`\`\`${g2 || '\n'}${g3}${g4 || '\n'}\`\`\``,
             },
             {
                 name: 'anchor',


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/14694

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

The change updates the tests in `ExpensiMark-HTML-test.js`, which depended on the previous incorrect behavior (i.e., the line break was always stripped). It also introduces a new test in `ExpensiMark-Markdown-test.js`, which validates the behavior described in the test, which was not covered by existing tests.


# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?

## Steps (validation + regressions)
1. Add a comment:
````
```
text

```
````
2. Verify that it has an empty line below `text` once added.
3. Edit it and check that it looks the same as 1.
4. Repeat 1-3 for the below, but instead, make sure that it has no added line below `text`:
````
```
text
```
````
https://user-images.githubusercontent.com/47689923/216426911-e27bce9b-457e-4b9f-9e81-89ee82fac659.mp4
