### PR TITLE
Fix/14670 sending multiline messages with 1st line as h1 and 2nd line regular, both lines appears in the LHN

### DIFF
--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -44,6 +44,60 @@ test('Test new line replacement on blockquote without content after closing bloc
     expect(parser.htmlToText(html)).toBe(text);
 });
 
+test('Test new line replacement on heading without content before heading', () => {
+    const html = '<h1>Confusing stuff</h1>Tell me about it';
+
+    // No new line should be added for <h1> if there is no content before it
+    const text = 'Confusing stuff\nTell me about it';
+
+    expect(parser.htmlToText(html)).toBe(text);
+});
+
+test('Test new line replacement on heading with content before heading', () => {
+    const html = 'content before<h1>Confusing stuff</h1>Tell me about it';
+
+    // A new line should be added for <h1> if there is content before it
+    const text = 'content before\nConfusing stuff\nTell me about it';
+
+    expect(parser.htmlToText(html)).toBe(text);
+});
+
+test('Test new line replacement on heading without content after closing heading', () => {
+    const html = 'content before<h1>Confusing stuff</h1>';
+
+    // No new line should be added after </h1> because there is no content after it
+    const text = 'content before\nConfusing stuff';
+
+    expect(parser.htmlToText(html)).toBe(text);
+});
+
+test('Test new line replacement on preformatted text without content before preformatted text', () => {
+    const html = '<pre>Confusing stuff</pre>Tell me about it';
+
+    // No new line should be added for <pre> if there is no content before it
+    const text = 'Confusing stuff\nTell me about it';
+
+    expect(parser.htmlToText(html)).toBe(text);
+});
+
+test('Test new line replacement on preformatted text with content before preformatted text', () => {
+    const html = 'content before<pre>Confusing stuff</pre>Tell me about it';
+
+    // A new line should be added for <pre> if there is content before it
+    const text = 'content before\nConfusing stuff\nTell me about it';
+
+    expect(parser.htmlToText(html)).toBe(text);
+});
+
+test('Test new line replacement on preformatted text without content after closing preformatted text', () => {
+    const html = 'content before<pre>Confusing stuff</pre>';
+
+    // No new line should be added after </pre> because there is no content after it
+    const text = 'content before\nConfusing stuff';
+
+    expect(parser.htmlToText(html)).toBe(text);
+});
+
 test('Test strip unhandled tags', () => {
     const html = 'First Line<br /><div>Quoted line <code>code</code></div>3<br /><span>4</span>Five';
 
@@ -54,8 +108,8 @@ test('Test strip unhandled tags', () => {
 });
 
 test('Test replacement on mixed html', () => {
-    const html = 'First Line<br /><blockquote>Quoted line <code>code</code></blockquote>3<br /><blockquote>4</blockquote><span>Five</span>';
-    const text = 'First Line\n\nQuoted line code\n3\n\n4\nFive';
+    const html = 'First Line<br /><blockquote>Quoted line <code>code</code></blockquote>3<br /><blockquote>4</blockquote><span>Five</span><h1>Six</h1>Seven<pre>Eight</pre>';
+    const text = 'First Line\n\nQuoted line code\n3\n\n4\nFive\nSix\nSeven\nEight';
 
     expect(parser.htmlToText(html)).toBe(text);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -295,14 +295,14 @@ export default class ExpensiMark {
                 replacement: '\n',
             },
             {
-                name: 'blockquoteopen',
-                regex: /(.|\s)(<blockquote>)/gi,
+                name: 'blockElementOpen',
+                regex: /(.|\s)<(blockquote|h1|pre)>/gi,
                 replacement: '$1\n',
             },
             {
-                name: 'blockquote',
-                regex: /<\/blockquote>(.|\s)/gm,
-                replacement: '\n$1',
+                name: 'blockElementClose',
+                regex: /<\/(blockquote|h1|pre)>(.|\s)/gm,
+                replacement: '\n$2',
             },
             {
                 name: 'stripTag',


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/14670
Proposal: https://github.com/Expensify/App/issues/14670#issuecomment-1413011449

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

The change updates the tests in `ExpensiMark-HTMLToText-test.js`. The new tests cover "Test new line replacement on heading" and "Test new line replacement on preformatted text" cases (Similiar to what was implemented "Test new line replacement on blockquote").

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?

### Steps
1. Open the app 
2. Turn off the internet (because the solution has just been implemented in front-end side)
3. Open any chat
4. Send bold text using # and normal text on next line
5. Verify that only first line of the messages is visible in the LHN

https://user-images.githubusercontent.com/113963320/217195906-14857c40-0cb5-4a66-8688-3a13ad61b2e4.mp4

