### PR TITLE
Fix incorrect text being displayed when an option exists

### DIFF
--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -385,9 +385,14 @@ class Combobox extends React.Component {
     /**
      * Hard sets the current text to what we want
      *
-     * @param {String} currentText
+     * @param {String} val
      */
-    setText(currentText) {
+    setText(val) {
+        // See if there is a value in the options that matches the text we want to set. If the option
+        // does exist, then use the text property of that option for the text to display. If the option
+        // does not exist, then just display whatever value was passed
+        const optionMatchingVal = _.findWhere(this.options, {value: val});
+        const currentText = get(optionMatchingVal, 'text', val);
         this.initialValue = currentText;
         this.initialText = currentText;
         this.setState({currentText});


### PR DESCRIPTION
### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/260640

# Tests
1. Add this tag to a policy: `Corporate : OOO Cost Center`
2. Create an expense with that tag
3. Open up the expense to edit it from the expenses page
4. Verify that the name of the tag doesn't have a backslash in front of the colon and verify that the tag field is not red (which would indicate the tag couldn't be found in the policy)

# QA
Same as above
