### PR TITLE
Fixes italic markdown to match newline and adds tests

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -13,6 +13,14 @@ test('Test bold markdown replacement', () => {
     expect(parser.replace(boldTestStartString)).toBe(boldTestReplacedString);
 });
 
+// Multi-line text wrapped in _ is successfully replaced with <em></em>
+test('Test multi-line italic markdown replacement', () => {
+    const testString = '_Here is a multi-line\ncomment that should\nbe italic_';
+    const replacedString = '<em>Here is a multi-line<br />comment that should<br />be italic</em>';
+
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 // Multi-line text wrapped in * is successfully replaced with <strong></strong>
 test('Test multi-line bold markdown replacement', () => {
     const testString = '*Here is a multi-line\ncomment that should\nbe bold*';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -13,14 +13,6 @@ test('Test bold markdown replacement', () => {
     expect(parser.replace(boldTestStartString)).toBe(boldTestReplacedString);
 });
 
-// Multi-line text wrapped in _ is successfully replaced with <em></em>
-test('Test multi-line italic markdown replacement', () => {
-    const testString = '_Here is a multi-line\ncomment that should\nbe italic_';
-    const replacedString = '<em>Here is a multi-line<br />comment that should<br />be italic</em>';
-
-    expect(parser.replace(testString)).toBe(replacedString);
-});
-
 // Multi-line text wrapped in * is successfully replaced with <strong></strong>
 test('Test multi-line bold markdown replacement', () => {
     const testString = '*Here is a multi-line\ncomment that should\nbe bold*';
@@ -42,6 +34,14 @@ test('Test italic markdown replacement', () => {
     const italicTestStartString = 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _';
     const italicTestReplacedString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _';
     expect(parser.replace(italicTestStartString)).toBe(italicTestReplacedString);
+});
+
+// Multi-line text wrapped in _ is successfully replaced with <em></em>
+test('Test multi-line italic markdown replacement', () => {
+    const testString = '_Here is a multi-line\ncomment that should\nbe italic_';
+    const replacedString = '<em>Here is a multi-line<br />comment that should<br />be italic</em>';
+
+    expect(parser.replace(testString)).toBe(replacedString);
 });
 
 // Words wrapped in ~ successfully replaced with <del></del>

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -23,6 +23,13 @@ test('Test multi-line bold HTML replacement', () => {
     expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
 });
 
+test('Test multi-line italic HTML replacement', () => {
+    const testString = '<em>Here is a multi-line<br />comment that should<br />be italic</em>';
+    const replacedString = '_Here is a multi-line\ncomment that should\nbe italic_';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
+});
+
 test('Test italic HTML replacement', () => {
     const italicTestStartString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _ '
         + 'This is a <i>sentence,</i> and it has some <i>punctuation, words, and spaces</i>. <i>test</i> _ testing_ test_test_test. _ test _ _test _';

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -23,19 +23,19 @@ test('Test multi-line bold HTML replacement', () => {
     expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
 });
 
-test('Test multi-line italic HTML replacement', () => {
-    const testString = '<em>Here is a multi-line<br />comment that should<br />be italic</em>';
-    const replacedString = '_Here is a multi-line\ncomment that should\nbe italic_';
-
-    expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
-});
-
 test('Test italic HTML replacement', () => {
     const italicTestStartString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _ '
         + 'This is a <i>sentence,</i> and it has some <i>punctuation, words, and spaces</i>. <i>test</i> _ testing_ test_test_test. _ test _ _test _';
     const italicTestReplacedString = 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _ '
         + 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _';
     expect(parser.htmlToMarkdown(italicTestStartString)).toBe(italicTestReplacedString);
+});
+
+test('Test multi-line italic HTML replacement', () => {
+    const testString = '<em>Here is a multi-line<br />comment that should<br />be italic</em>';
+    const replacedString = '_Here is a multi-line\ncomment that should\nbe italic_';
+
+    expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
 });
 
 // Words wrapped in ~ successfully replaced with <del></del>

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -129,9 +129,10 @@ export default class ExpensiMark {
                  * link replacement from being captured Additionally, something like
                  * `\b\_([^<>]*?)\_\b` doesn't work because it won't replace
                  * `_https://www.test.com_`
+                 * Use [\s\S]* instead of .* to match newline
                  */
                 name: 'italic',
-                regex: /(?!_blank")\b_((?!\s).*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>|_blank))/g,
+                regex: /(?!_blank")\b_((?!\s)[\s\S]*?\S)_\b(?![^<]*(<\/pre>|<\/code>|<\/a>|_blank))/g,
                 replacement: '<em>$1</em>',
             },
             {
@@ -237,9 +238,10 @@ export default class ExpensiMark {
                 regex: /\s*<(li)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
                 replacement: '<li>  $2</li>',
             },
+            // Use [\s\S]* instead of .* to match newline
             {
                 name: 'italic',
-                regex: /<(em|i)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(em|i)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '_$2_',
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -238,7 +238,7 @@ export default class ExpensiMark {
                 regex: /\s*<(li)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
                 replacement: '<li>  $2</li>',
             },
-            
+
             // Use [\s\S]* instead of .* to match newline
             {
                 name: 'italic',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -238,6 +238,7 @@ export default class ExpensiMark {
                 regex: /\s*<(li)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
                 replacement: '<li>  $2</li>',
             },
+            
             // Use [\s\S]* instead of .* to match newline
             {
                 name: 'italic',


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on @neil-marcellini @eVoloshchak -->
@neil-marcellini @eVoloshchak please take a look.

Markdown symbols like `*text*`, `~text~` or `_text_` should match text with newlines.
Bold and strikethrough markdown have been fixed here https://github.com/Expensify/expensify-common/pull/486
this PR adds fix for italic text `_text_` and corresponding tests

### Fixed Issues
$ https://github.com/Expensify/App/issues/14675

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
```
npm test -- __tests__/ExpensiMark-HTML-test.js
```
```
npm test -- __tests__/ExpensiMark-Markdown-test.js
```
1. What tests did you perform that validates your changed worked?
tested on native and web
<details>
<summary>ios</summary>
<img width="432" alt="Screenshot 2023-02-15 06 05 23" src="https://user-images.githubusercontent.com/3872759/218899007-b9460695-d1d2-4f69-aa81-e2bd75b3f919.png">
</details>
<details>
<summary>ios web</summary>
<img width="430" alt="Screenshot 2023-02-15 06 14 25" src="https://user-images.githubusercontent.com/3872759/218900160-6645774e-af9c-4a69-b60b-cddee9746d2c.png">
</details>
<details>
<summary>android</summary>
<img width="385" alt="Screenshot 2023-02-15 06 33 40" src="https://user-images.githubusercontent.com/3872759/218904769-4555dc78-e5be-4a01-b323-858f07a59ea5.png">

</details>
<details>
<summary>android web</summary>
<img width="385" alt="Screenshot 2023-02-15 06 29 41" src="https://user-images.githubusercontent.com/3872759/218902728-531b2dc1-ffc3-4711-af76-5b8cf81bf479.png">
</details>
<details>
<summary>web</summary>
<img width="509" alt="Screenshot 2023-02-15 06 10 41" src="https://user-images.githubusercontent.com/3872759/218899415-278e9cae-95e7-4cee-957d-a3dbb365f7a5.png">
</details>


# QA
1. What does QA need to do to validate your changes?
Changes should be validated in App
1. What areas to they need to test for regressions?
Markdown italic in composer
