### PR TITLE
fix line break handling for HTML h1 to markdown conversion

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -513,13 +513,20 @@ test('Test heading1 markdown when # is in the middle of the line', () => {
 
 test('Test html string to heading1 markdown', () => {
     const testString = '<h1>This is a heading1</h1>';
-    const resultString = '\n# This is a heading1\n';
+    const resultString = '# This is a heading1';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test html to heading1 markdown when there are other tags inside h1 tag', () => {
     const testString = '<h1>This is a <strong>heading1</strong></h1>';
-    const resultString = '\n# This is a *heading1*\n';
+    const resultString = '# This is a *heading1*';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test html to heading1 markdown when h1 tag is in the beginning of the line', () => {
+    const testString = '<h1>heading1</h1> in the beginning of the line';
+    const resultString = '# heading1\n'
+    + 'in the beginning of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
@@ -528,6 +535,29 @@ test('Test html to heading1 markdown when h1 tags are in the middle of the line'
     const resultString = 'this line has a\n'
     + '# heading1\n'
     + 'in the middle of the line';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test html to heading1 markdown when h1 tag is in the end of the line', () => {
+    const testString = 'this line has an h1 in the end of the line<h1>heading1</h1>';
+    const resultString = 'this line has an h1 in the end of the line'
+    + '\n# heading1';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test html to heading1 markdown when there are 2 h1 tags in the line', () => {
+    const testString = 'this is the first heading1<h1>heading1</h1>this is the second heading1<h1>heading1</h1>';
+    const resultString = 'this is the first heading1'
+    + '\n# heading1'
+    + '\nthis is the second heading1'
+    + '\n# heading1';
+    expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+});
+
+test('Test html to heading1 markdown when there are adjacent h1 tags in the line', () => {
+    const testString = '<h1>heading1</h1><h1>heading2</h1>';
+    const resultString = '# heading1'
+    + '\n# heading2';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -230,7 +230,7 @@ export default class ExpensiMark {
             {
                 name: 'heading1',
                 regex: /\s*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
-                replacement: '\n# $2\n',
+                replacement: '[block]# $2[block]',
             },
             {
                 name: 'listItem',


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/14668

# Tests
1. Open a chat and send this message
   ```text
   # heading
   ```
2. Edit the sent message and verify it's displayed in one line in editing mode
3. Edit and change the sent message to
   ```text
   # heading test
   ```
   and save it
4. Verify the edited header bold text is still displayed in one line

# QA
Same as above tests

Video demo


https://user-images.githubusercontent.com/117511920/218988451-5acc3f56-8e9f-4f45-89e5-734b293436ca.mov

