### PR TITLE
Fix/14941 whitespace above block quotes is stripped away

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -457,7 +457,7 @@ test('Test markdown and url links with inconsistent starting and closing parens'
 test('Test quotes markdown replacement with text matching inside and outside codefence without spaces', () => {
     const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\n```\nThe next line should not be quoted\n&gt;Hello,I’mtext\nsince its inside a codefence```';
 
-    const resultString = 'The next line should be quoted<blockquote>Hello,I’mtext</blockquote><pre>The&#32;next&#32;line&#32;should&#32;not&#32;be&#32;quoted<br />&gt;Hello,I’mtext<br />since&#32;its&#32;inside&#32;a&#32;codefence</pre>';
+    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote><pre>The&#32;next&#32;line&#32;should&#32;not&#32;be&#32;quoted<br />&gt;Hello,I’mtext<br />since&#32;its&#32;inside&#32;a&#32;codefence</pre>';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -465,7 +465,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence at the same line', () => {
     const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\nThe next line should not be quoted\n```&gt;Hello,I’mtext```\nsince its inside a codefence';
 
-    const resultString = 'The next line should be quoted<blockquote>Hello,I’mtext</blockquote>The next line should not be quoted <pre>&gt;Hello,I’mtext</pre>since its inside a codefence';
+    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted <pre>&gt;Hello,I’mtext</pre>since its inside a codefence';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -473,7 +473,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence at the end of the text', () => {
     const testString = 'The next line should be quoted\n&gt;Hello,I’mtext\nThe next line should not be quoted\n```&gt;Hello,I’mtext```';
 
-    const resultString = 'The next line should be quoted<blockquote>Hello,I’mtext</blockquote>The next line should not be quoted <pre>&gt;Hello,I’mtext</pre>';
+    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted <pre>&gt;Hello,I’mtext</pre>';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -481,7 +481,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence with quotes at the end of the text', () => {
     const testString = 'The next line should be quoted\n```&gt;Hello,I’mtext```\nThe next line should not be quoted\n&gt;Hello,I’mtext';
 
-    const resultString = 'The next line should be quoted <pre>&gt;Hello,I’mtext</pre>The next line should not be quoted<blockquote>Hello,I’mtext</blockquote>';
+    const resultString = 'The next line should be quoted <pre>&gt;Hello,I’mtext</pre>The next line should not be quoted<br /><blockquote>Hello,I’mtext</blockquote>';
 
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -184,11 +184,6 @@ export default class ExpensiMark {
                 regex: /<br\s*[/]?><pre>\s*/gi,
                 replacement: ' <pre>',
             },
-            {
-                name: 'replacebrquote',
-                regex: /<br\s*[/]?><blockquote>\s*/gi,
-                replacement: '<blockquote>',
-            },
         ];
 
         /**


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/14941

# Tests
## For all platforms
1, Compose a message like this:
```
normal text

> quote text

normal text
```
2, Post the message
3, Edit the message you posted
4, Verify that there is a blank line (and an even amount of space) above and below the block quote. The same message you sent in step 1 is shown in the editor

## Additional test for IOS and Android (to ensure there is no regression bug created by the PR)
1, Compose a message like this:
```
normal text
> quote text
normal text
```
2, Post the message
3, Verify that there is no extra space displayed when used non-quoted and quoted than non-quoted text

# QA
## For all platforms
1, Compose a message like this:
```
normal text

> quote text

normal text
```
2, Post the message
3, Edit the message you posted
4, Verify that there is a blank line (and an even amount of space) above and below the block quote. The same message you sent in step 1 is shown in the editor

## Additional test for IOS and Android (to ensure there is no regression bug created by the PR)
1, Compose a message like this:
```
normal text
> quote text
normal text
```
2, Post the message
3, Verify that there is no extra space displayed when used non-quoted and quoted than non-quoted text

### Screenshots/Videos
<details>
<summary>Web</summary>


https://user-images.githubusercontent.com/113963320/220953771-3d7338a7-1708-438a-8ba6-0c0134caa35d.mp4



</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/113963320/220953809-d08526ba-467f-4e26-8dd7-114fd15ae32a.mp4



</details>

<details>
<summary>Mobile Web - Safari</summary>

https://user-images.githubusercontent.com/113963320/220953844-3f9d3e04-62de-47b8-abcd-d34c19bbcbc1.mp4



</details>

<details>
<summary>Desktop</summary>


https://user-images.githubusercontent.com/113963320/220953882-c82dd006-f925-4d3e-ae3e-6e1c4880d95d.mp4





</details>

<details>
<summary>iOS</summary>


https://user-images.githubusercontent.com/113963320/220953907-aff74a22-6f07-42aa-95d2-d2b84b07efa4.mp4



</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/113963320/220953932-57c20672-0f13-4382-b6c2-b7630752cc60.mp4



</details>
