### PR TITLE
Strip ~_* from multi-line auto-emails

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -60,6 +60,59 @@ test('Test multi-line strikethrough markdown replacement', () => {
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
+// Emails containing *_~ are successfully wrapped in a mailto anchor tag
+test('Test markdown replacement for emails containing bold/strikethrough/italic', () => {
+    let testInput = 'a~b@gmail.com';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a~b@gmail.com">a~b@gmail.com</a>');
+
+    testInput = 'a*b@gmail.com';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a*b@gmail.com">a*b@gmail.com</a>');
+
+    testInput = 'a_b@gmail.com';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a_b@gmail.com">a_b@gmail.com</a>');
+
+    testInput = 'a~*_b@gmail.com';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a~*_b@gmail.com">a~*_b@gmail.com</a>');
+});
+
+// Single-line emails wrapped in *_~ are successfully wrapped in a mailto anchor tag
+test('Test markdown replacement for emails wrapped in bold/strikethrough/italic in a single line', () => {
+    let testInput = '~abc@gmail.com~';
+    expect(parser.replace(testInput)).toBe('<del><a href="mailto:abc@gmail.com">abc@gmail.com</a></del>');
+
+    testInput = '*abc@gmail.com*';
+    expect(parser.replace(testInput)).toBe('<strong><a href="mailto:abc@gmail.com">abc@gmail.com</a></strong>');
+
+    testInput = '_abc@gmail.com_';
+    expect(parser.replace(testInput)).toBe('<em><a href="mailto:abc@gmail.com">abc@gmail.com</a></em>');
+
+    testInput = '~*_abc@gmail.com_*~';
+    expect(parser.replace(testInput)).toBe('<del><strong><em><a href="mailto:abc@gmail.com">abc@gmail.com</a></em></strong></del>');
+});
+
+// Multi-line emails wrapped in *_~ are successfully wrapped in a mailto anchor tag
+test('Test markdown replacement for emails wrapped in bold/strikethrough/italic in multi-line', () => {
+    let testInput = '~abc@gmail.com\ndef@gmail.com~';
+    let result = '<del><a href="mailto:abc@gmail.com">abc@gmail.com</a><br />'
+        + '<a href="mailto:def@gmail.com">def@gmail.com</a></del>';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '*abc@gmail.com\ndef@gmail.com*';
+    result = '<strong><a href="mailto:abc@gmail.com">abc@gmail.com</a><br />'
+        + '<a href="mailto:def@gmail.com">def@gmail.com</a></strong>';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '_abc@gmail.com\ndef@gmail.com_';
+    result = '<em><a href="mailto:abc@gmail.com">abc@gmail.com</a><br />'
+        + '<a href="mailto:def@gmail.com">def@gmail.com</a></em>';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '~*_abc@gmail.com\ndef@gmail.com_*~';
+    result = '<del><strong><em><a href="mailto:abc@gmail.com">abc@gmail.com</a><br />'
+        + '<a href="mailto:def@gmail.com">def@gmail.com</a></em></strong></del>';
+    expect(parser.replace(testInput)).toBe(result);
+});
+
 // Markdown style links replaced successfully
 test('Test markdown style links', () => {
     const testString = 'Go to [Expensify](https://www.expensify.com) to learn more. [Expensify](www.expensify.com) [Expensify](expensify.com) [It\'s really the coolest](expensify.com) [`Some` Special cases - + . = , \'](expensify.com/some?query=par|am)';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -93,8 +93,7 @@ export default class ExpensiMark {
             /**
              * Automatically links emails that are not in a link. Runs before the autolinker as it will not link an
              * email that is in a link
-             * Prevent emails from starting with [~_*] (such emails should not be supported), which is the reliable
-             * way to strip any enclosing ~_* in multi-line emails and in general.
+             * Prevent emails from starting with [~_*]. Such emails should not be supported.
              */
             {
                 name: 'autoEmail',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -93,11 +93,13 @@ export default class ExpensiMark {
             /**
              * Automatically links emails that are not in a link. Runs before the autolinker as it will not link an
              * email that is in a link
+             * Prevent emails from starting with [~_*] (such emails should not be supported), which is the reliable
+             * way to strip any enclosing ~_* in multi-line emails and in general.
              */
             {
                 name: 'autoEmail',
-                regex: /(?![^<]*>|[^<>]*<\\)([_*~]*)([_*~]*)([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)\2\1(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
-                replacement: (match, g1, g2, g3) => `${g1}${g2}<a href="mailto:${g3}">${g3}</a>${g2}${g1}`,
+                regex: /(?![^<]*>|[^<>]*<\\)([a-zA-Z0-9.!#$%&'+/=?^`{|}-][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
+                replacement: '<a href="mailto:$1">$1</a>',
             },
 
             /**


### PR DESCRIPTION
Reviewers: @thesahindia @NikkiWines
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/14695

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?

The tests below are in `ExpensiMark-HTML-test.js`:
- Test covering new changes:
  - `Test markdown replacement for emails wrapped in bold/strikethrough/italic in multi-line`
- Tests covering current behavior:
  - `Test markdown replacement for emails wrapped in bold/strikethrough/italic in a single line`
  - `Test markdown replacement for emails containing bold/strikethrough/italic`


1. What tests did you perform that validates your changed worked?

Same as QA.


# QA
1. What does QA need to do to validate your changes?

    1. Add the below as a new comment (paste as plain text):
    ```
    ~abc@gmail.com
    def@gmail.com~
    _abc@gmail.com
    def@gmail.com_
    *abc@gmail.com
    def@gmail.com*
    ```
    3. Verify that it looks like the screenshot
    4. Edit the comment and verify that it is the same as the input.


1. What areas to they need to test for regressions?

    1. Add the below as a new comment (paste as plain text):
    ```
    ~abc@gmail.com~
    *abc@gmail.com*
    _abc@gmail.com_
    a~b@gmail.com
    a*b@gmail.com
    a_b@gmail.com
    ```
    2. Verify that it looks like the screenshot
    3. Edit the comment and verify that it is the same as the input.

![desktop-chrome](https://user-images.githubusercontent.com/47689923/220735363-b5fa3048-418d-4c58-bf54-b086ac23734c.png)


