### PR TITLE
Ignore heading markup if the line is just whitespaces

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -164,7 +164,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /^#(?!#) ++(.+)$\s*/gm,
+                regex: /^#(?!#) +(?! )(.+)$\s*/gm,
                 replacement: '<h1>$1</h1>',
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -164,7 +164,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /^#(?!#) +(.+)$\s*/gm,
+                regex: /^#(?!#) ++(.+)$\s*/gm,
                 replacement: '<h1>$1</h1>',
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
https://github.com/Expensify/App/issues/15372

# Tests
- Follow [the steps](https://github.com/Expensify/expensify-common) to get the changes in your App
- Open Newdot and start a chat
- Write `# Hello`. Hello should get formatted as a header
- Write `#  Hello` (with two spaces). Hello should get formatted as a header
- Write 
```
#  
Hello
```
(with two spaces after the #). Hello should NOT get formatted as a header and the `#` should remain visible

# QA
Will be QAed with App counterpart