### PR TITLE
Fixing inconsistencies between emails and autoEmail

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -61,7 +61,7 @@ test('Test multi-line strikethrough markdown replacement', () => {
 });
 
 // Emails containing *_~ are successfully wrapped in a mailto anchor tag
-test('Test markdown replacement for emails containing bold/strikethrough/italic', () => {
+test('Test markdown replacement for emails and linked emails containing bold/strikethrough/italic', () => {
     let testInput = 'a~b@gmail.com';
     expect(parser.replace(testInput)).toBe('<a href="mailto:a~b@gmail.com">a~b@gmail.com</a>');
 
@@ -73,6 +73,18 @@ test('Test markdown replacement for emails containing bold/strikethrough/italic'
 
     testInput = 'a~*_b@gmail.com';
     expect(parser.replace(testInput)).toBe('<a href="mailto:a~*_b@gmail.com">a~*_b@gmail.com</a>');
+
+    testInput = '[text](a~b@gmail.com)';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a~b@gmail.com">text</a>');
+
+    testInput = '[text](a*b@gmail.com)';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a*b@gmail.com">text</a>');
+
+    testInput = '[text](a_b@gmail.com)';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a_b@gmail.com">text</a>');
+
+    testInput = '[text](a~*_b@gmail.com)';
+    expect(parser.replace(testInput)).toBe('<a href="mailto:a~*_b@gmail.com">text</a>');
 });
 
 // Single-line emails wrapped in *_~ are successfully wrapped in a mailto anchor tag
@@ -88,6 +100,18 @@ test('Test markdown replacement for emails wrapped in bold/strikethrough/italic 
 
     testInput = '~*_abc@gmail.com_*~';
     expect(parser.replace(testInput)).toBe('<del><strong><em><a href="mailto:abc@gmail.com">abc@gmail.com</a></em></strong></del>');
+
+    testInput = '[text](~abc@gmail.com~)';
+    expect(parser.replace(testInput)).toBe('[text](<del><a href="mailto:abc@gmail.com">abc@gmail.com</a></del>)');
+
+    testInput = '[text](*abc@gmail.com*)';
+    expect(parser.replace(testInput)).toBe('[text](<strong><a href="mailto:abc@gmail.com">abc@gmail.com</a></strong>)');
+
+    testInput = '[text](_abc@gmail.com_)';
+    expect(parser.replace(testInput)).toBe('[text](<em><a href="mailto:abc@gmail.com">abc@gmail.com</a></em>)');
+
+    testInput = '[text](~*_abc@gmail.com_*~)';
+    expect(parser.replace(testInput)).toBe('[text](<del><strong><em><a href="mailto:abc@gmail.com">abc@gmail.com</a></em></strong></del>)');
 });
 
 // Multi-line emails wrapped in *_~ are successfully wrapped in a mailto anchor tag
@@ -110,6 +134,26 @@ test('Test markdown replacement for emails wrapped in bold/strikethrough/italic 
     testInput = '~*_abc@gmail.com\ndef@gmail.com_*~';
     result = '<del><strong><em><a href="mailto:abc@gmail.com">abc@gmail.com</a><br />'
         + '<a href="mailto:def@gmail.com">def@gmail.com</a></em></strong></del>';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '[text](~abc@gmail.com)\n[text](def@gmail.com~)';
+    result = '[text](<del><a href="mailto:abc@gmail.com">abc@gmail.com</a>)<br />'
+        + '[text](<a href="mailto:def@gmail.com">def@gmail.com</a></del>)';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '[text](*abc@gmail.com)\n[text](def@gmail.com*)';
+    result = '[text](<strong><a href="mailto:abc@gmail.com">abc@gmail.com</a>)<br />'
+        + '[text](<a href="mailto:def@gmail.com">def@gmail.com</a></strong>)';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '[text](_abc@gmail.com)\n[text](def@gmail.com_)';
+    result = '[text](<em><a href="mailto:abc@gmail.com">abc@gmail.com</a>)<br />'
+        + '[text](<a href="mailto:def@gmail.com">def@gmail.com</a></em>)';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '[text](~*_abc@gmail.com)\n[text](def@gmail.com_*~)';
+    result = '[text](<del><strong><em><a href="mailto:abc@gmail.com">abc@gmail.com</a>)<br />'
+        + '[text](<a href="mailto:def@gmail.com">def@gmail.com</a></em></strong></del>)';
     expect(parser.replace(testInput)).toBe(result);
 });
 

--- a/lib/Email.js
+++ b/lib/Email.js
@@ -1,0 +1,9 @@
+/*
+Email.js should be used for any common logic specific to emails.
+*/
+
+const EMAIL_REGEX = "([a-zA-Z0-9.!#$%&'+/=?^`{|}-][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*@[a-zA-Z0-9-]+?(\\.[a-zA-Z]+)+)"
+
+export {
+    EMAIL_REGEX,
+}

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import { EMAIL_REGEX } from './Email';
 import Str from './str';
 import {URL_REGEX} from './Url';
 
@@ -57,7 +58,7 @@ export default class ExpensiMark {
                 name: 'email',
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        '\\[([^[\\]]*)]\\(([a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9-]+?(\\.[a-zA-Z]+)+)\\)', 'gim'
+                        `\\[([^[\\]]*)]\\(${EMAIL_REGEX}\\)`, 'gim'
                     );
                     return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
                 },
@@ -97,7 +98,11 @@ export default class ExpensiMark {
              */
             {
                 name: 'autoEmail',
-                regex: /(?![^<]*>|[^<>]*<\\)([a-zA-Z0-9.!#$%&'+/=?^`{|}-][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
+                // regex: /(?![^<]*>|[^<>]*<\\)([a-zA-Z0-9.!#$%&'+/=?^`{|}-][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gim,
+                regex: new RegExp(
+                    `(?![^<]*>|[^<>]*<\\/)${EMAIL_REGEX}(?![^<]*(<\\/pre>|<\\/code>|<\\/a>))`,
+                    'gim',
+                ),
                 replacement: '<a href="mailto:$1">$1</a>',
             },
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
@cristipaval @Santhosh-Sellavel

### Fixed Issues
$ https://github.com/Expensify/App/issues/15621#issuecomment-1453778652

# Tests
What unit/integration tests cover your change? What autoQA tests cover your change?
Added linked email cases to existing email test cases for below
        Test markdown replacement for emails wrapped in bold/strikethrough/italic in multi-line
        Test markdown replacement for emails wrapped in bold/strikethrough/italic in a single line
        Test markdown replacement for emails containing bold/strikethrough/italic

What tests did you perform that validates your changed worked?
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://user-images.githubusercontent.com/46707890/223851322-e0905269-ac20-4d16-b2f8-6bb0094a14bc.mp4



</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://user-images.githubusercontent.com/46707890/223851345-f6eda165-366c-40ac-b6a9-135d6d249896.mp4




<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>
https://user-images.githubusercontent.com/46707890/223851361-06efeccc-8d90-4a25-9ba0-86f650e887ae.mp4



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/46707890/223851425-6c382cc3-6195-4d7e-a448-fd46305f31fe.mp4



<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

https://user-images.githubusercontent.com/46707890/223851455-e22dabdc-7e47-46fe-a0a5-77458e417ddd.mp4



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>


https://user-images.githubusercontent.com/46707890/223851482-e6ffa5e7-dae3-4189-bbef-fef1141d68c1.mp4

<!-- add screenshots or videos here -->

</details>



# QA
1. What does QA need to do to validate your changes?
Input the messages
Input:
```
[test](~abc@gmail.com)
```
Result:
Only 'abc@gmail.com' should be recognised as emailId

Input:
```
[test](*abc@gmail.com)
```
Result:
Only 'abc@gmail.com' should be recognised as emailId

Input:
```
[test](abc@gmail.com)
```
Result:
The message should be recognised as 'test' with emailId as link


1. What areas to they need to test for regressions?
Areas involving emailIds
