### PR TITLE
fix codeFence linebreak missing when convert to markdown

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -248,8 +248,11 @@ test('Test code fencing with spaces and new lines', () => {
     codeFenceExample = '```const javaScript = \'javaScript\'\n    const php = \'php\'```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
 
-    codeFenceExample = '```\n\nconst javaScript = \'javaScript\'\n    const php = \'php\'\n\n```';
-    expect(parser.replace(codeFenceExample)).toBe('<pre><br />const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;<br /><br /></pre>');
+    codeFenceExample = '```\n\n# test\n\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre><br />#&#32;test<br /><br /></pre>');
+
+    codeFenceExample = '```\n\n\n# test\n\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre><br /><br />#&#32;test<br /><br /></pre>');
 });
 
 test('Test inline code blocks', () => {

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -247,6 +247,9 @@ test('Test code fencing with spaces and new lines', () => {
 
     codeFenceExample = '```const javaScript = \'javaScript\'\n    const php = \'php\'```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;</pre>');
+
+    codeFenceExample = '```\n\nconst javaScript = \'javaScript\'\n    const php = \'php\'\n\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre><br />const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;<br /><br /></pre>');
 });
 
 test('Test inline code blocks', () => {

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -613,4 +613,10 @@ test('Test codeFence backticks occupying a separate line while not introducing r
 
     testInput = '<pre>test\n\n</pre>';
     expect(parser.htmlToMarkdown(testInput)).toBe('```\ntest\n\n```');
+
+    testInput = '<pre><br />#&#32;test<br /><br /></pre>';
+    expect(parser.htmlToMarkdown(testInput)).toBe('```\n\n# test\n\n```');
+
+    testInput = '<pre><br /><br />#&#32;test<br /><br /></pre>';
+    expect(parser.htmlToMarkdown(testInput)).toBe('```\n\n\n# test\n\n```');
 });

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -602,8 +602,14 @@ test('Test codeFence backticks occupying a separate line while not introducing r
     let testInput = '<pre>test</pre>';
     expect(parser.htmlToMarkdown(testInput)).toBe('```\ntest\n```');
 
-    testInput = '<pre>\ntest\n</pre>';
+    testInput = '<pre>test\n</pre>';
     expect(parser.htmlToMarkdown(testInput)).toBe('```\ntest\n```');
+
+    testInput = '<pre>\ntest</pre>';
+    expect(parser.htmlToMarkdown(testInput)).toBe('```\n\ntest\n```');
+
+    testInput = '<pre>\ntest\n</pre>';
+    expect(parser.htmlToMarkdown(testInput)).toBe('```\n\ntest\n```');
 
     testInput = '<pre>test\n\n</pre>';
     expect(parser.htmlToMarkdown(testInput)).toBe('```\ntest\n\n```');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -270,8 +270,8 @@ export default class ExpensiMark {
             },
             {
                 name: 'codeFence',
-                regex: /<(pre)(?:"[^"]*"|'[^']*'|[^'">])*>(\n?)([\s\S]*?)(\n?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
-                replacement: (match, g1, g2, g3, g4) => `\`\`\`${g2 || '\n'}${g3}${g4 || '\n'}\`\`\``,
+                regex: /<(pre)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)(\n?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                replacement: (match, g1, g2) => `\`\`\`\n${g2}\n\`\`\``,
             },
             {
                 name: 'anchor',


### PR DESCRIPTION
@aimane-chnaif @deetergp 

### Fixed Issues
$ https://github.com/Expensify/App/issues/15302

# Tests
1. Send this markdown: ```\n\n# test\n\n``` as new message
````
```

# test

```
````
2. Verify that converted html is `<pre><br />#&#32;test<br /><br /></pre>`
3. Edit this message
4. Verity that converted markdown is ```\n\n# test\n\n``` which is same as original one in Step 1.
5. Add one more line break at the beginning - ```\n\n\n# test\n\n``` and update message
````
```


# test

```
````
6. Verify that converted html is `<pre><br /><br />#&#32;test<br /><br /></pre>`
7. Edit this message
8. Verity that converted markdown is ```\n\n\n# test\n\n``` which is same as original one in Step 5.

# QA
Same as Tests step


https://user-images.githubusercontent.com/108292595/225628295-6b7f5b5a-b1dd-4612-8d00-b4840f65084a.mov

