### PR TITLE
Allow `webp` extension in Str.isImage

### DIFF
--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -14,12 +14,12 @@ describe('Str.isImage', () => {
         expect(Str.isImage(buildTestURLForType('JPG'))).toBeTruthy();
         expect(Str.isImage(buildTestURLForType('BMP'))).toBeTruthy();
         expect(Str.isImage(buildTestURLForType('PNG'))).toBeTruthy();
+        expect(Str.isImage(buildTestURLForType('webp'))).toBeTruthy();
     });
 
     it('Does not confirm these types', () => {
         // Note: These are types that React Native does not support as images so attempt to prevent their addition here
         expect(Str.isImage(buildTestURLForType('tiff'))).toBeFalsy();
-        expect(Str.isImage(buildTestURLForType('webp'))).toBeFalsy();
         expect(Str.isImage(buildTestURLForType('psd'))).toBeFalsy();
         expect(Str.isImage(buildTestURLForType('pdf'))).toBeFalsy();
     });

--- a/lib/str.js
+++ b/lib/str.js
@@ -1049,7 +1049,7 @@ const Str = {
      * @returns {Boolean}
      */
     isImage(url) {
-        return _.contains(['jpeg', 'jpg', 'gif', 'png', 'bmp'], this.getExtension(url));
+        return _.contains(['jpeg', 'jpg', 'gif', 'png', 'bmp', 'webp'], this.getExtension(url));
     },
 
     /**


### PR DESCRIPTION
We are working on a [P.R.](https://github.com/Expensify/App/pull/16031) to allow the `webp` attachment extension in newDot, but the image preview will only work if `Str.isImage` is truthy for that file extension.

### Fixed Issues
https://github.com/Expensify/App/issues/15565

# Tests
I updated the `Str-test` tests + this will be tested in https://github.com/Expensify/App/pull/16031

# QA
N/A, will be QA'ed in https://github.com/Expensify/App/pull/16031 
