### PR TITLE
escape code fencing (pre) from heading1 (h1) markdown

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -289,6 +289,11 @@ test('Test code fencing with ExpensiMark syntax inside', () => {
     expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)</pre>');
 });
 
+test('Test code fencing with ExpensiMark syntax outside', () => {
+    const codeFenceExample = '# Test1 ```code``` Test2';
+    expect(parser.replace(codeFenceExample)).toBe('<h1>Test1 </h1><pre>code</pre> Test2');
+});
+
 test('Test code fencing with additional backticks inside', () => {
     let nestedBackticks = '````test````';
     expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;test&#x60;</pre>');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -169,7 +169,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /^#(?!#) +(?! )(.+)$\s*/gm,
+                regex: /^# +(?! )((?:(?!<pre>).)+)\s*/gm,
                 replacement: '<h1>$1</h1>',
             },
             {


### PR DESCRIPTION
@roryabraham @aimane-chnaif 

### Fixed Issues
$ https://github.com/Expensify/App/issues/15193

# Tests
1. Send this markdown as new message
````
# Test1 ```code``` Test2`
````
2. Verify that converted html is `<h1>Test1 </h1><pre>code</pre> Test2`
3. Edit this message
4. Verity that converted markdown is below:
````
# Test1 
```
code
```
 Test2
````

# QA
Same as Tests step


https://user-images.githubusercontent.com/108292595/227124730-4610bc1d-27f3-4940-bc10-5e6bab714cd7.mov

