### PR TITLE
Update constant to point to new QBD sync manager file

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -369,7 +369,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_220929381.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230317395.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
https://github.com/Expensify/Expensify/issues/272561

# Tests
This is just a constant change. To confirm it works, I made sure that I'm able to download the sync manager from: https://d2k5nsl2zxldvw.cloudfront.net/files/quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230317395.exe

# QA
No QA. The QA will happen in the follow-up Web PR. 
