### PR TITLE
Revert "Update constant to point to new QBD sync manager file"

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -369,7 +369,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230317395.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_220929381.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },


### PR DESCRIPTION
Reverts Expensify/expensify-common#515

As discussed [here](https://github.com/Expensify/Expensify/issues/272561#issuecomment-1499679696), we want to keep pointing to the old link for now, so I'm reverting this change. That way if someone else updates expensify-common, we won't accidentally start pointing to the link that we don't want to.  