### PR TITLE
avoid creating empty blockquote tag

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -651,14 +651,14 @@ test('Test quotes markdown replacement with quotes includes a middle blank quote
 });
 
 test('Test quotes markdown replacement with quotes includes multiple middle blank quote rows', () => {
-    const testString = '>test\n> \n> \n>test';
-    const resultString = '<blockquote>test<br /><br />test</blockquote>';
+    const testString = '>test\n> \n> \n>test\ntest\n>test\n> \n> \n> \n>test';
+    const resultString = '<blockquote>test<br /><br /><br />test</blockquote>test<br /><blockquote>test<br /><br /><br /><br />test</blockquote>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test quotes markdown replacement with text includes blank quotes', () => {
     const testString = '> \n>quote1 line a\n> quote1 line b\ntest\n> \ntest\n>quote2 line a\n> \n> \n>quote2 line b with an empty line above';
-    const resultString = '<blockquote>quote1 line a<br />quote1 line b</blockquote>test<br />&gt; <br />test<br /><blockquote>quote2 line a<br /><br />quote2 line b with an empty line above</blockquote>';
+    const resultString = '<blockquote>quote1 line a<br />quote1 line b</blockquote>test<br />&gt; <br />test<br /><blockquote>quote2 line a<br /><br /><br />quote2 line b with an empty line above</blockquote>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -620,7 +620,7 @@ test('Test quotes markdown replacement and removing <br/> from <br/><pre> and </
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test quotes markdown replacement skipping blank quotes ', () => {
+test('Test quotes markdown replacement skipping blank quotes', () => {
     const testString = '> \n>';
     const resultString = '&gt; <br />&gt;';
     expect(parser.replace(testString)).toBe(resultString);
@@ -629,6 +629,30 @@ test('Test quotes markdown replacement skipping blank quotes ', () => {
 test('Test quotes markdown replacement with text starts with blank quote', () => {
     const testString = '> \ntest';
     const resultString = '&gt; <br />test';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with quotes starts with blank quote row', () => {
+    const testString = '> \n>test';
+    const resultString = '<blockquote>test</blockquote>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with quotes ends with blank quote rows', () => {
+    const testString = '>test\n> \n>';
+    const resultString = '<blockquote>test</blockquote>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with quotes includes a middle blank quote row', () => {
+    const testString = '>test\n> \n>test';
+    const resultString = '<blockquote>test<br /><br />test</blockquote>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with quotes includes multiple middle blank quote rows', () => {
+    const testString = '>test\n> \n> \n>test';
+    const resultString = '<blockquote>test<br /><br />test</blockquote>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -620,6 +620,24 @@ test('Test quotes markdown replacement and removing <br/> from <br/><pre> and </
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test quotes markdown replacement skipping blank quotes ', () => {
+    const testString = '> \n>';
+    const resultString = '&gt; <br />&gt;';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with text starts with blank quote', () => {
+    const testString = '> \ntest';
+    const resultString = '&gt; <br />test';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test quotes markdown replacement with text includes blank quotes', () => {
+    const testString = '> \n>quote1 line a\n> quote1 line b\ntest\n> \ntest\n>quote2 line a\n> \n> \n>quote2 line b with an empty line above';
+    const resultString = '<blockquote>quote1 line a<br />quote1 line b</blockquote>test<br />&gt; <br />test<br /><blockquote>quote2 line a<br /><br />quote2 line b with an empty line above</blockquote>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Single char matching', () => {
     const testString = ' *1* char _1_ char ~1~ char';
     const resultString = ' <strong>1</strong> char <em>1</em> char <del>1</del> char';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -581,7 +581,7 @@ export default class ExpensiMark {
                 } else {
                     // Make sure we will only modify if we have Text needed to be formatted for quote
                     if (textToFormat !== '') {
-                        replacedText += this.formatWhitespaceForQuote(regex, textToFormat, replacement);
+                        replacedText += this.formatTextForQuote(regex, textToFormat, replacement);
                         textToFormat = '';
                     }
 
@@ -601,7 +601,7 @@ export default class ExpensiMark {
 
             // When loop ends we need the last quote to be formatted if we have quotes at last rows
             if (textToFormat !== '') {
-                replacedText += this.formatWhitespaceForQuote(regex, textToFormat, replacement);
+                replacedText += this.formatTextForQuote(regex, textToFormat, replacement);
             }
 
             // Replace all the blank lines between quotes, if there are only blank lines between them
@@ -614,7 +614,7 @@ export default class ExpensiMark {
     }
 
     /**
-     * Handle whitespace for the content of blockquote if the text matches the regex or else just return the original text
+     * Format the content of blockquote if the text matches the regex or else just return the original text
      *
      * @param {RegExp} regex
      * @param {String} textToCheck
@@ -622,7 +622,7 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    formatWhitespaceForQuote(regex, textToCheck, replacement) {
+    formatTextForQuote(regex, textToCheck, replacement) {
         if (textToCheck.match(regex)) {
             // Remove '&gt;' and trim each line of quote content
             let textToFormat = textToCheck.trim().split('\n').map(row => row.substr(4).trim()).join('\n');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -581,7 +581,7 @@ export default class ExpensiMark {
                 } else {
                     // Make sure we will only modify if we have Text needed to be formatted for quote
                     if (textToFormat !== '') {
-                        replacedText += this.modifyTextForQuoteContent(regex, textToFormat, replacement);
+                        replacedText += this.formatWhitespaceForQuote(regex, textToFormat, replacement);
                         textToFormat = '';
                     }
 
@@ -601,7 +601,7 @@ export default class ExpensiMark {
 
             // When loop ends we need the last quote to be formatted if we have quotes at last rows
             if (textToFormat !== '') {
-                replacedText += this.modifyTextForQuoteContent(regex, textToFormat, replacement);
+                replacedText += this.formatWhitespaceForQuote(regex, textToFormat, replacement);
             }
 
             // Replace all the blank lines between quotes, if there are only blank lines between them
@@ -614,7 +614,7 @@ export default class ExpensiMark {
     }
 
     /**
-     * Modify text for Quote content and translate it into blockquote html if it matches the regex.
+     * Handle whitespace for the content of blockquote if the text matches the regex or else just return the original text
      *
      * @param {RegExp} regex
      * @param {String} textToCheck
@@ -622,7 +622,7 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    modifyTextForQuoteContent(regex, textToCheck, replacement) {
+    formatWhitespaceForQuote(regex, textToCheck, replacement) {
         if (textToCheck.match(regex)) {
             // Remove '&gt;' and trim each line of quote content
             let textToFormat = textToCheck.trim().split('\n').map(row => row.substr(4).trim()).join('\n');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -627,8 +627,8 @@ export default class ExpensiMark {
             // Remove '&gt;' and trim each line of quote content
             let textToFormat = textToCheck.trim().split('\n').map(row => row.substr(4).trim()).join('\n');
 
-            // Remove leading and trailing line breaks and ensure that we will have only one blank row
-            textToFormat = textToFormat.trim().replace(/\n{2,}/g, '\n\n');
+            // Remove leading and trailing line breaks
+            textToFormat = textToFormat.trim();
             return replacement(textToFormat);
         }
         return textToCheck;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -163,7 +163,7 @@ export default class ExpensiMark {
                 // inline code blocks. A single prepending space should be stripped if it exists
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        /\n?^&gt; ?(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm,
+                        /\n?^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm,
                     );
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
@@ -577,26 +577,11 @@ export default class ExpensiMark {
 
                 // We only want to modify lines starting with &gt; that is not codefence
                 if (Str.startsWith(textSplitted[i], '&gt;') && !insideCodefence) {
-                    // Avoid blank lines starting with &gt;
-                    if (textSplitted[i].trim() !== '&gt;') {
-                        textSplitted[i] = textSplitted[i].substr(4).trim();
-                        textSplitted[i] = textSplitted[i].trim();
-                        textToFormat += `${textSplitted[i]}\n`;
-
-                        // We need ensure that index i-1 >= 0
-                    } else if (i > 0) {
-                        // Certificate that we will have only one blank row
-                        if (textSplitted[i - 1].trim() !== '') {
-                            textSplitted[i] = textSplitted[i].substr(4).trim();
-                            textSplitted[i] = textSplitted[i].trim();
-                            textToFormat += `${textSplitted[i]}\n`;
-                        }
-                    }
+                    textToFormat += `${textSplitted[i]}\n`;
                 } else {
                     // Make sure we will only modify if we have Text needed to be formatted for quote
                     if (textToFormat !== '') {
-                        textToFormat = textToFormat.replace(/\n$/, '');
-                        replacedText += replacement(textToFormat);
+                        replacedText += this.modifyTextForQuoteContent(regex, textToFormat, replacement);
                         textToFormat = '';
                     }
 
@@ -616,8 +601,7 @@ export default class ExpensiMark {
 
             // When loop ends we need the last quote to be formatted if we have quotes at last rows
             if (textToFormat !== '') {
-                textToFormat = textToFormat.replace(/\n$/, '');
-                replacedText += replacement(textToFormat);
+                replacedText += this.modifyTextForQuoteContent(regex, textToFormat, replacement);
             }
 
             // Replace all the blank lines between quotes, if there are only blank lines between them
@@ -627,5 +611,26 @@ export default class ExpensiMark {
             replacedText = textToCheck;
         }
         return replacedText;
+    }
+
+    /**
+     * Modify text for Quote content and translate it into blockquote html if it matches the regex.
+     *
+     * @param {RegExp} regex
+     * @param {String} textToCheck
+     * @param {Function} replacement
+     *
+     * @returns {String}
+     */
+    modifyTextForQuoteContent(regex, textToCheck, replacement) {
+        if (textToCheck.match(regex)) {
+            // Remove '&gt;' and trim each line of quote content
+            let textToFormat = textToCheck.trim().split('\n').map(row => row.substr(4).trim()).join('\n');
+
+            // Remove leading and trailing line breaks and ensure that we will have only one blank row
+            textToFormat = textToFormat.trim().replace(/\n{2,}/g, '\n\n');
+            return replacement(textToFormat);
+        }
+        return textToCheck;
     }
 }

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -625,7 +625,7 @@ export default class ExpensiMark {
     formatTextForQuote(regex, textToCheck, replacement) {
         if (textToCheck.match(regex)) {
             // Remove '&gt;' and trim each line of quote content
-            let textToFormat = textToCheck.trim().split('\n').map(row => row.substr(4).trim()).join('\n');
+            let textToFormat = textToCheck.split('\n').map(row => row.substr(4).trim()).join('\n');
 
             // Remove leading and trailing line breaks
             textToFormat = textToFormat.trim();


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
https://github.com/Expensify/App/issues/17504

# Tests
1. Go to a chat and send blank quotes, like '> \n>'
2. Verify that '> \n>' is displayed as the original text and no error shown on the comment 

https://user-images.githubusercontent.com/117511920/233407771-e1abb5b3-1174-47d0-b765-ab7a1179fe46.mov

3. Add following comment
```
> 
>quote1 line a
> quote1 line b
> 
test
> 
test
>quote2 line a
> 
> 
>quote2 line b with an empty line above
```
4. Verify blank quote is not translated and all blank rows inside a quote are retained 





https://user-images.githubusercontent.com/117511920/234045882-0577bb1e-7588-45a3-ac1e-4bf7c07359ee.mov





# QA
Same as test
