### PR TITLE
allow heading inside a quote

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -720,4 +720,7 @@ test('Test quotes markdown replacement with heading inside', () => {
 
     testString = '> test\n> # heading\n> test';
     expect(parser.replace(testString)).toBe('<blockquote>test<br /><h1>heading</h1>test</blockquote>');
+
+    testString = '> # heading A\n> # heading B';
+    expect(parser.replace(testString)).toBe('<blockquote><h1>heading A</h1><h1>heading B</h1></blockquote>');
 });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -710,3 +710,14 @@ test('Test for link with no content', () => {
     const resultString = '[  ](<a href="https://www.link.com" target="_blank" rel="noreferrer noopener">www.link.com</a>)';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test quotes markdown replacement with heading inside', () => {
+    let testString = '> # heading';
+    expect(parser.replace(testString)).toBe('<blockquote><h1>heading</h1></blockquote>');
+
+    testString = '> # heading\n> test';
+    expect(parser.replace(testString)).toBe('<blockquote><h1>heading</h1>test</blockquote>');
+
+    testString = '> test\n> # heading\n> test';
+    expect(parser.replace(testString)).toBe('<blockquote>test<br /><h1>heading</h1>test</blockquote>');
+});

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -124,4 +124,6 @@ test('Test new line replacement on blockquote with heading inside', () => {
     testString = '<blockquote>test<br /><h1>heading</h1>test</blockquote>';
     expect(parser.htmlToText(testString)).toBe('test\n\nheading\ntest');
 
+    testString = '<blockquote><h1>heading A</h1><h1>heading B</h1></blockquote>';
+    expect(parser.htmlToText(testString)).toBe('heading A\n\nheading B');
 });

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -113,3 +113,15 @@ test('Test replacement on mixed html', () => {
 
     expect(parser.htmlToText(html)).toBe(text);
 });
+
+test('Test new line replacement on blockquote with heading inside', () => {
+    let testString = '<blockquote><h1>heading</h1></blockquote>';
+    expect(parser.htmlToText(testString)).toBe('heading');
+
+    testString = '<blockquote><h1>heading</h1>test</blockquote>';
+    expect(parser.htmlToText(testString)).toBe('heading\ntest');
+
+    testString = '<blockquote>test<br /><h1>heading</h1>test</blockquote>';
+    expect(parser.htmlToText(testString)).toBe('test\n\nheading\ntest');
+
+});

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -641,3 +641,14 @@ test('Test codeFence backticks occupying a separate line while not introducing r
     testInput = '<pre><br /><br />#&#32;test<br /><br /></pre>';
     expect(parser.htmlToMarkdown(testInput)).toBe('```\n\n\n# test\n\n```');
 });
+
+test('Test blockquote with h1 inside', () => {
+    let testString = '<blockquote><h1>heading</h1></blockquote>';
+    expect(parser.htmlToMarkdown(testString)).toBe('\n> # heading\n');
+
+    testString = '<blockquote><h1>heading</h1>test</blockquote>';
+    expect(parser.htmlToMarkdown(testString)).toBe('\n> # heading\n> test\n');
+
+    testString = '<blockquote>test<br /><h1>heading</h1>test</blockquote>';
+    expect(parser.htmlToMarkdown(testString)).toBe('\n> test\n> # heading\n> test\n');
+});

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -651,4 +651,7 @@ test('Test blockquote with h1 inside', () => {
 
     testString = '<blockquote>test<br /><h1>heading</h1>test</blockquote>';
     expect(parser.htmlToMarkdown(testString)).toBe('\n> test\n> # heading\n> test\n');
+
+    testString = '<blockquote><h1>heading A</h1><h1>heading B</h1></blockquote>';
+    expect(parser.htmlToMarkdown(testString)).toBe('\n> # heading A\n> # heading B\n');
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -264,7 +264,7 @@ export default class ExpensiMark {
                 name: 'quote',
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
-                    const resultString = g2.replace(/\[block\]/g, '\n').trim()
+                    const resultString = g2.replace(/(\[block\])+/g, '\n').trim()
                         .split('\n').map(m => `> ${m}`)
                         .join('\n');
                     return `\n${resultString}\n`;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -167,7 +167,10 @@ export default class ExpensiMark {
                     );
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
-                replacement: g1 => `<blockquote>${g1}</blockquote>`,
+                replacement: (g1) => {
+                    const replacedText = this.replace(g1, {filterRules: ['heading1'], shouldEscapeText: false});
+                    return `<blockquote>${replacedText}</blockquote>`;
+                },
             },
             {
                 name: 'heading1',
@@ -261,7 +264,10 @@ export default class ExpensiMark {
                 name: 'quote',
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
-                    const resultString = g2.trim().split('\n').map(m => `> ${m}`).join('\n');
+                    // const resultString = g2.trim().split('\n').map(m => `> ${m}`).join('\n');
+                    const resultString = g2.replace(/\[block\]/g, '\n').trim()
+                        .split('\n').map(m => `> ${m}`)
+                        .join('\n');
                     return `\n${resultString}\n`;
                 },
             },
@@ -298,6 +304,16 @@ export default class ExpensiMark {
                 name: 'breakline',
                 regex: /<br[^>]*>/gi,
                 replacement: '\n',
+            },
+            {
+                name: 'blockquoteWrapHeadingOpen',
+                regex: /<blockquote><h1>/gi,
+                replacement: '<blockquote>',
+            },
+            {
+                name: 'blockquoteWrapHeadingClose',
+                regex: /<\/h1><\/blockquote>/gi,
+                replacement: '</blockquote>',
             },
             {
                 name: 'blockElementOpen',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -265,7 +265,8 @@ export default class ExpensiMark {
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
                     const resultString = g2.replace(/(\[block\])+/g, '\n').trim()
-                        .split('\n').map(m => `> ${m}`)
+                        .split('\n')
+                        .map(m => `> ${m}`)
                         .join('\n');
                     return `\n${resultString}\n`;
                 },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -264,7 +264,6 @@ export default class ExpensiMark {
                 name: 'quote',
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
-                    // const resultString = g2.trim().split('\n').map(m => `> ${m}`).join('\n');
                     const resultString = g2.replace(/\[block\]/g, '\n').trim()
                         .split('\n').map(m => `> ${m}`)
                         .join('\n');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -264,7 +264,8 @@ export default class ExpensiMark {
                 name: 'quote',
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
-                    const resultString = g2.replace(/(\[block\])+/g, '\n').trim()
+                    const resultString = g2.replace(/(\[block\])+/g, '\n')
+                        .trim()
                         .split('\n')
                         .map(m => `> ${m}`)
                         .join('\n');


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
https://github.com/Expensify/App/issues/17367

# Tests
1. Send a message, `> # heading`
2. Verify the text is displayed in as header inside the quote
3. Send following message
```
========= test case 1 ========
> [quote] case 1
> # heading
> [quote] case 1

[normal] case 1
# heading
[normal] case 1

========= test case 2 ========
> [quote] case 2
> 
> # heading
> 
> [quote] case 2

[normal] case 2

# heading

[normal] case 2
```
4. Verify normal heading and heading inside quote have the same line break handling


https://user-images.githubusercontent.com/117511920/234178742-048ea7c0-5e49-47f6-8d82-3f5e78daa8d5.mov



# QA
Same as Tests above
