### PR TITLE
Link to new sync manager file in Const

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -369,7 +369,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_220929381.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230403124.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This updates the constant in expensify-common to point to the new QBD sync manager file.

### Fixed Issues
https://github.com/Expensify/Expensify/issues/272561

# Tests
Make sure that you are able to download the file at: https://d2k5nsl2zxldvw.cloudfront.net/files/quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230403124.exe

# QA
Make sure that you are able to download the file at: https://d2k5nsl2zxldvw.cloudfront.net/files/quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230403124.exe
