### PR TITLE
Avoid parsing nested link

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -584,6 +584,30 @@ test('Test markdown and url links with inconsistent starting and closing parens'
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test autolink replacement to avoid parsing nested links', () => {
+    const testString = '[click google.com *here*](google.com) '
+        + '[click google.com ~here~](google.com) '
+        + '[click google.com _here_](google.com) '
+        + '[click google.com `here`](google.com) '
+        + '[*click* google.com here](google.com) '
+        + '[~click~ google.com here](google.com) '
+        + '[_click_ google.com here](google.com) '
+        + '[`click` google.com here](google.com) '
+        + '[`click` google.com *here*](google.com)';
+
+    const resultString = '<a href="https://google.com" target="_blank" rel="noreferrer noopener">click google.com <strong>here</strong></a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener">click google.com <del>here</del></a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener">click google.com <em>here</em></a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener">click google.com <code>here</code></a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener"><strong>click</strong> google.com here</a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener"><del>click</del> google.com here</a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener"><em>click</em> google.com here</a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener"><code>click</code> google.com here</a> '
+    + '<a href="https://google.com" target="_blank" rel="noreferrer noopener"><code>click</code> google.com <strong>here</strong></a>';
+
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test quotes markdown replacement with text matching inside and outside codefence without spaces', () => {
     const testString = 'The next line should be quoted\n>Hello,I’mtext\n```\nThe next line should not be quoted\n>Hello,I’mtext\nsince its inside a codefence```';
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -115,7 +115,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `(?![^<]*>|[^<>]*<\\/)([_*~]*?)${URL_REGEX}\\1(?![^<]*(<\\/pre>|<\\/code>))`,
+                        `(?![^<]*>|[^<>]*<\\/)([_*~]*?)${URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`,
                         'gi',
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/17772

# Tests
1. Go to a chat and add a comment
```
[click google.com *here*](google.com)
```
2. Verify that the text `here` is displayed in bold

# QA
Same as test
