### PR TITLE
Avoid removing break before and after heading

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -719,8 +719,16 @@ test('Test quotes markdown replacement with heading inside', () => {
     expect(parser.replace(testString)).toBe('<blockquote><h1>heading</h1>test</blockquote>');
 
     testString = '> test\n> # heading\n> test';
-    expect(parser.replace(testString)).toBe('<blockquote>test<h1>heading</h1>test</blockquote>');
+    expect(parser.replace(testString)).toBe('<blockquote>test<br /><h1>heading</h1>test</blockquote>');
 
     testString = '> # heading A\n> # heading B';
     expect(parser.replace(testString)).toBe('<blockquote><h1>heading A</h1><h1>heading B</h1></blockquote>');
+
+    testString = '> test\n>\n> # heading\n>\n>test';
+    expect(parser.replace(testString)).toBe('<blockquote>test<br /><br /><h1>heading</h1><br />test</blockquote>');
+});
+
+test('Test heading1 markdown replacement with line break before or after the heading1', () => {
+    const testString = 'test\n\n# heading\n\ntest';
+    expect(parser.replace(testString)).toBe('test<br /><br /><h1>heading</h1><br />test');
 });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -719,7 +719,7 @@ test('Test quotes markdown replacement with heading inside', () => {
     expect(parser.replace(testString)).toBe('<blockquote><h1>heading</h1>test</blockquote>');
 
     testString = '> test\n> # heading\n> test';
-    expect(parser.replace(testString)).toBe('<blockquote>test<br /><h1>heading</h1>test</blockquote>');
+    expect(parser.replace(testString)).toBe('<blockquote>test<h1>heading</h1>test</blockquote>');
 
     testString = '> # heading A\n> # heading B';
     expect(parser.replace(testString)).toBe('<blockquote><h1>heading A</h1><h1>heading B</h1></blockquote>');

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -649,7 +649,7 @@ test('Test blockquote with h1 inside', () => {
     testString = '<blockquote><h1>heading</h1>test</blockquote>';
     expect(parser.htmlToMarkdown(testString)).toBe('\n> # heading\n> test\n');
 
-    testString = '<blockquote>test<br /><h1>heading</h1>test</blockquote>';
+    testString = '<blockquote>test<h1>heading</h1>test</blockquote>';
     expect(parser.htmlToMarkdown(testString)).toBe('\n> test\n> # heading\n> test\n');
 
     testString = '<blockquote><h1>heading A</h1><h1>heading B</h1></blockquote>';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -167,7 +167,10 @@ export default class ExpensiMark {
                     );
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
-                replacement: quoteText => `<blockquote>${quoteText}</blockquote>`,
+                replacement: (g1) => {
+                    const replacedText = this.replace(g1, {filterRules: ['heading1'], shouldEscapeText: false});
+                    return `<blockquote>${replacedText}</blockquote>`;
+                },
             },
             {
                 name: 'heading1',
@@ -645,10 +648,6 @@ export default class ExpensiMark {
 
             // Remove leading and trailing line breaks
             textToFormat = textToFormat.trim();
-
-            // We replace heading1 to html
-            textToFormat = this.replace(textToFormat, {filterRules: ['heading1'], shouldEscapeText: false});
-
             return replacement(textToFormat);
         }
         return textToCheck;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -167,10 +167,7 @@ export default class ExpensiMark {
                     );
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
-                replacement: (g1) => {
-                    const replacedText = this.replace(g1, {filterRules: ['heading1'], shouldEscapeText: false});
-                    return `<blockquote>${replacedText}</blockquote>`;
-                },
+                replacement: (quoteText) => `<blockquote>${quoteText}</blockquote>`,
             },
             {
                 name: 'heading1',
@@ -235,7 +232,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /\s*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))\s*/gi,
+                regex: /[^\S\r\n]*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))[^\S\r\n]*/gi,
                 replacement: '[block]# $2[block]',
             },
             {
@@ -646,6 +643,12 @@ export default class ExpensiMark {
 
             // Remove leading and trailing line breaks
             textToFormat = textToFormat.trim();
+
+            // We replace heading1 to html and remove the line break before <h1> or after </h1> to avoid adding extra line 
+            // breaks because we join rows of quote with '\n'
+            textToFormat = this.replace(textToFormat, {filterRules: ['heading1'], shouldEscapeText: false});
+            textToFormat = textToFormat.replace(/\n?(<\/?h1>)\n?/gi, '$1');
+
             return replacement(textToFormat);
         }
         return textToCheck;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -167,11 +167,11 @@ export default class ExpensiMark {
                     );
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
-                replacement: (quoteText) => `<blockquote>${quoteText}</blockquote>`,
+                replacement: quoteText => `<blockquote>${quoteText}</blockquote>`,
             },
             {
                 name: 'heading1',
-                regex: /^# +(?! )((?:(?!<pre>).)+)\s*/gm,
+                regex: /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)\n?/gm,
                 replacement: '<h1>$1</h1>',
             },
             {
@@ -261,7 +261,9 @@ export default class ExpensiMark {
                 name: 'quote',
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
-                    const resultString = g2.replace(/(\[block\])+/g, '\n')
+                    // We remove the line break before heading inside quote to avoid adding extra line
+                    const resultString = g2.replace(/\n?(\[block\]# )/g, '$1')
+                        .replace(/(\[block\])+/g, '\n')
                         .trim()
                         .split('\n')
                         .map(m => `> ${m}`)
@@ -644,10 +646,8 @@ export default class ExpensiMark {
             // Remove leading and trailing line breaks
             textToFormat = textToFormat.trim();
 
-            // We replace heading1 to html and remove the line break before <h1> or after </h1> to avoid adding extra line 
-            // breaks because we join rows of quote with '\n'
+            // We replace heading1 to html
             textToFormat = this.replace(textToFormat, {filterRules: ['heading1'], shouldEscapeText: false});
-            textToFormat = textToFormat.replace(/\n?(<\/?h1>)\n?/gi, '$1');
 
             return replacement(textToFormat);
         }


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/17998

# Tests
1. Add a comment
```
========= test case 2 ========
> [quote] case 2
> 
> # heading
> 
> [quote] case 2

[normal] case 2

# heading

[normal] case 2
```
2. Verify that there's a line break before and after the heading for both normal header and header inside quote
3. Edit the comment and verify that the markdown is same as the input.


https://github.com/Expensify/expensify-common/assets/117511920/a7bc1689-4d0c-473a-bb45-000317bc7062



# QA
Same as test
