### PR TITLE
Allow tilde (~) in url parameters

### DIFF
--- a/lib/Url.js
+++ b/lib/Url.js
@@ -1,7 +1,7 @@
 import TLD_REGEX from './tlds';
 
 const ALLOWED_PORTS = '([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])';
-const URL_PROTOCOL_REGEX = '((ht|f)tps?:[\\/|\\\\]{2})';
+const URL_PROTOCOL_REGEX = '((ht|f)tps?:(?:\\/{2}|\\\\{2}))';
 const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))`;
 const addEscapedChar = reg => `(?:${reg}|&(?:amp|quot|#x27);)`;
 const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?[\\/|\\\\]${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/|\\\\)*`;

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -1,11 +1,11 @@
 import TLD_REGEX from './tlds';
 
 const ALLOWED_PORTS = '([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])';
-const URL_PROTOCOL_REGEX = '((ht|f)tps?:\\/\\/)';
+const URL_PROTOCOL_REGEX = '((ht|f)tps?:[\\/|\\\\]{2})';
 const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))`;
 const addEscapedChar = reg => `(?:${reg}|&(?:amp|quot|#x27);)`;
-const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?\\/${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/)*`;
-const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_]')}*)?`;
+const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?[\\/|\\\\]${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/|\\\\)*`;
+const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~|\\\\]')}*)?`;
 const URL_FRAGMENT_REGEX = `(?:#${addEscapedChar('[-\\w$@.+!*()[\\],=%;\\/:~]')}*)?`;
 const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
 

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -1,11 +1,11 @@
 import TLD_REGEX from './tlds';
 
 const ALLOWED_PORTS = '([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])';
-const URL_PROTOCOL_REGEX = '((ht|f)tps?:(?:\\/{2}|\\\\{2}))';
+const URL_PROTOCOL_REGEX = '((ht|f)tps?:\\/\\/)';
 const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))`;
 const addEscapedChar = reg => `(?:${reg}|&(?:amp|quot|#x27);)`;
-const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?(?:\\/|\\\\)${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/|\\\\)*`;
-const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~|\\\\]')}*)?`;
+const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?\\/${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/)*`;
+const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~]')}*)?`;
 const URL_FRAGMENT_REGEX = `(?:#${addEscapedChar('[-\\w$@.+!*()[\\],=%;\\/:~]')}*)?`;
 const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
 

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -4,7 +4,7 @@ const ALLOWED_PORTS = '([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9
 const URL_PROTOCOL_REGEX = '((ht|f)tps?:(?:\\/{2}|\\\\{2}))';
 const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))`;
 const addEscapedChar = reg => `(?:${reg}|&(?:amp|quot|#x27);)`;
-const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?[\\/|\\\\]${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/|\\\\)*`;
+const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?(?:\\/|\\\\)${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/|\\\\)*`;
 const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~|\\\\]')}*)?`;
 const URL_FRAGMENT_REGEX = `(?:#${addEscapedChar('[-\\w$@.+!*()[\\],=%;\\/:~]')}*)?`;
 const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ [Expensify/App/issues/18564](https://github.com/Expensify/App/issues/18564)

# Tests
Verify if `~` works in query params

1. Send a valid url
2. Verify that the sent url appears as a valid url(blue and underlined)
3. Verify hovering over the url shows the tooltip in Web and Desktop
4. Verify that Right click (Web and Desktop) or long press (mWeb and native) shows Copy Url to Clipboard context menu
5. Edit the sent url
6. Verify steps 2-4

**Examples:**
```
https://example.com/search?q=foobar~
https://example.com/search?q=~foobar
https://example.com/?~parameter~
https://example.com/?parameter~
https://example.com/?~parameter
```

# QA
Same as tests



### Screenshots/Videos
<details>
<summary>Web</summary>

#### Safari


https://github.com/Expensify/expensify-common/assets/68777211/6a04f557-43b8-4672-8882-7058119f4ec5






#### Chrome


https://github.com/Expensify/expensify-common/assets/68777211/929f8aa4-f408-4147-8edb-73de3d2aad4e






</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/expensify-common/assets/68777211/c349e3b7-f0c4-4a2d-9522-1fcfb19412b8



</details>

<details>
<summary>Mobile Web - Safari</summary>



https://github.com/Expensify/expensify-common/assets/68777211/e1deff7d-4dd8-4018-84ee-c642956cede6




</details>

<details>
<summary>Desktop</summary>



https://github.com/Expensify/expensify-common/assets/68777211/476985cf-a328-4a01-9139-3224745b57d3




</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/expensify-common/assets/68777211/e407e70b-dae8-4190-9ece-d19691375a64


</details>

<details>
<summary>Android</summary>


https://github.com/Expensify/expensify-common/assets/68777211/d3fca658-39fa-491d-9946-e0bc1126eeab



</details>

