### PR TITLE
fix: auto link after email domain not parsed.

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -371,7 +371,10 @@ test('Test url replacements', () => {
         + 'https://example.com/~username/foo~bar.txt '
         + 'http://example.com/foo/*/bar/*/test.txt '
         + 'test-.com '
-        + '-test.com ';
+        + '-test.com '
+        + '@test.com '
+        + '@test.com test.com '
+        + '@test.com @test.com ';
 
     const urlTestReplacedString = 'Testing '
         + '<a href="https://foo.com" target="_blank" rel="noreferrer noopener">foo.com</a> '
@@ -409,7 +412,10 @@ test('Test url replacements', () => {
         + '<a href="https://example.com/~username/foo~bar.txt" target="_blank" rel="noreferrer noopener">https://example.com/~username/foo~bar.txt</a> '
         + '<a href="http://example.com/foo/*/bar/*/test.txt" target="_blank" rel="noreferrer noopener">http://example.com/foo/*/bar/*/test.txt</a> '
         + 'test-.com '
-        + '-<a href="https://test.com" target="_blank" rel="noreferrer noopener">test.com</a> ';
+        + '-<a href="https://test.com" target="_blank" rel="noreferrer noopener">test.com</a> '
+        + '@test.com '
+        + '@test.com <a href="https://test.com" target="_blank" rel="noreferrer noopener">test.com</a> '
+        + '@test.com @test.com ';
 
     expect(parser.replace(urlTestStartString)).toBe(urlTestReplacedString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -417,10 +417,10 @@ export default class ExpensiMark {
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;
-        let abort = false;
 
         while (match !== null) {
             // we want to avoid matching email address domains
+            let abort = false;
             if ((match.index !== 0) && (textToCheck[match.index - 1] === '@')) {
                 abort = true;
             }


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
@parasharrajat @francoisl 
### Fixed Issues
$ https://github.com/Expensify/App/issues/18443

# Tests
1. Go to any chat and add a comment 
```
@google.com google.com
```
2. Verify that the `@google.com` is displayed as plain text and the next `google.com` is displayed as a link.

# QA
Same as test
