### PR TITLE
fix: emoji anchor text with hyperlink

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -710,3 +710,9 @@ test('Test for link with no content', () => {
     const resultString = '[  ](<a href="https://www.link.com" target="_blank" rel="noreferrer noopener">www.link.com</a>)';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test for link with emoji', () => {
+    const testString = '[😀](www.link.com)';
+    const resultString = '[😀](<a href="https://www.link.com" target="_blank" rel="noreferrer noopener">www.link.com</a>)';
+    expect(parser.replace(testString)).toBe(resultString);
+});

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -331,6 +331,13 @@ export const CONST = {
          * @type String
          */
         MARKDOWN_EMAIL: "([a-zA-Z0-9.!#$%&'+/=?^`{|}-][a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]*@[a-zA-Z0-9-]+?(\\.[a-zA-Z]+)+)",
+
+        /**
+         * Regex matching an text containing an Emoji
+         *
+         * @type RegExp
+         */
+        EMOJIS: /[\p{Extended_Pictographic}\u200d\u{1f1e6}-\u{1f1ff}\u{1f3fb}-\u{1f3ff}\u{e0020}-\u{e007f}\u20E3\uFE0F]|[#*0-9]\uFE0F?\u20E3/gu,
     },
 
     REPORT: {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -83,7 +83,7 @@ export default class ExpensiMark {
                 // We use a function here to check if there is already a https:// on the link.
                 // If there is not, we force the link to be absolute by prepending '//' to the target.
                 replacement: (match, g1, g2, g3) => {
-                    if (!g1.trim()) {
+                    if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
                         return match;
                     }
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
### Details
Emoji only is accepted as an anchor text and it doesn't look pleasing to the eye. We don't want emoji-only text to be anchor text for links.
### Fixed Issues
$ https://github.com/Expensify/App/issues/18386
PROPOSAL: https://github.com/Expensify/App/issues/18386#issuecomment-1542063094
# Tests
To test, we need to update the hash commit of expensify-common package in App repo into `0f363d1eb6731aac34c20a0102822557253ac6a4` like this:
"expensify-common": "git+ssh://git@github.com/expensify/expensifycommon.git#0f363d1eb6731aac34c20a0102822557253ac6a4"

Open any chat and:
1. Put an emoji inside of square brackets "[]" and put a link inside of parenthesis "()"
2. Post the comment
3. Verify emoji text not to be anchor text for links

- [x] Verify that no errors appear in the JS console

### QA Steps

Open any chat and:
1. Put an emoji inside of square brackets "[]" and put a link inside of parenthesis "()"
2. Post the comment
3. Verify emoji text not to be anchor text for links

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/expensify-common/assets/129500732/91aa810a-f154-4e62-9683-15c383357f9d


<!-- add screenshots or videos here -->
</details>
<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/expensify-common/assets/129500732/75374776-ca40-4462-950a-e0ae046bb02b

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/expensify-common/assets/129500732/2a6f8db8-1259-4e2f-b4ab-faf0fc739781
</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/expensify-common/assets/129500732/91dab230-ab44-4542-a26f-343016c4c766


</details>

<details>
<summary>IOS</summary>

https://github.com/Expensify/expensify-common/assets/129500732/41b7b0c0-45bd-4548-ae67-e6d5c490357f

</details>
<details>
<summary>Android</summary>

https://github.com/Expensify/expensify-common/assets/129500732/883c0e9b-41df-4f3a-b82e-7231a7bf1fba

</details>