### PR TITLE
Add method normalizeWebsiteOfUrl to format the website of url to lower case

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -395,7 +395,7 @@ test('Test url replacements', () => {
         + '<a href="https://expensify.cash/#/r/1234" target="_blank" rel="noreferrer noopener">https://expensify.cash/#/r/1234</a> '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/6.45" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/6.45</a> '
         + '<a href="https://github.com/Expensify/Expensify/issues/143,231" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/Expensify/issues/143,231</a> '
-        + '<a href="https://testRareTLDs.beer" target="_blank" rel="noreferrer noopener">testRareTLDs.beer</a> '
+        + '<a href="https://testraretlds.beer" target="_blank" rel="noreferrer noopener">testRareTLDs.beer</a> '
         + '<a href="mailto:test@expensify.com">test@expensify.com</a> '
         + 'test.completelyFakeTLD '
         + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank" rel="noreferrer noopener">https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878</a>) '

--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -86,7 +86,7 @@ describe('Str.isValidMention', () => {
 });
 
 describe('Str.normalizeWebsiteOfUrl', () => {
-    it('Normalize website of url to lower case and add missing https:// protocol', () => {
+    it('Normalize domain name to lower case and add missing https:// protocol', () => {
         expect(Str.normalizeWebsiteOfUrl('https://google.com')).toBe('https://google.com');
         expect(Str.normalizeWebsiteOfUrl('google.com')).toBe('https://google.com');
         expect(Str.normalizeWebsiteOfUrl('Https://google.com')).toBe('https://google.com');

--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -85,14 +85,14 @@ describe('Str.isValidMention', () => {
     });
 });
 
-describe('Str.normalizeWebsiteOfUrl', () => {
+describe('Str.sanitizeURL', () => {
     it('Normalize domain name to lower case and add missing https:// protocol', () => {
-        expect(Str.normalizeWebsiteOfUrl('https://google.com')).toBe('https://google.com');
-        expect(Str.normalizeWebsiteOfUrl('google.com')).toBe('https://google.com');
-        expect(Str.normalizeWebsiteOfUrl('Https://google.com')).toBe('https://google.com');
-        expect(Str.normalizeWebsiteOfUrl('https://GOOgle.com')).toBe('https://google.com');
-        expect(Str.normalizeWebsiteOfUrl('FOO.com/blah_BLAH')).toBe('https://foo.com/blah_BLAH');
-        expect(Str.normalizeWebsiteOfUrl('http://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
-        expect(Str.normalizeWebsiteOfUrl('HTtp://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
+        expect(Str.sanitizeURL('https://google.com')).toBe('https://google.com');
+        expect(Str.sanitizeURL('google.com')).toBe('https://google.com');
+        expect(Str.sanitizeURL('Https://google.com')).toBe('https://google.com');
+        expect(Str.sanitizeURL('https://GOOgle.com')).toBe('https://google.com');
+        expect(Str.sanitizeURL('FOO.com/blah_BLAH')).toBe('https://foo.com/blah_BLAH');
+        expect(Str.sanitizeURL('http://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
+        expect(Str.sanitizeURL('HTtp://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
     });
 });

--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -84,3 +84,15 @@ describe('Str.isValidMention', () => {
         expect(Str.isValidMention('"@username@expensify.com"')).toBeTruthy();
     });
 });
+
+describe('Str.normalizeWebsiteOfUrl', () => {
+    it('Normalize website of url to lower case and add missing https:// protocol', () => {
+        expect(Str.normalizeWebsiteOfUrl('https://google.com')).toBe('https://google.com');
+        expect(Str.normalizeWebsiteOfUrl('google.com')).toBe('https://google.com');
+        expect(Str.normalizeWebsiteOfUrl('Https://google.com')).toBe('https://google.com');
+        expect(Str.normalizeWebsiteOfUrl('https://GOOgle.com')).toBe('https://google.com');
+        expect(Str.normalizeWebsiteOfUrl('FOO.com/blah_BLAH')).toBe('https://foo.com/blah_BLAH');
+        expect(Str.normalizeWebsiteOfUrl('http://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
+        expect(Str.normalizeWebsiteOfUrl('HTtp://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
+    });
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -113,13 +113,11 @@ export default class ExpensiMark {
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
                 },
 
-                // We use a function here to check if there is already a https:// on the link.
-                // If there is not, we force the link to be absolute by prepending '//' to the target.
                 replacement: (match, g1, g2) => {
                     if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
                         return match;
                     }
-                    return `<a href="${Str.normalizeWebsiteOfUrl(g2)}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
+                    return `<a href="${Str.sanitizeURL(g2)}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
                 },
             },
 
@@ -152,10 +150,8 @@ export default class ExpensiMark {
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
                 },
 
-                // We use a function here to check if there is already a https:// on the link.
-                // If there is not, we force the link to be absolute by prepending '//' to the target.
                 replacement: (match, g1, g2) => {
-                    const href = Str.normalizeWebsiteOfUrl(g2);
+                    const href = Str.sanitizeURL(g2);
                     return `${g1}<a href="${href}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
                 },
             },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -115,13 +115,11 @@ export default class ExpensiMark {
 
                 // We use a function here to check if there is already a https:// on the link.
                 // If there is not, we force the link to be absolute by prepending '//' to the target.
-                replacement: (match, g1, g2, g3) => {
+                replacement: (match, g1, g2) => {
                     if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
                         return match;
                     }
-
-                    const href = g3 ? g2.replace(g3, g3.toLowerCase()) : `https://${g2}`;
-                    return `<a href="${href}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
+                    return `<a href="${Str.normalizeWebsiteOfUrl(g2)}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
                 },
             },
 
@@ -156,8 +154,8 @@ export default class ExpensiMark {
 
                 // We use a function here to check if there is already a https:// on the link.
                 // If there is not, we force the link to be absolute by prepending '//' to the target.
-                replacement: (match, g1, g2, g3) => {
-                    const href = g3 ? g2.replace(g3, g3.toLowerCase()) : `https://${g2}`;
+                replacement: (match, g1, g2) => {
+                    const href = Str.normalizeWebsiteOfUrl(g2);
                     return `${g1}<a href="${href}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
                 },
             },
@@ -465,7 +463,7 @@ export default class ExpensiMark {
                     filterRules: ['bold', 'strikethrough', 'italic'],
                     shouldEscapeText: false,
                 });
-                replacedText = replacedText.concat(replacement(match[0], linkText, match[2], match[3]));
+                replacedText = replacedText.concat(replacement(match[0], linkText, match[2]));
             }
             startIndex = match.index + (match[0].length);
 

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -7,7 +7,7 @@ const addEscapedChar = reg => `(?:${reg}|&(?:amp|quot|#x27);)`;
 const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?\\/${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/)*`;
 const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~]')}*)?`;
 const URL_FRAGMENT_REGEX = `(?:#${addEscapedChar('[-\\w$@.+!*()[\\],=%;\\/:~]')}*)?`;
-const URL_REGEX = `(${URL_WEBSITE_REGEX}${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
+const URL_REGEX = `((${URL_WEBSITE_REGEX})${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
 
 const URL_REGEX_WITH_REQUIRED_PROTOCOL = URL_REGEX.replace(`${URL_PROTOCOL_REGEX}?`, URL_PROTOCOL_REGEX);
 

--- a/lib/str.js
+++ b/lib/str.js
@@ -1023,7 +1023,7 @@ const Str = {
     },
 
     /**
-     * Takes in a URL, returns it with website in lower case and adds missing https:// protocol
+     *  * Formats a URL by converting the domain name to lowercase and adding the missing 'https://' protocol.
      *
      * @param {url} url The URL to be formatted
      * @returns {String} The formatted URL

--- a/lib/str.js
+++ b/lib/str.js
@@ -3,6 +3,7 @@ import _ from 'underscore';
 import {AllHtmlEntities} from 'html-entities';
 import replaceAll from 'string.prototype.replaceall';
 import {CONST} from './CONST';
+import {URL_REGEX} from './Url';
 
 const REMOVE_SMS_DOMAIN_PATTERN = new RegExp(`@${CONST.SMS.DOMAIN}`, 'gi');
 
@@ -1019,6 +1020,22 @@ const Str = {
      */
     normalizeUrl(url) {
         return (typeof url === 'string' && url.startsWith('/')) ? url : `/${url}`;
+    },
+
+    /**
+     * Takes in a URL, returns it with website in lower case and adds missing https:// protocol
+     *
+     * @param {url} url The URL to be formatted
+     * @returns {String} The formatted URL
+     */
+    normalizeWebsiteOfUrl(url) {
+        const regex = new RegExp(`^${URL_REGEX}$`, 'i');
+        const match = regex.exec(url);
+        if (!match) {
+            return url;
+        }
+        const website = match[3] ? match[2] : `https://${match[2]}`;
+        return website.toLowerCase() + this.cutBefore(match[1], match[2]);
     },
 
     /**

--- a/lib/str.js
+++ b/lib/str.js
@@ -1028,7 +1028,7 @@ const Str = {
      * @param {url} url The URL to be formatted
      * @returns {String} The formatted URL
      */
-    normalizeURL(url) {
+    sanitizeURL(url) {
         const regex = new RegExp(`^${URL_REGEX}$`, 'i');
         const match = regex.exec(url);
         if (!match) {

--- a/lib/str.js
+++ b/lib/str.js
@@ -1023,7 +1023,7 @@ const Str = {
     },
 
     /**
-     *  * Formats a URL by converting the domain name to lowercase and adding the missing 'https://' protocol.
+     *  Formats a URL by converting the domain name to lowercase and adding the missing 'https://' protocol.
      *
      * @param {url} url The URL to be formatted
      * @returns {String} The formatted URL

--- a/lib/str.js
+++ b/lib/str.js
@@ -1028,7 +1028,7 @@ const Str = {
      * @param {url} url The URL to be formatted
      * @returns {String} The formatted URL
      */
-    normalizeWebsiteOfUrl(url) {
+    normalizeURL(url) {
         const regex = new RegExp(`^${URL_REGEX}$`, 'i');
         const match = regex.exec(url);
         if (!match) {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR adds a new method normalizeWebsiteOfUrl in str.js to format the website of url to lower case. The new method is used in both `link` and `autolink` rule replacement to format the `href` property of an anchor tag. It can also be used in the App codebase when handling edited link.

### Fixed Issues
$ https://github.com/Expensify/App/issues/18514

# Tests
1. Add a comment
```
Google.com
```
2. Click to edit the comment and verify the domain `google.com` of the url is in lower case in the initial draft, like
```
[Google.com](https://google.com)
```
3. Edit the comment to
```
[Google.com](https://Google.com)
```
and save the comment
4. Verify that the link is unchanged.


https://github.com/Expensify/expensify-common/assets/117511920/0856a371-419a-478d-8442-bd01e12ba5cd



# QA
N/A
