### PR TITLE
Added unescape to htmlToText

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -8,3 +8,9 @@ test('Test text is escaped', () => {
     const resultString = '&amp; &amp;amp; &amp;lt; &lt;';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test text is unescaped', () => {
+    const htmlString = '&amp; &amp;amp; &amp;lt; &lt;';
+    const resultString = '& &amp; &lt; <';
+    expect(parser.htmlToText(htmlString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -590,6 +590,8 @@ export default class ExpensiMark {
             replacedText = replacedText.replace(rule.regex, rule.replacement);
         });
 
+        // Unescaping because the text is escaped in 'replace' function
+        replacedText = _.unescape(replacedText);
         return replacedText;
     }
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
Added `_.unescape` to `htmlToText` method, because we are escaping in `replace`

### Fixed Issues
$ https://github.com/Expensify/App/issues/17658

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
In `Expensimark-test.js` file, text named `Test text is unescaped`

2. What tests did you perform that validates your changed worked?
Checked if string is unescaped and character codes are turning back into characters

# QA
1. What does QA need to do to validate your changes?
Run the new test cases
2. What areas to they need to test for regressions?
Check if character codes are turned back into charecters in `htmlToText` method. `&amp;` ->`&`
