### PR TITLE
Prevent mention rendered inside link and code

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -837,12 +837,24 @@ test('Test for user mention with invalid username', () => {
 });
 
 test('Test for user mention with codefence style', () => {
+    const testString = '```@username@expensify.com```';
+    const resultString = '<pre>@username@expensify.com</pre>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test for user mention with inlineCodeBlock style', () => {
+    const testString = '`@username@expensify.com`';
+    const resultString = '<code>@username@expensify.com</code>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test for user mention with text with codefence style', () => {
     const testString = '```hi @username@expensify.com```';
     const resultString = '<pre>hi&#32;@username@expensify.com</pre>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test for user mention with inlineCodeBlock style', () => {
+test('Test for user mention with text with inlineCodeBlock style', () => {
     const testString = '`hi @username@expensify.com`';
     const resultString = '<code>hi @username@expensify.com</code>';
     expect(parser.replace(testString)).toBe(resultString);

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -838,13 +838,13 @@ test('Test for user mention with invalid username', () => {
 
 test('Test for user mention with codefence style', () => {
     const testString = '```hi @username@expensify.com```';
-    const resultString = '<pre>@username@expensify.com</pre>';
+    const resultString = '<pre>hi&#32;@username@expensify.com</pre>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test for user mention with inlineCodeBlock style', () => {
     const testString = '`hi @username@expensify.com`';
-    const resultString = '<code>@username@expensify.com</code>';
+    const resultString = '<code>hi @username@expensify.com</code>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -837,14 +837,26 @@ test('Test for user mention with invalid username', () => {
 });
 
 test('Test for user mention with codefence style', () => {
-    const testString = '```@username@expensify.com```';
+    const testString = '```hi @username@expensify.com```';
     const resultString = '<pre>@username@expensify.com</pre>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test for user mention with inlineCodeBlock style', () => {
-    const testString = '`@username@expensify.com`';
+    const testString = '`hi @username@expensify.com`';
     const resultString = '<code>@username@expensify.com</code>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test for user mention inside link markdown', () => {
+    const testString = '[@username@expensify.com](expensify.com)';
+    const resultString = '<a href="https://expensify.com" target="_blank" rel="noreferrer noopener">@username@expensify.com</a>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test for user mention inside email markdown', () => {
+    const testString = '[@username@expensify.com](username@expensify.com)';
+    const resultString = '<a href="mailto:username@expensify.com">@username@expensify.com</a>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -50,39 +50,6 @@ export default class ExpensiMark {
             },
 
             /**
-             * Apply the hereMention first because the string @here is still a valid mention for the userMention regex.
-             * This ensures that the hereMention is always considered first, even if it is followed by a valid userMention.
-            */
-            {
-                name: 'hereMentions',
-                regex: /((&#x60;|<code>|<pre>)\s*?)?[`.a-zA-Z]?@here\b/gm,
-                replacement: (match) => {
-                    if (!Str.isValidMention(match)) {
-                        return match;
-                    }
-                    return `<mention-here>${match}</mention-here>`;
-                },
-            },
-
-            /**
-             * This regex matches a valid user mention in a string.
-             * A user mention is a string that starts with the '@' symbol and is followed by a valid user's primary login
-             *
-             * Note: currently we are only allowing mentions in a format of @+19728974297@expensify.sms and @username@example.com
-             * The username can contain any combination of alphanumeric letters, numbers, and underscores
-             */
-            {
-                name: 'userMentions',
-                regex: new RegExp(`((&#x60;|<code>|<pre>)\\s*?)?[\`.a-zA-Z]?@+${CONST.REG_EXP.EMAIL_PART}`, 'gm'),
-                replacement: (match) => {
-                    if (!Str.isValidMention(match)) {
-                        return match;
-                    }
-                    return `<mention-user>${match}</mention-user>`;
-                },
-            },
-
-            /**
              * Converts markdown style links to anchor tags e.g. [Expensify](concierge@expensify.com)
              * We need to convert before the auto email link rule and the manual link rule since it will not try to create a link
              * from an existing anchor tag.
@@ -118,6 +85,41 @@ export default class ExpensiMark {
                         return match;
                     }
                     return `<a href="${Str.sanitizeURL(g2)}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
+                },
+            },
+
+            /**
+             * Apply the hereMention first because the string @here is still a valid mention for the userMention regex.
+             * This ensures that the hereMention is always considered first, even if it is followed by a valid userMention.
+             * 
+             * Also, apply the mention rule after email/link to prevent mention appears in an email/link.
+             */
+            {
+                name: 'hereMentions',
+                regex: /(\s*?)?[`.a-zA-Z]?@here\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/gm,
+                replacement: (match) => {
+                    if (!Str.isValidMention(match)) {
+                        return match;
+                    }
+                    return `<mention-here>${match}</mention-here>`;
+                },
+            },
+
+            /**
+             * This regex matches a valid user mention in a string.
+             * A user mention is a string that starts with the '@' symbol and is followed by a valid user's primary login
+             *
+             * Note: currently we are only allowing mentions in a format of @+19728974297@expensify.sms and @username@example.com
+             * The username can contain any combination of alphanumeric letters, numbers, and underscores
+             */
+            {
+                name: 'userMentions',
+                regex: new RegExp(`(\\s*?)?[\`.a-zA-Z]?@+${CONST.REG_EXP.EMAIL_PART}(?![^<]*(<\\/pre>|<\\/code>|<\\/a>))`, 'gm'),
+                replacement: (match) => {
+                    if (!Str.isValidMention(match)) {
+                        return match;
+                    }
+                    return `<mention-user>${match}</mention-user>`;
                 },
             },
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -96,7 +96,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'hereMentions',
-                regex: /(\s*?)?[`.a-zA-Z]?@here\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/gm,
+                regex: /[`.a-zA-Z]?@here\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/gm,
                 replacement: (match) => {
                     if (!Str.isValidMention(match)) {
                         return match;
@@ -114,7 +114,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`(\\s*?)?[\`.a-zA-Z]?@+${CONST.REG_EXP.EMAIL_PART}(?![^<]*(<\\/pre>|<\\/code>|<\\/a>))`, 'gm'),
+                regex: new RegExp(`[\`.a-zA-Z]?@+${CONST.REG_EXP.EMAIL_PART}(?![^<]*(<\\/pre>|<\\/code>|<\\/a>))`, 'gm'),
                 replacement: (match) => {
                     if (!Str.isValidMention(match)) {
                         return match;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -91,7 +91,7 @@ export default class ExpensiMark {
             /**
              * Apply the hereMention first because the string @here is still a valid mention for the userMention regex.
              * This ensures that the hereMention is always considered first, even if it is followed by a valid userMention.
-             * 
+             *
              * Also, apply the mention rule after email/link to prevent mention appears in an email/link.
              */
             {

--- a/lib/str.js
+++ b/lib/str.js
@@ -937,10 +937,7 @@ const Str = {
     },
 
     /**
-     * We validate mentions by checking if it's first character is an allowed character
-     * and by checking that we make sure it isn't inside other tags where mentions aren't allowed.
-     * For example, *@username@expensify.com* is a valid mention because we allow bold styling for it,
-     * but `@username@expensify.com` is not because we do not allow mentions within code
+     * We validate mentions by checking if it's first character is an allowed character.
      *
      * @param {String} mention
      * @returns {bool}
@@ -948,11 +945,7 @@ const Str = {
     isValidMention(mention) {
         // A valid mention starts with a space, *, _, #, ', ", or @ (with no preceding characters).
         const startsWithValidChar = /[\s*~_#'"@]/g.test(mention.charAt(0));
-
-        // We don't support mention inside code or codefence styling,
-        // for example using `@username@expensify.com` or ```@username@expensify.com``` will be invalid.
-        const containsInvalidTag = /(<code>|<pre>|&#x60;)/g.test(mention);
-        return startsWithValidChar && !containsInvalidTag;
+        return startsWithValidChar;
     },
 
     /**

--- a/lib/str.js
+++ b/lib/str.js
@@ -944,8 +944,7 @@ const Str = {
      */
     isValidMention(mention) {
         // A valid mention starts with a space, *, _, #, ', ", or @ (with no preceding characters).
-        const startsWithValidChar = /[\s*~_#'"@]/g.test(mention.charAt(0));
-        return startsWithValidChar;
+        return /[\s*~_#'"@]/g.test(mention.charAt(0));
     },
 
     /**


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/18983
$ https://github.com/Expensify/App/issues/18857

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
ExpensiMark-HTML-test.js. Added test for mention inside link and email and update the test with code block/fence a bit.

1. What tests did you perform that validates your changed worked?
Make sure mention won't get converted into HTML if it's inside code block/fence and link/email.

# QA
1. What does QA need to do to validate your changes?
Can QA run the unit test? Or maybe we can test in App instead.
1. What areas to they need to test for regressions?
In chat by sending mention inside code block/fence and link/email markdown.

Step:
1. Open any chat
2. Type:
a. Mention inside code block, for example 
```
`hi @bernhard.josephus@gmail.com`
```
b. Mention inside code fence, for example
```
```hi @bernhard.josephus@gmail.com```
```
c. Mention inside link, for example
```
[@bernhard.josephus@gmail.com](google.com)
```
3. Send each message you type
4. Verify `@bernhard.josephus@gmail.com` is not converted into a mention

**Video**

https://github.com/Expensify/expensify-common/assets/50919443/f05cc963-c2ed-4627-82ee-bbabbe6d4c8a

