### PR TITLE
fix: export link regex for use in edit message

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -1,9 +1,7 @@
 import _ from 'underscore';
 import Str from './str';
-import {MARKDOWN_URL_REGEX, LOOSE_URL_REGEX, URL_REGEX} from './Url';
+import {MARKDOWN_LINK_REGEX, MARKDOWN_URL_REGEX, LOOSE_URL_REGEX, URL_REGEX} from './Url';
 import {CONST} from './CONST';
-
-const MARKDOWN_LINK_REGEX = `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`;
 
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
@@ -722,7 +720,3 @@ export default class ExpensiMark {
         return tagStack.length !== 0;
     }
 }
-
-export {
-    MARKDOWN_LINK_REGEX
-};

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -1,7 +1,9 @@
 import _ from 'underscore';
 import Str from './str';
-import {MARKDOWN_LINK_REGEX, MARKDOWN_URL_REGEX, LOOSE_URL_REGEX, URL_REGEX} from './Url';
+import {MARKDOWN_URL_REGEX, LOOSE_URL_REGEX, URL_REGEX} from './Url';
 import {CONST} from './CONST';
+
+const MARKDOWN_LINK_REGEX = `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`;
 
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
@@ -720,3 +722,7 @@ export default class ExpensiMark {
         return tagStack.length !== 0;
     }
 }
+
+export {
+    MARKDOWN_LINK_REGEX
+};

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -3,6 +3,8 @@ import Str from './str';
 import {MARKDOWN_URL_REGEX, LOOSE_URL_REGEX, URL_REGEX} from './Url';
 import {CONST} from './CONST';
 
+const MARKDOWN_LINK_REGEX = `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`;
+
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
 export default class ExpensiMark {
@@ -106,10 +108,7 @@ export default class ExpensiMark {
             {
                 name: 'link',
                 process: (textToProcess, replacement) => {
-                    const regex = new RegExp(
-                        `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`,
-                        'gi',
-                    );
+                    const regex = new RegExp(MARKDOWN_LINK_REGEX, 'gi');
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
                 },
 
@@ -721,3 +720,7 @@ export default class ExpensiMark {
         return tagStack.length !== 0;
     }
 }
+
+export {
+    MARKDOWN_LINK_REGEX
+};

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -721,8 +721,31 @@ export default class ExpensiMark {
         // If there are any tags left in the stack, they're unclosed
         return tagStack.length !== 0;
     }
-}
 
-export {
-    MARKDOWN_LINK_REGEX
-};
+    /**
+     * @param {String} comment
+     * @returns {Array}
+     */
+    extractLinksInMarkdownComment(comment) {
+        const regex = new RegExp(MARKDOWN_LINK_REGEX, 'gi');
+        const escapedComment = _.escape(comment);
+        const matches = [...escapedComment.matchAll(regex)];
+
+        // Element 1 from match is the regex group if it exists which contains the link URLs
+        const links = _.map(matches, (match) => Str.sanitizeURL(match[2]));
+        return links;
+    };
+
+    /**
+     * Compares two markdown comments and returns a list of the links removed in a new comment.
+     *
+     * @param {String} oldComment
+     * @param {String} newComment
+     * @returns {Array}
+     */
+    getRemovedMarkdownLinks(oldComment, newComment) {
+        const linksInOld = this.extractLinksInMarkdownComment(oldComment);
+        const linksInNew = this.extractLinksInMarkdownComment(newComment);
+        return _.difference(linksInOld, linksInNew);
+    };
+}

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -3,7 +3,7 @@ import Str from './str';
 import {MARKDOWN_URL_REGEX, LOOSE_URL_REGEX, URL_REGEX} from './Url';
 import {CONST} from './CONST';
 
-const MARKDOWN_LINK_REGEX = `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`;
+const MARKDOWN_LINK_REGEX = new RegExp(`\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
 
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
@@ -74,10 +74,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'link',
-                process: (textToProcess, replacement) => {
-                    const regex = new RegExp(MARKDOWN_LINK_REGEX, 'gi');
-                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
-                },
+                process: (textToProcess, replacement) => this.modifyTextForUrlLinks(MARKDOWN_LINK_REGEX, textToProcess, replacement),
 
                 replacement: (match, g1, g2) => {
                     if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
@@ -727,9 +724,8 @@ export default class ExpensiMark {
      * @returns {Array}
      */
     extractLinksInMarkdownComment(comment) {
-        const regex = new RegExp(MARKDOWN_LINK_REGEX, 'gi');
         const escapedComment = _.escape(comment);
-        const matches = [...escapedComment.matchAll(regex)];
+        const matches = [...escapedComment.matchAll(MARKDOWN_LINK_REGEX)];
 
         // Element 1 from match is the regex group if it exists which contains the link URLs
         const links = _.map(matches, match => Str.sanitizeURL(match[2]));

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -732,9 +732,9 @@ export default class ExpensiMark {
         const matches = [...escapedComment.matchAll(regex)];
 
         // Element 1 from match is the regex group if it exists which contains the link URLs
-        const links = _.map(matches, (match) => Str.sanitizeURL(match[2]));
+        const links = _.map(matches, match => Str.sanitizeURL(match[2]));
         return links;
-    };
+    }
 
     /**
      * Compares two markdown comments and returns a list of the links removed in a new comment.
@@ -747,5 +747,5 @@ export default class ExpensiMark {
         const linksInOld = this.extractLinksInMarkdownComment(oldComment);
         const linksInNew = this.extractLinksInMarkdownComment(newComment);
         return _.difference(linksInOld, linksInNew);
-    };
+    }
 }

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -16,7 +16,6 @@ const LOOSE_URL_REGEX = `((${LOOSE_URL_WEBSITE_REGEX})${URL_PATH_REGEX}(?:${URL_
 
 
 const MARKDOWN_URL_REGEX = `(${LOOSE_URL_REGEX}|${URL_REGEX})`;
-const MARKDOWN_LINK_REGEX = `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`;
 
 export {
     URL_WEBSITE_REGEX,
@@ -29,5 +28,4 @@ export {
     LOOSE_URL_REGEX,
     LOOSE_URL_WEBSITE_REGEX,
     MARKDOWN_URL_REGEX,
-    MARKDOWN_LINK_REGEX,
 };

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -16,6 +16,7 @@ const LOOSE_URL_REGEX = `((${LOOSE_URL_WEBSITE_REGEX})${URL_PATH_REGEX}(?:${URL_
 
 
 const MARKDOWN_URL_REGEX = `(${LOOSE_URL_REGEX}|${URL_REGEX})`;
+const MARKDOWN_LINK_REGEX = `\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`;
 
 export {
     URL_WEBSITE_REGEX,
@@ -28,4 +29,5 @@ export {
     LOOSE_URL_REGEX,
     LOOSE_URL_WEBSITE_REGEX,
     MARKDOWN_URL_REGEX,
+    MARKDOWN_LINK_REGEX,
 };


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/18911

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
ExpensiMark-HTML-test.js. Nothing added because there is no regex change.
2. What tests did you perform that validates your changed worked?
Make sure that all unit-tests are passed.

# QA
1. What does QA need to do to validate your changes?
This PR has no regex change. Can verify if all unit-tests are passed.
2. What areas to they need to test for regressions?
Nothing.
