### PR TITLE
Remove `[block]` intermediary

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -265,7 +265,7 @@ export default class ExpensiMark {
             {
                 name: 'heading1',
                 regex: /[^\S\r\n]*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))[^\S\r\n]*/gi,
-                replacement: '[block]# $2[block]',
+                replacement: '<h1># $2</h1>',
             },
             {
                 name: 'listItem',
@@ -294,8 +294,8 @@ export default class ExpensiMark {
                 regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
                     // We remove the line break before heading inside quote to avoid adding extra line
-                    const resultString = g2.replace(/\n?(\[block\]# )/g, '$1')
-                        .replace(/(\[block\])+/g, '\n')
+                    const resultString = g2.replace(/\n?(<h1># )/g, '$1')
+                        .replace(/(<h1>|<\/h1>)+/g, '\n')
                         .trim()
                         .split('\n')
                         .map(m => `> ${m}`)
@@ -511,17 +511,18 @@ export default class ExpensiMark {
     }
 
     /**
-     * replace [block] with '\n' if :
-     * 1. We have text before the [block].
+     * replace block element with '\n' if :
+     * 1. We have text within the element.
      * 2. The text does not end with a new line.
      * 3. The text does not have quote mark '>' .
-     * 4. [block] not the last [block] in the string.
+     * 4. It's not the last element in the string.
      *
      * @param {String} htmlString
      * @returns {String}
      */
     replaceBlockWithNewLine(htmlString) {
-        const splitText = htmlString.split('[block]');
+        let splitText = htmlString.split(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>/);
+        splitText = splitText.map(text => Str.stripHTML(text));
         let joinedText = '';
 
         // Delete whitespace at the end
@@ -537,7 +538,7 @@ export default class ExpensiMark {
                 return;
             }
 
-            // Insert '\n' unless it ends with '\n' or '>' or it's the last [block].
+            // Insert '\n' unless it ends with '\n' or '>' or it's the last element.
             if (text.match(/[\n|>][>]?[\s]?$/) || index === splitText.length - 1) {
                 joinedText += text;
             } else {
@@ -572,11 +573,7 @@ export default class ExpensiMark {
             }
             generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
         });
-        generatedMarkdown = generatedMarkdown.replace(
-            /<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>/gm,
-            '[block]',
-        );
-        return Str.htmlDecode(this.replaceBlockWithNewLine(Str.stripHTML(generatedMarkdown)));
+        return Str.htmlDecode(this.replaceBlockWithNewLine(generatedMarkdown));
     }
 
     /**

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -520,7 +520,7 @@ export default class ExpensiMark {
      * @param {String} htmlString
      * @returns {String}
      */
-    replaceBlockWithNewLine(htmlString) {
+    replaceBlockElementWithNewLine(htmlString) {
         let splitText = htmlString.split(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>/);
         splitText = splitText.map(text => Str.stripHTML(text));
         let joinedText = '';
@@ -573,7 +573,7 @@ export default class ExpensiMark {
             }
             generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
         });
-        return Str.htmlDecode(this.replaceBlockWithNewLine(generatedMarkdown));
+        return Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
     }
 
     /**


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR completely removes `[block]` intermediary as it may coincide with user's input.

### Fixed Issues
<!---
1. Please replace GH_LINK with a URL link to the GitHub issue this Pull Request is fixing.
2. Please replace PROPOSAL: GH_LINK_ISSUE(COMMENT) with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<number-of-the-issue>
$ https://github.com/Expensify/App/issues/<number-of-the-issue(comment)>

Do NOT only link the issue number like this: $ #<number-of-the-issue>
--->

$ https://github.com/Expensify/App/issues/17776
$ PROPOSAL: https://github.com/Expensify/App/issues/17776#issuecomment-1538347039

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Login ND with any account
2. Go to any chat
3. Type the word `[block]` and send it
4. Click the pencil icon to edit the comment
5. Verify that the composer shows `[block]` as is

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

NA

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Login ND with any account
2. Go to any chat
3. Type the word `[block]` and send it
4. Click the pencil icon to edit the comment
5. Verify that the composer shows `[block]` as is

- [ ] Verify that no errors appear in the JS console

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

[Screencast from 23-05-2023 21:12:02.webm](https://github.com/Expensify/expensify-common/assets/113963320/91b2d28e-43a8-4e63-aa7e-c092ab0ef4f4)

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/expensify-common/assets/113963320/786a05f4-71e6-425a-b11f-78a2d115864c



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/expensify-common/assets/113963320/74b54984-95d5-40d6-a456-1193a6562e37



</details>

<details>
<summary>Desktop</summary>


<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/113963320/b3a56179-a121-430e-afe8-6ec8de9b4418


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/113963320/d90846d0-5d7f-429f-a00d-1add25033a4a

</details>

<details>
<summary>Android</summary>


[untitled.webm](https://github.com/Expensify/expensify-common/assets/113963320/b2b950e5-52c7-404c-b095-490e96f35a5e)


<!-- add screenshots or videos here -->

</details>