### PR TITLE
Skip rendering bold style when partially overlapping with quote

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -949,4 +949,7 @@ test('Skip rendering invalid markdown',() => {
 
     testString = '~*test~*';
     expect(parser.replace(testString)).toBe('~<strong>test~</strong>');
+
+    testString = '> *This is multiline\nbold text*';
+    expect(parser.replace(testString)).toBe('<blockquote>*This is multiline</blockquote>bold text*');
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -154,6 +154,23 @@ export default class ExpensiMark {
                 },
             },
             {
+                name: 'quote',
+
+                // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
+                // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
+                // inline code blocks. A single prepending space should be stripped if it exists
+                process: (textToProcess, replacement) => {
+                    const regex = new RegExp(
+                        /\n?^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm,
+                    );
+                    return this.modifyTextForQuote(regex, textToProcess, replacement);
+                },
+                replacement: (g1) => {
+                    const replacedText = this.replace(g1, {filterRules: ['heading1'], shouldEscapeText: false});
+                    return `<blockquote>${replacedText}</blockquote>`;
+                },
+            },
+            {
                 /**
                  * Use \b in this case because it will match on words, letters,
                  * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
@@ -179,23 +196,6 @@ export default class ExpensiMark {
                 name: 'strikethrough',
                 regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: (match, g1) => (this.containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
-            },
-            {
-                name: 'quote',
-
-                // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
-                // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
-                // inline code blocks. A single prepending space should be stripped if it exists
-                process: (textToProcess, replacement) => {
-                    const regex = new RegExp(
-                        /\n?^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm,
-                    );
-                    return this.modifyTextForQuote(regex, textToProcess, replacement);
-                },
-                replacement: (g1) => {
-                    const replacedText = this.replace(g1, {filterRules: ['heading1'], shouldEscapeText: false});
-                    return `<blockquote>${replacedText}</blockquote>`;
-                },
             },
             {
                 name: 'heading1',
@@ -517,6 +517,7 @@ export default class ExpensiMark {
      * @returns {String}
      */
     replaceBlockElementWithNewLine(htmlString) {
+        // eslint-disable-next-line max-len
         let splitText = htmlString.split(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>/);
         splitText = splitText.map(text => Str.stripHTML(text));
         let joinedText = '';


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/19607

# Tests
1. Go to a chat
2. Add a comment
```
> *This is multiline
bold text*
```
3. Verify that text isn’t bold and the bold syntax is displayed in original text.


https://github.com/Expensify/expensify-common/assets/117511920/14c91e9a-5350-49da-acee-48d67f508d21



# QA
Same as test
