### PR TITLE
Use htmlDecode instead of unescape

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -10,7 +10,7 @@ test('Test text is escaped', () => {
 });
 
 test('Test text is unescaped', () => {
-    const htmlString = '&amp; &amp;amp; &amp;lt; &lt;';
-    const resultString = '& &amp; &lt; <';
+    const htmlString = '&amp; &#38; &amp;amp; &amp;lt; &#60; &lt;';
+    const resultString = '& & &amp; &lt; < <';
     expect(parser.htmlToText(htmlString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -10,7 +10,7 @@ test('Test text is escaped', () => {
 });
 
 test('Test text is unescaped', () => {
-    const htmlString = '&amp; &#38; &amp;amp; &amp;lt; &#60; &lt;';
-    const resultString = '& & &amp; &lt; < <';
+    const htmlString = '&amp;&#32;&amp;amp;&#32;&amp;lt;&#32;&lt;';
+    const resultString = '& &amp; &lt; <';
     expect(parser.htmlToText(htmlString)).toBe(resultString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -587,7 +587,8 @@ export default class ExpensiMark {
         });
 
         // Unescaping because the text is escaped in 'replace' function
-        replacedText = _.unescape(replacedText);
+        // We use 'htmlDecode' instead of 'unescape' to replace entities like '&#32;'
+        replacedText = Str.htmlDecode(replacedText);
         return replacedText;
     }
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -23,7 +23,7 @@ export default class ExpensiMark {
             {
                 name: 'codeFence',
 
-                // &#60; is a backtick symbol we are matching on three of them before then after a new line character
+                // &#x60; is a backtick symbol we are matching on three of them before then after a new line character
                 regex: /(&#x60;&#x60;&#x60;[\n]?)((?:\s*?(?![\n]?&#x60;&#x60;&#x60;(?!&#x60;))[\S])+\s*?)((?=\n?)&#x60;&#x60;&#x60;)/g,
 
                 // We're using a function here to perform an additional replace on the content


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
Currently `_.unescape()` is used to replace entities while html is being converted to text, however this function only replaces a limited number of entities resulting in only a part of the string being unescaped in a few cases. Because of this I've replaced it with `Str.htmlDecode()`.

For example `&#32;` is not unescaped by `_.unescape()` but is added in the replace function in line 36.

https://github.com/Expensify/expensify-common/blob/925e62744f784a92c3ad8947aabfc21c93bec221/lib/ExpensiMark.js#L23-L39

### Fixed Issues
$ https://github.com/Expensify/App/issues/19789

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
    - Added html entities to the unescape test in `ExpensiMark-test.js`.
    - Previously `&amp;&#32;&amp;amp;&#32;&amp;lt;&#32;&lt;` was being unescaped to `&&#32;&amp;&#32;&lt;&#32;<`, now it'll be unescaped to `& &amp; &lt; <`.
2. What tests did you perform that validates your changed worked?
    - Made sure all unit tests passed.

# QA
1. What does QA need to do to validate your changes?
    - Test the function with other [HTML entities](https://www.w3schools.com/html/html_entities.asp) to verify that they are being unescaped or simply run all unit tests.
2. What areas to they need to test for regressions?
    - Directly pushing these changes to other repositories such as [Expensify/App](https://github.com/Expensify/App) may cause some regressions.
    - While pushing these changes a few other changes have to be made. There are a few occurrences of `Str.htmlDecode()` being used on top of `parser.htmlToText()`, these will have to be changed to just `parser.htmlToText()` or it may result in a double unescape.