### PR TITLE
Support italic style for @here mention

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -934,6 +934,12 @@ test('Test for here mention with invalid username', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test for @here mention with italic style', () => {
+    const testString = '_@here_ @here_123 @here_abc @here123 @hereabc';
+    const resultString = '<em><mention-here>@here</mention-here></em> @here_123 @here_abc @here123 @hereabc';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test for @here mention without space or supported styling character', () => {
     const testString = 'hi@username@expensify.com';
     const resultString = 'hi@<a href=\"mailto:username@expensify.com\">username@expensify.com</a>';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -935,8 +935,37 @@ test('Test for here mention with invalid username', () => {
 });
 
 test('Test for @here mention with italic style', () => {
-    const testString = '_@here_ @here_123 @here_abc @here123 @hereabc';
-    const resultString = '<em><mention-here>@here</mention-here></em> @here_123 @here_abc @here123 @hereabc';
+    const testString = '@here'
+    + ' _@here_'
+    + ' [@here](google.com)'
+    + ' @here_123'
+    + ' @here_abc'
+    + ' @here123'
+    + ' @hereabc'
+    + ' @here abc'
+    + ' @here*'
+    + ' @here~'
+    + ' @here#'
+    + ' @here@'
+    + ' @here$'
+    + ' @here^'
+    + ' @here(';
+
+    const resultString = '<mention-here>@here</mention-here>'
+    + ' <em><mention-here>@here</mention-here></em>'
+    + ' <a href="https://google.com" target="_blank" rel="noreferrer noopener">@here</a>'
+    + ' @here_123'
+    + ' @here_abc'
+    + ' @here123'
+    + ' @hereabc'
+    + ' <mention-here>@here</mention-here> abc'
+    + ' <mention-here>@here</mention-here>*'
+    + ' <mention-here>@here</mention-here>~'
+    + ' <mention-here>@here</mention-here>#'
+    + ' <mention-here>@here</mention-here>@'
+    + ' <mention-here>@here</mention-here>$'
+    + ' <mention-here>@here</mention-here>^'
+    + ' <mention-here>@here</mention-here>(';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -934,9 +934,11 @@ test('Test for here mention with invalid username', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test for @here mention with italic style', () => {
+test('Test for @here mention with italic, bold and strikethrough styles', () => {
     const testString = '@here'
     + ' _@here_'
+    + ' *@here*'
+    + ' ~@here~'
     + ' [@here](google.com)'
     + ' @here_123'
     + ' @here_abc'
@@ -953,6 +955,8 @@ test('Test for @here mention with italic style', () => {
 
     const resultString = '<mention-here>@here</mention-here>'
     + ' <em><mention-here>@here</mention-here></em>'
+    + ' <strong><mention-here>@here</mention-here></strong>'
+    + ' <del><mention-here>@here</mention-here></del>'
     + ' <a href="https://google.com" target="_blank" rel="noreferrer noopener">@here</a>'
     + ' @here_123'
     + ' @here_abc'

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -92,7 +92,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'hereMentions',
-                regex: /[`.a-zA-Z]?@here\b(?![^<]*(<\/pre>|<\/code>|<\/a>))/gm,
+                regex: /[`.a-zA-Z]?@here(?=_\b|\b)(?![^<]*(<\/pre>|<\/code>|<\/a>))/gm,
                 replacement: (match) => {
                     if (!Str.isValidMention(match)) {
                         return match;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/19857

# Tests

https://github.com/Expensify/expensify-common/assets/117511920/f2a46c8e-0100-4448-8dfc-b35b1bfe9c1d


1. Add a comment `_@here_`
2. Verify that `@here` mention is displayed in italic



# QA
Same as test
