### PR TITLE
fix: italic syntax removing a preceding character

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -47,11 +47,13 @@ test('Test multi-line italic markdown replacement', () => {
 test('Test italic markdown replacement with word boundary and undercores', () => {
     const testString = 'hello_world '
         + 'hello__world '
+        + 'h_ello_ '
         + '_hello_ '
         + '___hello_ '
         + '___hello______';
     const replacedString = 'hello_world '
         + 'hello__world '
+        + 'h_ello_ '
         + '<em>hello</em> '
         + '__<em>hello</em> '
         + '__<em>hello</em>_____';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -44,6 +44,20 @@ test('Test multi-line italic markdown replacement', () => {
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
+test('Test italic markdown replacement with word boundary and undercores', () => {
+    const testString = 'hello_world '
+        + 'hello__world '
+        + '_hello_ '
+        + '___hello_ '
+        + '___hello______';
+    const replacedString = 'hello_world '
+        + 'hello__world '
+        + '<em>hello</em> '
+        + '__<em>hello</em> '
+        + '__<em>hello</em>_____';
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 // Words wrapped in ~ successfully replaced with <del></del>
 test('Test strikethrough markdown replacement', () => {
     const strikethroughTestStartString = 'This is a ~sentence,~ and it has some ~punctuation, words, and spaces~. ~test~ ~ testing~ test~test~test. ~ testing ~ ~testing ~';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -181,8 +181,10 @@ export default class ExpensiMark {
                  * Use [\s\S]* instead of .* to match newline
                  */
                 name: 'italic',
-                regex: /(?!_blank")[^\W_]?_((?![\s_])[\s\S]*?[^\s_])_(?![^\W_])(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|_blank))/g,
-                replacement: (match, g1) => (g1.includes('<pre>') || this.containsNonPairTag(g1) ? match : `<em>${g1}</em>`),
+                regex: /(\b_+|\b)(?!_blank")_((?![\s_])[\s\S]*?[^\s_])_(?![^\W_])(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|_blank))/g,
+
+                // We add g1 which is underscores or empty string back before the <em> tag
+                replacement: (match, g1, g2) => (g2.includes('<pre>') || this.containsNonPairTag(g2) ? match : `${g1}<em>${g2}</em>`),
             },
             {
                 // Use \B in this case because \b doesn't match * or ~.

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -183,7 +183,8 @@ export default class ExpensiMark {
                 name: 'italic',
                 regex: /(\b_+|\b)(?!_blank")_((?![\s_])[\s\S]*?[^\s_])_(?![^\W_])(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|_blank))/g,
 
-                // We add g1 which is underscores or empty string back before the <em> tag
+                // g1 is empty string or includes one or more underscores, eg: `hello ___world_`
+                // We want to add g1 back before the <em> tag
                 replacement: (match, g1, g2) => (g2.includes('<pre>') || this.containsNonPairTag(g2) ? match : `${g1}<em>${g2}</em>`),
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -183,9 +183,12 @@ export default class ExpensiMark {
                 name: 'italic',
                 regex: /(\b_+|\b)(?!_blank")_((?![\s_])[\s\S]*?[^\s_])_(?![^\W_])(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|_blank))/g,
 
-                // g1 is empty string or includes one or more underscores, eg: `hello ___world_`
-                // We want to add g1 back before the <em> tag
-                replacement: (match, g1, g2) => (g2.includes('<pre>') || this.containsNonPairTag(g2) ? match : `${g1}<em>${g2}</em>`),
+                // We want to add extraLeadingUnderscores back before the <em> tag
+                replacement: (match, extraLeadingUnderscores, textWithinUnderscores) => (
+                    textWithinUnderscores.includes('<pre>') || this.containsNonPairTag(textWithinUnderscores)
+                        ? match
+                        : `${extraLeadingUnderscores}<em>${textWithinUnderscores}</em>`
+                ),
             },
             {
                 // Use \B in this case because \b doesn't match * or ~.


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/20111

# Tests
1. Go to chat and add a comment
```
h_ello_
```
2. Verify that the comment text is `h_ello_` and it's not rendered as italic style.

# QA
Same
