### PR TITLE
fix: parsing underscores in the email of user mention 

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -890,6 +890,12 @@ test('Test for user mention without space or supported styling character', () =>
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test for user mention with user email includes underscores', () => {
+    const testString = '@_concierge_@expensify.com';
+    const resultString = '<mention-user>@_concierge_@expensify.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test for @here mention with codefence style', () => {
     const testString = '```@here```';
     const resultString = '<pre>@here</pre>';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -181,7 +181,7 @@ export default class ExpensiMark {
                  * Use [\s\S]* instead of .* to match newline
                  */
                 name: 'italic',
-                regex: /(?!_blank")[^\W_]?_((?![\s_])[\s\S]*?[^\s_])_(?![^\W_])(?![^<]*(<\/pre>|<\/code>|<\/a>|_blank))/g,
+                regex: /(?!_blank")[^\W_]?_((?![\s_])[\s\S]*?[^\s_])_(?![^\W_])(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|_blank))/g,
                 replacement: (match, g1) => (g1.includes('<pre>') || this.containsNonPairTag(g1) ? match : `<em>${g1}</em>`),
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/19957

# Tests
1. Go to a chat and add a comment `@_concierge_@expensify.com`
2. Verify that App doesn’t crash and `_concierge_` is not rendered as italic 

# QA
Same as test
