### PR TITLE
fix: unwanted linebreaks added when translating html blockquote to markdown

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -293,7 +293,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'quote',
-                regex: /\n?<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(blockquote|q)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (match, g1, g2) => {
                     // We remove the line break before heading inside quote to avoid adding extra line
                     const resultString = g2.replace(/\n?(<h1># )/g, '$1')
@@ -302,7 +302,9 @@ export default class ExpensiMark {
                         .split('\n')
                         .map(m => `> ${m}`)
                         .join('\n');
-                    return `\n${resultString}\n`;
+
+                    // We want to keep <blockquote> tag here and let method replaceBlockElementWithNewLine to handle the line break later
+                    return `<blockquote>${resultString}</blockquote>`;
                 },
             },
             {
@@ -524,7 +526,7 @@ export default class ExpensiMark {
      */
     replaceBlockElementWithNewLine(htmlString) {
         // eslint-disable-next-line max-len
-        let splitText = htmlString.split(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>/);
+        let splitText = htmlString.split(/<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>|<blockquote>|<\/blockquote>/);
         splitText = splitText.map(text => Str.stripHTML(text));
         let joinedText = '';
 
@@ -654,9 +656,6 @@ export default class ExpensiMark {
             if (textToFormat !== '') {
                 replacedText += this.formatTextForQuote(regex, textToFormat, replacement);
             }
-
-            // Replace all the blank lines between quotes, if there are only blank lines between them
-            replacedText = replacedText.replace(/(<\/blockquote>((\s*)+)<blockquote>)/g, '</blockquote><blockquote>');
         } else {
             // If we doesn't have matches make sure the function will return the same textToCheck
             replacedText = textToCheck;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/20725

# Tests


1. Go to a chat and add a comment for case 1

```
==== Case 1: simple quote ===
> one line quote a

> two line quote b
> two line quote b

> quote c with internal line break
> 
> quote c with internal line break
```

2. Open the comment in editing mode and verify that the initial draft is same as input.

3. Select the comment, copy the selection by Ctr/Cmd + C, paste it to composer and verify that it's same as input

   https://github.com/Expensify/App/assets/117511920/fa1332d1-b19d-425f-b759-c864b0a0f653

4. Add a comment for case 2

```
==== Case 2: quote surrounded by text ===
text a
> quote a

> quote b
text b

text c
> quote c
text c
```

5. Repeat step 2 and 3

   https://github.com/Expensify/App/assets/117511920/b35284f5-3f41-49ef-9223-aa018022d6b3

6. Add a comment for case 3

```
==== Case 3: quote surrounded by inline element ===
_italic a_
> quote a

> quote b
*bold b*

_italic c_
> quote c
*bold c*
```

7. Repeat step 2 and 3

   https://github.com/Expensify/App/assets/117511920/5d0a6c47-fe21-4a66-ad09-4c76862d0759

8. Open [w3schools](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_blockquote_test), add following html and run

```html
<!DOCTYPE html>
<html>
<body>

<p>==== Case 4A: quote surrounded by block element ===</p>

<pre>code fence a</pre>
<blockquote>
quote a
</blockquote>

<br />

<blockquote>
quote b
</blockquote>
<pre>code fence b</pre>

<br />

<pre>code fence c</pre>
<blockquote>
quote c
</blockquote>
<pre>code fence c</pre>

</body>
</html>
```

9. Select and copy html from right hand side of w3schools page and paste it to composer
10. Verify that the composer input is equal to following input

````
==== Case 4A: quote surrounded by block element ===
```
code fence a
```
> quote a

> quote b
```
code fence b
```

```
code fence c
```
> quote c
```
code fence c
```
````
https://github.com/Expensify/App/assets/117511920/12b54ae0-e024-4212-8c49-7a6b11595c33

11. Repeat Step 8 with following html

```html
<!DOCTYPE html>
<html>
<body>

<p>==== Case 4B: quote surrounded by block element ===</p>

<h1>h1 a</h1>
<blockquote>
quote a
</blockquote>

<br />

<blockquote>
quote b
</blockquote>
<h1>h1 b</h1>

<br />

<h1>h1 c</h1>
<blockquote>
quote c
</blockquote>
<h1>h1 c</h1>

</body>
</html>

```

12. Repeat step 9
13. Verify that the composer input is equal to following input

```
==== Case 4B: quote surrounded by block element ===
# h1 a
> quote a

> quote b
# h1 b

# h1 c
> quote c
# h1 c
```
https://github.com/Expensify/App/assets/117511920/c31728f3-f183-430a-9196-eae236342a32



# QA
1. Go to a chat and add comment
```
==== Case 1: simple quote ===
> one line quote a

> two line quote b
> two line quote b

> quote c with internal line break
> 
> quote c with internal line break

==== Case 2: quote surrounded by text ===
text a
> quote a

> quote b
text b

text c
> quote c
text c

==== Case 3: quote surrounded by inline element ===
_italic a_
> quote a

> quote b
*bold b*

_italic c_
> quote c
*bold c*
```
2. Open the comment in editing mode and verify that the initial draft is same as input.
3. Test copy and pasting 
3a. On Web and Desktop, select the comment, copy the selection by Ctr/Cmd + C, paste it to composer and verify that it's same as input
3b. On mobile, long press comment, copy to clipboard, pasting in composer and verify that it's same as input
4. (Perform step 4-9 on Web only) Open [w3schools](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_blockquote_test), add following html and run

```html
<!DOCTYPE html>
<html>
<body>

<p>==== Case 4A: quote surrounded by block element ===</p>

<pre>code fence a</pre>
<blockquote>
quote a
</blockquote>

<br />

<blockquote>
quote b
</blockquote>
<pre>code fence b</pre>

<br />

<pre>code fence c</pre>
<blockquote>
quote c
</blockquote>
<pre>code fence c</pre>

</body>
</html>
```

5. Select and copy html from right hand side of w3schools page and paste it to composer
6. Verify that the composer input is equal to following input

````
==== Case 4A: quote surrounded by block element ===
```
code fence a
```
> quote a

> quote b
```
code fence b
```

```
code fence c
```
> quote c
```
code fence c
```
````
https://github.com/Expensify/App/assets/117511920/12b54ae0-e024-4212-8c49-7a6b11595c33

7. Repeat Step 4 with following html

```html
<!DOCTYPE html>
<html>
<body>

<p>==== Case 4B: quote surrounded by block element ===</p>

<h1>h1 a</h1>
<blockquote>
quote a
</blockquote>

<br />

<blockquote>
quote b
</blockquote>
<h1>h1 b</h1>

<br />

<h1>h1 c</h1>
<blockquote>
quote c
</blockquote>
<h1>h1 c</h1>

</body>
</html>

```

8. Repeat step 5
9. Verify that the composer input is equal to following input

```
==== Case 4B: quote surrounded by block element ===
# h1 a
> quote a

> quote b
# h1 b

# h1 c
> quote c
# h1 c
```
https://github.com/Expensify/App/assets/117511920/c31728f3-f183-430a-9196-eae236342a32


### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.



### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/expensify-common/assets/117511920/506663cb-2b32-4d82-ac09-1b3303212e02



https://github.com/Expensify/expensify-common/assets/117511920/972ce5cf-5d38-45c2-b61f-95a7d3b8efab



https://github.com/Expensify/expensify-common/assets/117511920/dc0dd8c2-6992-44e1-9738-8f35cf8ff0e9




</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/expensify-common/assets/117511920/fab436c6-4033-4690-836f-bf9c01c3aa79





</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/Expensify/expensify-common/assets/117511920/b932ce11-f87f-4723-aa63-6086d9108ce8





</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/expensify-common/assets/117511920/8f9bb6cc-3f07-4402-b2a7-bd4421677eab






</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->




https://github.com/Expensify/expensify-common/assets/117511920/c151ed5b-f54b-474b-8225-8b1755387ce4




</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->



https://github.com/Expensify/expensify-common/assets/117511920/cfe65284-bd67-4401-855d-b081ae1692f9



</details>