### PR TITLE
fix: 'No content to add' error if we send empty alias for email

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -509,8 +509,8 @@ test('Test markdown style email link with various styles', () => {
         + '[Expensify!](no-concierge1@expensify.com) '
         + '[Expensify?](concierge?@expensify.com) '
         + '[Applause](applausetester+qaabecciv@applause.expensifail.com) '
-        + '[](concierge@expensify.com)' // empty in []
-        + '[   ](concierge@expensify.com)' // only spaces in []
+        + '[](concierge@expensify.com)' // only parse autoEmail in ()
+        + '[   ](concierge@expensify.com)' // only parse autoEmail in () and keep spaces in []
         + '[ Expensify ](concierge@expensify.com)' // edge spaces in []
         + '[ Expensify Email ](concierge@expensify.com)' // space between words in []
         + '[concierge@expensify.com](concierge@expensify.com)' // same email between [] and ()
@@ -526,8 +526,8 @@ test('Test markdown style email link with various styles', () => {
         + '<a href="mailto:no-concierge1@expensify.com">Expensify!</a> '
         + '<a href="mailto:concierge?@expensify.com">Expensify?</a> '
         + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">Applause</a> '
-        + '<a href="mailto:concierge@expensify.com"></a>'
-        + '<a href="mailto:concierge@expensify.com"></a>'
+        + '[](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)'
+        + '[   ](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)'
         + '<a href="mailto:concierge@expensify.com">Expensify</a>'
         + '<a href="mailto:concierge@expensify.com">Expensify Email</a>'
         + '<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>'

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -511,6 +511,7 @@ test('Test markdown style email link with various styles', () => {
         + '[Applause](applausetester+qaabecciv@applause.expensifail.com) '
         + '[](concierge@expensify.com)' // only parse autoEmail in ()
         + '[   ](concierge@expensify.com)' // only parse autoEmail in () and keep spaces in []
+        + '[   \n ](concierge@expensify.com)' // only parse autoEmail in () and keep spaces in []
         + '[ Expensify ](concierge@expensify.com)' // edge spaces in []
         + '[ Expensify Email ](concierge@expensify.com)' // space between words in []
         + '[concierge@expensify.com](concierge@expensify.com)' // same email between [] and ()
@@ -528,6 +529,7 @@ test('Test markdown style email link with various styles', () => {
         + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">Applause</a> '
         + '[](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)'
         + '[   ](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)'
+        + '[   <br /> ](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)'
         + '<a href="mailto:concierge@expensify.com">Expensify</a>'
         + '<a href="mailto:concierge@expensify.com">Expensify Email</a>'
         + '<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>'

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -60,7 +60,7 @@ export default class ExpensiMark {
                 name: 'email',
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `\\[([^[\\]]*)]\\(${CONST.REG_EXP.MARKDOWN_EMAIL}\\)`, 'gim'
+                        `(?!\\[\\s*\\])\\[([^[\\]]*)]\\(${CONST.REG_EXP.MARKDOWN_EMAIL}\\)`, 'gim'
                     );
                     return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
                 },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/21234

# Tests
1. Go to a chat and add following comment
```
[](concierge@expensify.com)
[   ](concierge@expensify.com)
[   

 ](concierge@expensify.com)
```
2. Verify that 
   a. Only emails inside `()` are parsed as email link
   b. `[]`, `()` and spaces(including line break) inside `[]` are not parsed
3. Click to edit the comment
4. Verify that the initial draft is same as the original input.

See below demo video 

https://github.com/Expensify/expensify-common/assets/117511920/82b49d50-067b-4299-a3e7-dea2a3ab0928

I'll fill out the full checklist in the PR to update version of App repo.


# QA
Same as test
