### PR TITLE
Fix/21846 heading after quote is not rendering

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -21,10 +21,18 @@ test('Test multi-line bold markdown replacement', () => {
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
+test('Test heading markdown replacement', () => {
+    let testString = '# Heading should not have new line after it.\n';
+    expect(parser.replace(testString)).toBe('<h1>Heading should not have new line after it.</h1>');
+
+    testString = '# Heading should have only one new line after it.\n\n';
+    expect(parser.replace(testString)).toBe('<h1>Heading should have only one new line after it.</h1><br />');
+});
+
 // Sections starting with > are successfully wrapped with <blockquote></blockquote>
 test('Test quote markdown replacement', () => {
-    const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+    const quoteTestStartString = '>This is a *quote* that started on a new line.\n# Heading 1 after the quote.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
+    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote><h1>Heading 1 after the quote.</h1>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
 
     expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
 });
@@ -790,6 +798,11 @@ test('Test quotes markdown replacement with heading inside', () => {
 test('Test heading1 markdown replacement with line break before or after the heading1', () => {
     const testString = 'test\n\n# heading\n\ntest';
     expect(parser.replace(testString)).toBe('test<br /><br /><h1>heading</h1><br />test');
+});
+
+test('Test heading1 markdown replacement when heading appear after the quote', () => {
+    const testString = '> quote \n# heading 1 after the quote.\nHere is a multi-line\ncomment that contains *bold* string.';
+    expect(parser.replace(testString)).toBe('<blockquote>quote</blockquote><h1>heading 1 after the quote.</h1>Here is a multi-line<br />comment that contains <strong>bold</strong> string.');
 });
 
 // Valid text that should match for user mentions

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -31,8 +31,8 @@ test('Test heading markdown replacement', () => {
 
 // Sections starting with > are successfully wrapped with <blockquote></blockquote>
 test('Test quote markdown replacement', () => {
-    const quoteTestStartString = '>This is a *quote* that started on a new line.\n# Heading 1 after the quote.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote><h1>Heading 1 after the quote.</h1>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+    const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
+    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
 
     expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -154,6 +154,11 @@ export default class ExpensiMark {
                 },
             },
             {
+                name: 'heading1',
+                regex: /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm,
+                replacement: '<h1>$1</h1>',
+            },
+            {
                 name: 'quote',
 
                 // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
@@ -202,11 +207,6 @@ export default class ExpensiMark {
                 name: 'strikethrough',
                 regex: /\B~((?=\S)((~~(?!~)|[^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: (match, g1) => (this.containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
-            },
-            {
-                name: 'heading1',
-                regex: /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)\n?/gm,
-                replacement: '<h1>$1</h1>',
             },
             {
                 name: 'newline',

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -225,6 +225,12 @@ export default class ExpensiMark {
                 regex: /<br\s*[/]?><pre>\s*/gi,
                 replacement: ' <pre>',
             },
+            {
+                // We're removing <br /> because when <h1> and <br /> occur together, an extra line is added.
+                name: 'replaceh1br',
+                regex: /<\/h1><br\s*[/]?>/gi,
+                replacement: '</h1>',
+            },
         ];
 
         /**


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ [#21846](https://github.com/Expensify/App/issues/21846)
PROPOSAL: [#21846 (comment)](https://github.com/Expensify/App/issues/21846#issuecomment-1612228425)


# Tests
Following cases are verified while performing unit test:

* Case 1: Heading after the quote
```
> quote
# heading
```

* Case 2: Heading before and after quote
```
# heading
> quote
# heading
> quote
# heading
```

* Case 3: Some text after heading
```
> quote
# heading
> quote
# heading
Some text here *bold*
```

* Also added a new unit test to cover heading replacement

```html
Input: '# heading\n'
Output: '<h1>heading</h1>'

Input: '# heading\n\n'
Output: '<h1>heading</h1></br>'


Input: `> a\n# da\n> test`
Output: '<blockquote>a</blockquote><h1>da</h1><blockquote>test</blockquote>'


Input: `>This is a *quote* that started on a new line.\n# Heading 1 should be captured\nHere is a >quote that did not\n`
Output '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote><h1>Heading 1 should be captured</h1>Here is a &gt;quote that did not<br />'

```
# QA
1. Open any chat room
2. Send a message which contain heading after the quote text. 
```
Example 1: Heading after the quote

> quote
# heading

Example 2: Heading before and after quote

# heading
> quote
# heading
> quote
# headind


Example 3: Some text after heading

# heading
Some text here *bold*
```
3. Copy a comment and paste to verify that it's same as the initial input
4. Edit a comment and verify that it's same as initial draft.


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>
<!-- add screenshots or videos here -->




https://github.com/Expensify/expensify-common/assets/19812199/fe310777-6723-42e1-b34b-ec4d2d0622e5




</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/expensify-common/assets/19812199/26910ad9-06d0-4eb4-a75a-f42ef2125e5a
</details>




<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/Expensify/expensify-common/assets/19812199/91bd77cd-29fe-4d8e-ace3-28845a587790






</details>

<details>
<summary>Desktop</summary>
<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/19812199/d58cff6b-b33c-4ac7-ad1e-f751cc65ad88


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/19812199/f881eecc-0ba4-4d4d-b087-81fc3e3da2c5




</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/19812199/f1199cc7-6758-45e9-a30b-432a8ecf59e1


</details>

