### PR TITLE
fix: allow to add link with code block inside alias text part

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1123,3 +1123,12 @@ test('Test here mention with @here@here', () => {
     const resultString = '<mention-here>@here</mention-here><mention-here>@here</mention-here>';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test link with code fence inside the alias text part', () => {
+    const testString = '[```code```](google.com) '
+        + '[test ```code``` test](google.com)';
+
+    const resultString = '[<pre>code</pre>](<a href="https://google.com" target="_blank" rel="noreferrer noopener">google.com</a>) '
+        + '[test <pre>code</pre> test](<a href="https://google.com" target="_blank" rel="noreferrer noopener">google.com</a>)';
+    expect(parser.replace(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -457,7 +457,7 @@ export default class ExpensiMark {
             }
             replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
 
-            if (abort) {
+            if (abort || match[1].includes('<pre>')) {
                 replacedText = replacedText.concat(textToCheck.substr(match.index, (match[0].length)));
             } else {
                 const urlRegex = new RegExp(`^${LOOSE_URL_REGEX}$|^${URL_REGEX}$`, 'i');


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/22492
Proposal: https://github.com/Expensify/App/issues/22492#issuecomment-1627450749

# Tests
1. Go to a chat and add following comment
````
[```code```](google.com)
````
2. Verify that only `code` is displayed as code block and link `google.com` is displayed as auto link.
3. Edit the comment and verify the initial draft is 
````
[```
code
```
]([google.com](https://google.com))
````

Demo video

https://github.com/Expensify/expensify-common/assets/117511920/9fc0302e-cd4c-4195-bb93-f68960acd288



# QA
Same as test
