### PR TITLE
fix: replace window-style newline with <br />

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -238,10 +238,14 @@ test('Test HTML encoded strings', () => {
     expect(parser.replace(rawHTMLTestStartString)).toBe(rawHTMLTestReplacedString);
 });
 
-// New lines characters \\n were successfully replaced with <br>
+// New lines characters \n or \r\n were successfully replaced with <br>
 test('Test newline markdown replacement', () => {
-    const newLineTestStartString = 'This sentence has a newline \n Yep just had one \n Oh there it is another one';
-    const newLineReplacedString = 'This sentence has a newline <br /> Yep just had one <br /> Oh there it is another one';
+    let newLineTestStartString = 'This sentence has a newline \n Yep just had one \n Oh there it is another one';
+    let newLineReplacedString = 'This sentence has a newline <br /> Yep just had one <br /> Oh there it is another one';
+    expect(parser.replace(newLineTestStartString)).toBe(newLineReplacedString);
+
+    newLineTestStartString = 'This sentence has a windows-style newline \r\n Yep just had one \r\n Oh there it is another one';
+    newLineReplacedString = 'This sentence has a windows-style newline <br /> Yep just had one <br /> Oh there it is another one';
     expect(parser.replace(newLineTestStartString)).toBe(newLineReplacedString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -210,7 +210,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'newline',
-                regex: /\n/g,
+                regex: /\r?\n/g,
                 replacement: '<br />',
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/22890

# Tests
Verified that windows-style newline(\r\n) is replaced with `<br />` during the unit-tests
```
    Input: 'This sentence has a windows-style newline \r\n Yep just had one \r\n Oh there it is another one'
    Output: 'This sentence has a windows-style newline <br /> Yep just had one <br /> Oh there it is another one'
```

Also tested in the following steps
1. Open any chat
2. Copy any text on windows and paste it to the composer and send it
3. Verify that new line doesn't appear and the text is sent as is

# QA
1. Open any chat
2. Copy any text on windows and paste it to the composer and send it
3. Verify that new line doesn't appear and the text is sent as is
