### PR TITLE
Handle currency symbols with a period in fromUSDToNumber

### DIFF
--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -95,3 +95,9 @@ describe('Str.sanitizeURL', () => {
         expect(Str.sanitizeURL('HTtp://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
     });
 });
+
+describe('Str.fromUSDToNumber', () => {
+    it('Handles currency symbols with a period', () => {
+        expect(Str.fromUSDToNumber('Bs.S2.48')).toBe('248');
+    });
+});

--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -96,8 +96,34 @@ describe('Str.sanitizeURL', () => {
     });
 });
 
-describe('Str.fromUSDToNumber', () => {
+describe('Str.fromCurrencyToNumber', () => {
+    it('Handles negative amounts with minus sign', () => {
+        expect(Str.fromCurrencyToNumber('-$5.23')).toBe(-523);
+        expect(Str.fromCurrencyToNumber('$-5.23')).toBe(-523);
+    });
+
+    it('Handles negative amounts with ()', () => {
+        expect(Str.fromCurrencyToNumber('($5.23)')).toBe(-523);
+    });
+
+    it('Handles fractional cents when allowed', () => {
+        expect(Str.fromCurrencyToNumber('$5.223', true)).toBe(522.3);
+    });
+
+    it('Handles amounts without leading zeros', () => {
+        expect(Str.fromCurrencyToNumber('$.23')).toBe(23);
+    });
+
+    it('Handles amounts without cents', () => {
+        expect(Str.fromCurrencyToNumber('$5')).toBe(500);
+    });
+
     it('Handles currency symbols with a period', () => {
-        expect(Str.fromUSDToNumber('Bs.S2.48')).toBe('248');
+        expect(Str.fromCurrencyToNumber('Bs.S2.48')).toBe(248);
+        expect(Str.fromCurrencyToNumber('Bs.S-2.48')).toBe(-248);
+        expect(Str.fromCurrencyToNumber('-Bs.S2.48')).toBe(-248);
+        expect(Str.fromCurrencyToNumber('(Bs.S2.48)')).toBe(-248);
+        expect(Str.fromCurrencyToNumber('Bs.S.48')).toBe(48);
+        expect(Str.fromCurrencyToNumber('Bs.S2')).toBe(200);
     });
 });

--- a/lib/str.js
+++ b/lib/str.js
@@ -26,20 +26,23 @@ const Str = {
     /**
      * Converts a currency string into the number of cents it represents.
      *
-     * @param {String}  amountStr     A string representing a currency symbol and value, like $4.02 or Bs.S97.9
-     * @param {Boolean} allowFraction Flag indicating if fractions of cents should be
-     *                                allowed in the output.
+     * @param {String}  amountStr     String representing a currency symbol and value, like $4.02 or Bs.S97.9
+     * @param {Boolean} allowFraction Flag indicating if fractions of cents should be allowed in the output.
      *
      * @return {Number} The cent value of the @p amountStr.
      */
-    fromUSDToNumber(amountStr, allowFraction) {
+    fromCurrencyToNumber(amountStr, allowFraction) {
+        // eslint-disable-next-line no-param-reassign
         amountStr = String(amountStr);
-        // Currently, no currency symbol has a number in it, so we find the first number
-        let withoutCurrency = amountStr.substring(amountStr.search(/\d/));
-        let amount = withoutCurrency.replace(/[^\d.\-()]+/g, '');
-        if (amount.match(/\(.*\)/)) {
-            const modifiedAmount = amount.replace(/[()]/g, '');
-            amount = `-${modifiedAmount}`;
+
+        // Ideally, we would pass the currency symbol directly here the same string
+        // could be interpreted differently based on currency symbol but for now
+        // we match the amount from the end of the string.
+        let amount = amountStr.match(/(-?(?:\.\d+|\d+\.?\d*))\)?$/)[1];
+
+        // We want to support both -$5.00 and $-5.00, so we check if the string starts with -
+        if (amountStr.match(/\(.*\)/) || amountStr[0] === '-') {
+            amount = `-${amount}`;
         }
         amount = Number(amount) * 100;
 
@@ -51,6 +54,19 @@ const Str = {
         // 67.9
         amount = Math.round(amount * 1e3) / 1e3;
         return allowFraction ? amount : Math.round(amount);
+    },
+
+    /**
+     * Wrapper around fromCurrencyToNumber
+     *
+     * @deprecated
+     * @param {String}  amountStr     String representing a currency symbol and value, like $4.02 or Bs.S97.9
+     * @param {Boolean} allowFraction Flag indicating if fractions of cents should be allowed in the output.
+     *
+     * @return {Number} The cent value of the @p amountStr.
+     */
+    fromUSDToNumber(...args) {
+        return Str.fromCurrencyToNumber(...args);
     },
 
     /**

--- a/lib/str.js
+++ b/lib/str.js
@@ -24,16 +24,19 @@ const Str = {
     },
 
     /**
-     * Converts a USD string into th number of cents it represents.
+     * Converts a currency string into the number of cents it represents.
      *
-     * @param {String}  amountStr     A string representing a USD value.
+     * @param {String}  amountStr     A string representing a currency symbol and value, like $4.02 or Bs.S97.9
      * @param {Boolean} allowFraction Flag indicating if fractions of cents should be
-     *                               allowed in the output.
+     *                                allowed in the output.
      *
      * @return {Number} The cent value of the @p amountStr.
      */
     fromUSDToNumber(amountStr, allowFraction) {
-        let amount = String(amountStr).replace(/[^\d.\-()]+/g, '');
+        amountStr = String(amountStr);
+        // Currently, no currency symbol has a number in it, so we find the first number
+        let withoutCurrency = amountStr.substring(amountStr.search(/\d/));
+        let amount = withoutCurrency.replace(/[^\d.\-()]+/g, '');
         if (amount.match(/\(.*\)/)) {
             const modifiedAmount = amount.replace(/[()]/g, '');
             amount = `-${modifiedAmount}`;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/303703

# Tests
Added a unit test for Bs.S, the Venezuelan currency that has a period in the symbol itself. Before, this was parsing as NaN.

# QA
In OldDot, Verify that when changing Settings > Policies > Reports > Report Currency to Bs.S then going to Settings > Policies > Expenses > Time and setting the Default Hourly Rate to Bs.S6.00 correctly autosaves.
