### PR TITLE
Update email regex

### DIFF
--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -95,3 +95,11 @@ describe('Str.sanitizeURL', () => {
         expect(Str.sanitizeURL('HTtp://FOO.com/blah_BLAH')).toBe('http://foo.com/blah_BLAH');
     });
 });
+
+describe('Str.isValidEmail', () => {
+    it('Correctly detects a valid email', () => {
+        expect(Str.isValidEmail('abc@gmail.com')).toBeTruthy();
+        expect(Str.isValidEmail('test@gmail')).toBeFalsy();
+        expect(Str.isValidEmail('usernamelongerthan64charactersshouldnotworkaccordingtorfc822whichisusedbyphp@gmail.com')).toBeFalsy();
+    });
+});

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-useless-escape */
 
-const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]{0,64}(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
+const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]{1,64}(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
 
 const MOMENT_FORMAT_STRING = 'YYYY-MM-DD';
 

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-useless-escape */
 
-const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
+const EMAIL_BASE_REGEX = "([\\w\\-\\+\\'#]{0,64}(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
 
 const MOMENT_FORMAT_STRING = 'YYYY-MM-DD';
 


### PR DESCRIPTION
We don't want the front end to pass emails that are not valid in the backend. We use [FILTER_VALIDATE_EMAIL](https://www.php.net/manual/en/filter.constants.php) from php which validates the emails if they match RFC-822 standards. According to those standards, the username part of the email can't be longer than 64 characters. This PR adds this condition in our regex for the email validation in JS.

See [here](https://expensify.slack.com/archives/C03TQ48KC/p1690482472889119) a discussion about the email validation inconsistency throughout the project.

### Fixed Issues
Part of https://github.com/Expensify/App/issues/23180

# Tests
1. In NewDot, go to **Profile** -> **Contact Method** -> **New Contact Method**
2. In the email input field add an email with a long username, like `usernamelongerthan64charactersshouldnotworkaccordingtorfc822whichisusedbyphp@gmail.com`
3. Click on **Add** button
4. Verify that you get an **Invalid contact method** error

# QA
We'll be QA'd with the App PR 
