### PR TITLE
fix: last backtick should be in inline codeblock when sending a text wrapped with two backticks

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -309,6 +309,11 @@ test('Test inline code blocks inside ExpensiMark', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test inline code blocks with two backticks', () => {
+    const testString = '``JavaScript``';
+    expect(parser.replace(testString)).toBe('<code>&#x60;JavaScript&#x60;</code>');
+});
+
 test('Test code fencing with ExpensiMark syntax inside', () => {
     let codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)<br /></pre>');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -47,7 +47,7 @@ export default class ExpensiMark {
 
                 // Use the url escaped version of a backtick (`) symbol. Mobile platforms do not support lookbehinds,
                 // so capture the first and third group and place them in the replacement.
-                regex: /(\B|_|)&#x60;(.*?\S.*?)&#x60;(\B|_|)(?![^<]*<\/pre>)/g,
+                regex: /(\B|_|)&#x60;(.*?\S.*?)&#x60;(\B|_|)(?!&#x60;|[^<]*<\/pre>)/g,
                 replacement: '$1<code>$2</code>$3',
             },
 


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/23352
Proposal: https://github.com/Expensify/App/issues/23352#issuecomment-1659859472

### Tests
1. Go to any chat and Send a text wrapped in two backticks
2. Verify that last backtick is inside of inline code block.

### QA
same as test

## PR Author checklist
- [x] I linked the correct issue in the ### Fixed Issues section above
- [x] I wrote clear testing steps that cover the changes made in this PR
     - [x] I added steps for local testing in the Tests section
     - [x] I added steps for the expected offline behavior in the Offline steps section
     - [x] I added steps for Staging and/or Production testing in the QA steps section
     - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
     - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
     - [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on all platforms & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified proper code patterns were followed (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`).
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` have been tested & I retested again)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG`)
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/expensify-common/assets/139204153/ded24e2e-6c23-49af-b25f-796dde4e3619


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>


https://github.com/Expensify/expensify-common/assets/139204153/4fefcbf0-df26-41ab-b136-48d496dc3fe5



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/expensify-common/assets/139204153/807cda0a-30af-4b7b-9cca-7986024b66ba


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/expensify-common/assets/139204153/62ba8d04-151a-4058-bbde-aaeeb871eab6

<!-- add screenshots  or videos here -->

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/expensify-common/assets/139204153/2b668d17-9801-46c3-8684-799ce4192ee6


</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/expensify-common/assets/139204153/e1f74742-9d43-46f0-b7ca-30fdf3fe35f5


<!-- add screenshots or videos here -->

</details>

