### PR TITLE
Removing special chars that are in the end of a url and shouldn't be

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -616,14 +616,22 @@ test('Test urls ending with special characters followed by unmatched closing par
         + 'https://github.com/Expensify/ReactNativeChat/pull/645+) '
         + 'https://github.com/Expensify/ReactNativeChat/pull/645!) '
         + 'https://github.com/Expensify/ReactNativeChat/pull/645,) '
-        + 'https://github.com/Expensify/ReactNativeChat/pull/645=) ';
+        + 'https://github.com/Expensify/ReactNativeChat/pull/645=) '
+        + 'https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings. '
+        + 'https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings.. '
+        + 'https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings..) '
+        + '[https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings] ';
     const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>.) '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>$) '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>*) '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>+) '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>!) '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>,) '
-        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>=) ';
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>=) '
+        + '<a href="https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>. '
+        + '<a href="https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>.. '
+        + '<a href="https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>..) '
+        + '[<a href=\"https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings\" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>] ';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -609,6 +609,24 @@ test('Test a url ending with a closing parentheses autolinks correctly', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test urls ending with special characters followed by unmatched closing parentheses autolinks correctly', () => {
+    const testString = 'https://github.com/Expensify/ReactNativeChat/pull/645.) '
+        + 'https://github.com/Expensify/ReactNativeChat/pull/645$) '
+        + 'https://github.com/Expensify/ReactNativeChat/pull/645*) '
+        + 'https://github.com/Expensify/ReactNativeChat/pull/645+) '
+        + 'https://github.com/Expensify/ReactNativeChat/pull/645!) '
+        + 'https://github.com/Expensify/ReactNativeChat/pull/645,) '
+        + 'https://github.com/Expensify/ReactNativeChat/pull/645=) ';
+    const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>.) '
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>$) '
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>*) '
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>+) '
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>!) '
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>,) '
+        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>=) ';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test markdown style email link with various styles', () => {
     const testString = 'Go to ~[Expensify](concierge@expensify.com)~ '
         + '_[Expensify](concierge@expensify.com)_ '

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1348,3 +1348,11 @@ test('Test link with code fence inside the alias text part', () => {
         + '[test <pre>code</pre> test](<a href="https://google.com" target="_blank" rel="noreferrer noopener">google.com</a>)';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Test strikethrough with multiple tilde characters', () => {
+    let testString = '~~~hello~~~';
+    expect(parser.replace(testString)).toBe('~~<del>hello</del>~~');
+
+    testString = '~~~~';
+    expect(parser.replace(testString)).toBe('~~~~');
+});

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -620,7 +620,9 @@ test('Test urls ending with special characters followed by unmatched closing par
         + 'https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings. '
         + 'https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings.. '
         + 'https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings..) '
-        + '[https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings] ';
+        + '[https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings] '
+        + 'https://google.com/path?param=) '
+        + 'https://google.com/path#fragment!) ';
     const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>.) '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>$) '
         + '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>*) '
@@ -631,7 +633,9 @@ test('Test urls ending with special characters followed by unmatched closing par
         + '<a href="https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>. '
         + '<a href="https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>.. '
         + '<a href="https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>..) '
-        + '[<a href=\"https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings\" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>] ';
+        + '[<a href=\"https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings\" target=\"_blank\" rel=\"noreferrer noopener\">https://staging.new.expensify.com/get-assistance/WorkspaceGeneralSettings</a>] '
+        + '<a href=\"https://google.com/path?param=" target=\"_blank\" rel=\"noreferrer noopener\">https://google.com/path?param=</a>) '
+        + '<a href=\"https://google.com/path#fragment!" target=\"_blank\" rel=\"noreferrer noopener\">https://google.com/path#fragment!</a>) ';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -264,7 +264,7 @@ export const CONST = {
     },
 
     /**
-     * Special characters that need to be removed when there in the end of an url
+     * Special characters that need to be removed when they are ending an url
      *
      * @type String
      */

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -264,6 +264,13 @@ export const CONST = {
     },
 
     /**
+     * Special characters that need to be removed when there in the end of an url
+     *
+     * @type String
+     */
+    SPECIAL_CHARS_TO_REMOVE: "$*.+!(,=",
+
+    /**
      * Store all the regular expression we are using for matching stuff
      */
     REG_EXP: {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -470,7 +470,7 @@ export default class ExpensiMark {
             }
 
             // Because we are removing ) parenthesis, some special characters that shouldn't be in the href are in the href
-            // For example google.com/toto.) is accepted by the regexp, above we remove the ) parenthese so the link becomes google.com/toto. which is not a valid link
+            // For example google.com/toto.) is accepted by the regular expression above and we remove the ) parenthesis, so the link becomes google.com/toto. which is not a valid link
             // In that case we should also remove the "."
             let numberOfCharsToRemove = 0;
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -482,8 +482,8 @@ export default class ExpensiMark {
                     break;
             }
             if (numberOfCharsToRemove){
-                match[0] = match[0].substr(0, match[0].length - numberOfCharsToRemove);
-                match[2] = match[2].substr(0, match[2].length - numberOfCharsToRemove);
+                match[0] = match[0].substring(0, match[0].length - numberOfCharsToRemove);
+                match[2] = match[2].substring(0, match[2].length - numberOfCharsToRemove);
             }
 
             replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -475,7 +475,7 @@ export default class ExpensiMark {
             var numberOfCharsToRemove = 0;
 
             for (let i = match[2].length - 1; i >= 0; i--) {
-                if ("$*.+!(,=".includes(match[2][i])) {
+                if (CONST.SPECIAL_CHARS_TO_REMOVE.includes(match[2][i])) {
                     numberOfCharsToRemove++;
                 }
                 else

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -469,7 +469,7 @@ export default class ExpensiMark {
                 }
             }
 
-            // Because we are removing ) parenthese, some special characters that shouldn't be in the href are in the href
+            // Because we are removing ) parenthesis, some special characters that shouldn't be in the href are in the href
             // For example google.com/toto.) is accepted by the regexp, above we remove the ) parenthese so the link becomes google.com/toto. which is not a valid link
             // In that case we should also remove the "."
             let numberOfCharsToRemove = 0;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -474,6 +474,24 @@ export default class ExpensiMark {
                     match[2] = match[2].substr(0, match[2].length + brace);
                 }
             }
+
+            //Because we are removing ) parenthese, some special characters that shouldn't be in the href are in the href
+            // For example google.com/toto.) is accepted by the regexp, above we remove the ) parenthese so the link becomes google.com/toto. which is not a valid link
+            //In that case we should also remove the "."
+            var numberOfCharsToRemove = 0;
+
+            for (let i = match[2].length - 1; i >= 0; i--) {
+                if ("$*.+!(,=".includes(match[2][i])){
+                    numberOfCharsToRemove++;
+                }
+                else
+                    break;
+            }
+            if(numberOfCharsToRemove){
+                match[0] = match[0].substr(0, match[0].length - numberOfCharsToRemove);
+                match[2] = match[2].substr(0, match[2].length - numberOfCharsToRemove);
+            }
+
             replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
 
             if (abort || match[1].includes('<pre>')) {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -475,19 +475,19 @@ export default class ExpensiMark {
                 }
             }
 
-            //Because we are removing ) parenthese, some special characters that shouldn't be in the href are in the href
+            // Because we are removing ) parenthese, some special characters that shouldn't be in the href are in the href
             // For example google.com/toto.) is accepted by the regexp, above we remove the ) parenthese so the link becomes google.com/toto. which is not a valid link
-            //In that case we should also remove the "."
+            // In that case we should also remove the "."
             var numberOfCharsToRemove = 0;
 
             for (let i = match[2].length - 1; i >= 0; i--) {
-                if ("$*.+!(,=".includes(match[2][i])){
+                if ("$*.+!(,=".includes(match[2][i])) {
                     numberOfCharsToRemove++;
                 }
                 else
                     break;
             }
-            if(numberOfCharsToRemove){
+            if (numberOfCharsToRemove){
                 match[0] = match[0].substr(0, match[0].length - numberOfCharsToRemove);
                 match[2] = match[2].substr(0, match[2].length - numberOfCharsToRemove);
             }

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -472,18 +472,21 @@ export default class ExpensiMark {
             // Because we are removing ) parenthesis, some special characters that shouldn't be in the href are in the href
             // For example google.com/toto.) is accepted by the regular expression above and we remove the ) parenthesis, so the link becomes google.com/toto. which is not a valid link
             // In that case we should also remove the "."
-            let numberOfCharsToRemove = 0;
+            // Those characters should only be remove from the url if this url doesn't have a parameter or a fragment
+            if (!match[2].includes('?') && !match[2].includes('#')) {
+                let numberOfCharsToRemove = 0;
 
-            for (let i = match[2].length - 1; i >= 0; i--) {
-                if (CONST.SPECIAL_CHARS_TO_REMOVE.includes(match[2][i])) {
-                    numberOfCharsToRemove++;
-                } else {
-                    break;
+                for (let i = match[2].length - 1; i >= 0; i--) {
+                    if (CONST.SPECIAL_CHARS_TO_REMOVE.includes(match[2][i])) {
+                        numberOfCharsToRemove++;
+                    } else {
+                        break;
+                    }
                 }
-            }
-            if (numberOfCharsToRemove) {
-                match[0] = match[0].substring(0, match[0].length - numberOfCharsToRemove);
-                match[2] = match[2].substring(0, match[2].length - numberOfCharsToRemove);
+                if (numberOfCharsToRemove) {
+                    match[0] = match[0].substring(0, match[0].length - numberOfCharsToRemove);
+                    match[2] = match[2].substring(0, match[2].length - numberOfCharsToRemove);
+                }
             }
 
             replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));


### PR DESCRIPTION
Because we are removing unmatched end parenthesis, some links that end with special characters are accepted when they shouldn't be. we need to remove those special characters.

### Fixed Issues
$ https://github.com/Expensify/App/issues/25532

# Tests
1. Go to any repórt
2. Send a link with a slash for example: google.com/toto
3. Edit the message and add one of those characters to the link in the parenthese: `$*.+!,=`
4. When you validate the edit verify that the text is white without links like this:
![image](https://github.com/Expensify/expensify-common/assets/19537677/2fbfb1e5-bba6-47f2-ba4d-cd10ecb65c50)

5. Send another message google.com/toto.) or google.com/toto$) for example and verify that the special char before the parenthese is not blue (not included in the link)
![image](https://github.com/Expensify/expensify-common/assets/19537677/7f1dad72-4cd7-4cdf-830a-6af41717c90e)


# QA
Same as above and test links in general

Video for web:


https://github.com/Expensify/expensify-common/assets/19537677/8bd1d2ca-5695-412a-8690-448a46295b4c

