### PR TITLE
Modify regex in textToMarkdown functionality

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -554,7 +554,7 @@ test('Test html to heading1 markdown when there are other tags inside h1 tag', (
 test('Test html to heading1 markdown when h1 tag is in the beginning of the line', () => {
     const testString = '<h1>heading1</h1> in the beginning of the line';
     const resultString = '# heading1\n'
-    + 'in the beginning of the line';
+    + ' in the beginning of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
@@ -562,7 +562,7 @@ test('Test html to heading1 markdown when h1 tags are in the middle of the line'
     const testString = 'this line has a <h1>heading1</h1> in the middle of the line';
     const resultString = 'this line has a\n'
     + '# heading1\n'
-    + 'in the middle of the line';
+    + ' in the middle of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -282,7 +282,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /[^\S\r\n]*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))[^\S\r\n]*/gi,
+                regex: /[^\S\r\n]*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '<h1># $2</h1>',
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/27445

# Tests
Following tests are related to changes I made and I needed to modify them because that's the correct behaviour (to have space before `in` in the first test and before `in` in the second test.
1. https://github.com/Expensify/expensify-common/blob/35bff866a8d345b460ea6256f0a0f0a8a7f81086/__tests__/ExpensiMark-Markdown-test.js#L554-L559
2. https://github.com/Expensify/expensify-common/blob/35bff866a8d345b460ea6256f0a0f0a8a7f81086/__tests__/ExpensiMark-Markdown-test.js#L561-L567

# QA
1. Open any chat
2. Type `# sometext`<br/>`                      someothertext`
3. Send the message and it should preserve the whitespace before second line.
4. Now create another message with text `            # sometext`<br/>`                      someothertext`
5. Send the message and it should remove the whitespace before first line but it should preserve it in front of second line.