### PR TITLE
fix: keep tail spaces in heading

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -554,7 +554,7 @@ test('Test html to heading1 markdown when there are other tags inside h1 tag', (
 test('Test html to heading1 markdown when h1 tag is in the beginning of the line', () => {
     const testString = '<h1>heading1</h1> in the beginning of the line';
     const resultString = '# heading1\n'
-    + 'in the beginning of the line';
+    + ' in the beginning of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
@@ -562,7 +562,7 @@ test('Test html to heading1 markdown when h1 tags are in the middle of the line'
     const testString = 'this line has a <h1>heading1</h1> in the middle of the line';
     const resultString = 'this line has a\n'
     + '# heading1\n'
-    + 'in the middle of the line';
+    + ' in the middle of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -282,7 +282,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'heading1',
-                regex: /[^\S\r\n]*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))[^\S\r\n]*/gi,
+                regex: /[^\S\r\n]*<(h1)(?:"[^"]*"|'[^']*'|[^'">])*>(.*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '<h1># $2</h1>',
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/27445

# Tests

```
    Input: <h1>heading1</h1> in the beginning of the line
    Output: # heading1\n in the beginning of the line
```

1. Open any chat and send message
```
# heading 1
    in the beginning of the line
```
2. Switch the message just sent to edit mode
3. Verify that spaces in the second line not disappeared


# QA
1. Open any chat and send message
```
# heading 1
    in the beginning of the line
```
2. Switch the message just sent to edit mode
3. Verify that spaces in the second line not disappeared

