### PR TITLE
End the url at the first unmatched closing parenthesis

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -632,13 +632,24 @@ test('Test a url ending with a question mark autolinks correctly', () => {
 });
 
 test('Test urls with unmatched closing parentheses autolinks correctly', () => {
-    const testString = 'https://github.com/Expensify/ReactNativeChat/pull/645) '
-    + 'https://github.com/Expensify/ReactNativeChat/pull/test(645)) '
-    + 'google.com/(toto))titi)';
-    const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>) '
-    + '<a href="https://github.com/Expensify/ReactNativeChat/pull/test(645)" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/test(645)</a>) '
-    + '<a href="https://google.com/(toto)" target="_blank" rel="noreferrer noopener">google.com/(toto)</a>)titi)';
-    expect(parser.replace(testString)).toBe(resultString);
+    const testCases = [
+        {
+            testString: 'https://github.com/Expensify/ReactNativeChat/pull/645)',
+            resultString: '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>)',
+        },
+        {
+            testString: 'https://github.com/Expensify/ReactNativeChat/pull/test(645))',
+            resultString: '<a href="https://github.com/Expensify/ReactNativeChat/pull/test(645)" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/test(645)</a>)',
+        },
+        {
+            testString: 'google.com/(toto))titi)',
+            resultString: '<a href="https://google.com/(toto)" target="_blank" rel="noreferrer noopener">google.com/(toto)</a>)titi)',
+        },
+        
+    ];
+    testCases.forEach(testCase => {
+        expect(parser.replace(testCase.testString)).toBe(testCase.resultString);
+    });
 });
 
 test('Test urls autolinks correctly', () => {

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -631,9 +631,13 @@ test('Test a url ending with a question mark autolinks correctly', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test a url ending with a closing parentheses autolinks correctly', () => {
-    const testString = 'https://github.com/Expensify/ReactNativeChat/pull/645)';
-    const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>)';
+test('Test urls with unmatched closing parentheses autolinks correctly', () => {
+    const testString = 'https://github.com/Expensify/ReactNativeChat/pull/645) '
+    + 'https://github.com/Expensify/ReactNativeChat/pull/test(645)) '
+    + 'google.com/(toto))titi)';
+    const resultString = '<a href="https://github.com/Expensify/ReactNativeChat/pull/645" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/645</a>) '
+    + '<a href="https://github.com/Expensify/ReactNativeChat/pull/test(645)" target="_blank" rel="noreferrer noopener">https://github.com/Expensify/ReactNativeChat/pull/test(645)</a>) '
+    + '<a href="https://google.com/(toto)" target="_blank" rel="noreferrer noopener">google.com/(toto)</a>)titi)';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -453,10 +453,9 @@ export default class ExpensiMark {
             for (let i = 0; i < url.length; i++) {
                 if (url[i] === '(') {
                     unmatchedOpenParentheses++;
-                }
-                else if (url[i] === ')') {
+                } else if (url[i] === ')') {
                     // Unmatched closing parenthesis
-                    if(unmatchedOpenParentheses <= 0){ 
+                    if (unmatchedOpenParentheses <= 0) {
                         const numberOfCharsToRemove = url.length - i;
                         match[0] = match[0].substr(0, match[0].length - numberOfCharsToRemove);
                         url = url.substr(0, url.length - numberOfCharsToRemove);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -455,7 +455,8 @@ export default class ExpensiMark {
                     unmatchedOpenParentheses++;
                 }
                 else if (url[i] === ')') {
-                    if(unmatchedOpenParentheses <= 0){ // unmatched closing parenthesis
+                    // Unmatched closing parenthesis
+                    if(unmatchedOpenParentheses <= 0){ 
                         const numberOfCharsToRemove = url.length - i;
                         match[0] = match[0].substr(0, match[0].length - numberOfCharsToRemove);
                         url = url.substr(0, url.length - numberOfCharsToRemove);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -446,26 +446,22 @@ export default class ExpensiMark {
         let startIndex = 0;
 
         while (match !== null) {
-            // we want to avoid matching ending ) unless it is a closing parenthesis for the URL
-            if (textToCheck[(match.index + match[2].length) - 1] === ')' && !match[2].includes('(')) {
-                match[0] = match[0].substr(0, match[0].length - 1);
-                match[2] = match[2].substr(0, match[2].length - 1);
-            }
-
-            // remove extra ) parentheses
-            let brace = 0;
-            if (match[2][match[2].length - 1] === ')') {
-                for (let i = 0; i < match[2].length; i++) {
-                    if (match[2][i] === '(') {
-                        brace++;
-                    }
-                    if (match[2][i] === ')') {
-                        brace--;
-                    }
+            // We end the link at the last closing parenthesis that matches an opening parenthesis because unmatched closing parentheses are unlikely to be in the url
+            // and can be part of markdown for example
+            let unmatchedOpenParentheses = 0;
+            let url = match[2];
+            for (let i = 0; i < url.length; i++) {
+                if (url[i] === '(') {
+                    unmatchedOpenParentheses++;
                 }
-                if (brace) {
-                    match[0] = match[0].substr(0, match[0].length + brace);
-                    match[2] = match[2].substr(0, match[2].length + brace);
+                else if (url[i] === ')') {
+                    if(unmatchedOpenParentheses <= 0){ // unmatched closing parenthesis
+                        const numberOfCharsToRemove = url.length - i;
+                        match[0] = match[0].substr(0, match[0].length - numberOfCharsToRemove);
+                        url = url.substr(0, url.length - numberOfCharsToRemove);
+                        break;
+                    }
+                    unmatchedOpenParentheses--;
                 }
             }
             replacedText = replacedText.concat(textToCheck.substr(startIndex, (match.index - startIndex)));
@@ -479,7 +475,7 @@ export default class ExpensiMark {
             // If we find a URL with a leading @ sign, we need look for other domains in the rest of the string
             if ((match.index !== 0) && (textToCheck[match.index - 1] === '@')) {
                 const domainRegex = new RegExp('^(([a-z-0-9]+\\.)+[a-z]{2,})(\\S*)', 'i');
-                const domainMatch = domainRegex.exec(match[2]);
+                const domainMatch = domainRegex.exec(url);
 
                 // If we find another domain in the remainder of the string, we apply the auto link rule again and set a flag to avoid re-doing below.
                 if ((domainMatch !== null) && (domainMatch[3] !== '')) {
@@ -506,7 +502,7 @@ export default class ExpensiMark {
                     filterRules: ['bold', 'strikethrough', 'italic'],
                     shouldEscapeText: false,
                 });
-                replacedText = replacedText.concat(replacement(match[0], linkText, match[2]));
+                replacedText = replacedText.concat(replacement(match[0], linkText, url));
             }
             startIndex = match.index + (match[0].length);
 


### PR DESCRIPTION
@robertKozik @cead22 
We end the url at the first unmatched parenthesis because it is unlikely that this closing parenthesis is part of the url and it can be part of the markdown for example

### Fixed Issues
$ https://github.com/Expensify/App/issues/26788

# Tests
1. Go to any report
2. Send a link with multiple umatched closing parentheses that are not all at the end, for example: `google.com/(toto))titi)`
3. Verify that the link ends at the first unmatched parenthesis, in the above example the link should be `google.com/(toto)`

# QA
Same tests and test urls and markdown in general

# Video


https://github.com/Expensify/expensify-common/assets/19537677/ff78206c-b5c6-41b3-b519-558eea3a6037



