### PR TITLE
Update links to QBD sync manager

### DIFF
--- a/lib/CONST.d.ts
+++ b/lib/CONST.d.ts
@@ -316,7 +316,7 @@ export declare const CONST: {
         readonly CLOUDFRONT: "https://d2k5nsl2zxldvw.cloudfront.net";
         readonly CLOUDFRONT_IMG: "https://d2k5nsl2zxldvw.cloudfront.net/images/";
         readonly CLOUDFRONT_FILES: "https://d2k5nsl2zxldvw.cloudfront.net/files/";
-        readonly EXPENSIFY_SYNC_MANAGER: "quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230403124.exe";
+        readonly EXPENSIFY_SYNC_MANAGER: "quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_2300802.exe";
         readonly USEDOT_ROOT: "https://use.expensify.com/";
         readonly ITUNES_SUBSCRIPTION: "https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions";
     };
@@ -436,7 +436,7 @@ export declare const CONST: {
             readonly REPORT_SUBMITTED: "REPORT_SUBMITTED";
         };
         readonly XERO_HQ_CONNECTION_NAME: "xerohq";
-        readonly EXPENSIFY_SYNC_MANAGER_VERSION: "23.0.403.124";
+        readonly EXPENSIFY_SYNC_MANAGER_VERSION: "23.0.802.0";
     };
     readonly INTEGRATION_TYPES: {
         readonly ACCOUNTING: "accounting";

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -376,7 +376,7 @@ export const CONST = {
         CLOUDFRONT: 'https://d2k5nsl2zxldvw.cloudfront.net',
         CLOUDFRONT_IMG: 'https://d2k5nsl2zxldvw.cloudfront.net/images/',
         CLOUDFRONT_FILES: 'https://d2k5nsl2zxldvw.cloudfront.net/files/',
-        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_230403124.exe',
+        EXPENSIFY_SYNC_MANAGER: 'quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_2300802.exe',
         USEDOT_ROOT: 'https://use.expensify.com/',
         ITUNES_SUBSCRIPTION: 'https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions'
     },
@@ -567,7 +567,7 @@ export const CONST = {
 
         XERO_HQ_CONNECTION_NAME: 'xerohq',
 
-        EXPENSIFY_SYNC_MANAGER_VERSION: '23.0.403.124',
+        EXPENSIFY_SYNC_MANAGER_VERSION: '23.0.802.0',
     },
 
     INTEGRATION_TYPES: {


### PR DESCRIPTION
- [x] Held on https://github.com/Expensify/Web-Static/pull/130

This updates the constant in expensify-common to point to the new QBD sync manager file. And adds a new constant for the version number so that we can show the version number in the download link on web. 

### Fixed Issues
https://github.com/Expensify/Expensify/issues/299596

# Tests
Make sure that you are able to download the file at: https://d2k5nsl2zxldvw.cloudfront.net/files/quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_2300802.exe

# QA
Make sure that you are able to download the file at: https://d2k5nsl2zxldvw.cloudfront.net/files/quickbooksdesktop/Expensify_QuickBooksDesktop_Setup_2300802.exe
