### PR TITLE
Strikethrough link is not parsed correctly on link with URL that contains tilde

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1366,3 +1366,11 @@ test('Test strikethrough with multiple tilde characters', () => {
     testString = '~~~~';
     expect(parser.replace(testString)).toBe('~~~~');
 });
+
+test('Test strikethrough with link with URL that contains tilde', () => {
+    let testString = '~[Example Link](https://example.com/?example=~ex)~';
+    expect(parser.replace(testString)).toBe('<del><a href="https://example.com/?example=~ex" target="_blank" rel="noreferrer noopener">Example Link</a></del>');
+
+    testString = '~[Example Link](https://example.com/?~example=~~~ex~)~';
+    expect(parser.replace(testString)).toBe('<del><a href="https://example.com/?~example=~~~ex~" target="_blank" rel="noreferrer noopener">Example Link</a></del>');
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -210,7 +210,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'strikethrough',
-                regex: /\B~((?=\S)(([^\s~]|\s(?!~))+?))~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B~((?![\s~])[\s\S]*?[^\s~])~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: (match, g1) => (this.containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

Strikethrough link isn't parsed correctly on link with URL that contains `~`

### Fixed Issues
$ https://github.com/Expensify/App/issues/27329

# Tests

1. Open a chat
2. Send this message `~[Example Link](https://example.com/?example=~ex)~` (URL includes `~`)
3. The text must be crossed out

    Input: `~[Example Link](https://example.com/?example=~ex)~` 
    Output: ~[Example Link](https://example.com/?example=~ex)~

# QA

1. Open a chat
2. Send this message `~[Example Link](https://example.com/?example=~ex)~` (URL includes `~`)
3. The text must be crossed out