### PR TITLE
Fix adding parentheses after link removes link

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -32,3 +32,9 @@ test('Test with regex Maximum regex stack depth reached error', () => {
     expect(parser.getRemovedMarkdownLinks(testString, 'google.com')).toStrictEqual([]);
     expect(extractLinksInMarkdownCommentMock).toHaveBeenCalledTimes(3);
 });
+
+test('Test extract link with ending parentheses', () => {
+    const comment = '[Staging Detail](https://staging.new.expensify.com/details) [Staging Detail](https://staging.new.expensify.com/details)) [Staging Detail](https://staging.new.expensify.com/details)))';
+    const links = ['https://staging.new.expensify.com/details', 'https://staging.new.expensify.com/details', 'https://staging.new.expensify.com/details'];
+    expect(parser.extractLinksInMarkdownComment(comment)).toStrictEqual(links);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -766,11 +766,11 @@ export default class ExpensiMark {
      */
     extractLinksInMarkdownComment(comment) {
         try {
-            const escapedComment = _.escape(comment);
-            const matches = [...escapedComment.matchAll(MARKDOWN_LINK_REGEX)];
+            const html = this.replace(comment);
+            const matches = [...html.matchAll(new RegExp(`<a href="${MARKDOWN_URL_REGEX}" target="_blank" rel="noreferrer noopener">`, 'gi'))];
 
             // Element 1 from match is the regex group if it exists which contains the link URLs
-            const links = _.map(matches, match => Str.sanitizeURL(match[2]));
+            const links = _.map(matches, match => Str.sanitizeURL(match[1]));
             return links;
         } catch (e) {
             // eslint-disable-next-line no-console

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -766,8 +766,11 @@ export default class ExpensiMark {
      */
     extractLinksInMarkdownComment(comment) {
         try {
-            const html = this.replace(comment);
-            const matches = [...html.matchAll(new RegExp(`<a href="${MARKDOWN_URL_REGEX}" target="_blank" rel="noreferrer noopener">`, 'gi'))];
+            const htmlString = this.replace(comment);
+
+            // We use same anchore tag template as link and autolink rules to extract link
+            const regex = new RegExp(`<a href="${MARKDOWN_URL_REGEX}" target="_blank" rel="noreferrer noopener">`, 'gi');
+            const matches = [...htmlString.matchAll(regex)];
 
             // Element 1 from match is the regex group if it exists which contains the link URLs
             const links = _.map(matches, match => Str.sanitizeURL(match[1]));

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -768,7 +768,7 @@ export default class ExpensiMark {
         try {
             const htmlString = this.replace(comment);
 
-            // We use same anchore tag template as link and autolink rules to extract link
+            // We use same anchor tag template as link and autolink rules to extract link
             const regex = new RegExp(`<a href="${MARKDOWN_URL_REGEX}" target="_blank" rel="noreferrer noopener">`, 'gi');
             const matches = [...htmlString.matchAll(regex)];
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/28344

# Tests
1. Go to a chat and add a link, like `https://staging.new.expensify.com/details`
2. Click the to edit the comment and add an extra parentheses `)` at the end of the link markdown, like
```
[Staging Detail](https://staging.new.expensify.com/details))
```
3. Save the draft
4. Verify link is not removed and the extra ending parentheses is not part of link and is displayed as plain text.

https://github.com/Expensify/expensify-common/assets/117511920/5caa4b3e-165c-4243-8d88-2a57d5dc884b




# QA
Same as tests.
