### PR TITLE
match email rule with link rule

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -271,6 +271,26 @@ test('Test markdown replacement for invalid emails', () => {
     expect(parser.replace(testString)).toBe(result);
 });
 
+
+test('Test markdown replacement for emojis with emails', () => {
+    const testString = 'Do not replace the emoji with link '
+    + '[😄](abc@gmail.com) '
+    + '[😄]( abc@gmail.com) '
+    + '[😄] abc@gmail.com '
+    + '[😄]((abc@gmail.com)) '
+    + '[😄abc@gmail.com](abc@gmail.com) '
+    + '[😄 abc@gmail.com ](abc@gmail.com) '
+    const result = 'Do not replace the emoji with link '
+    + '[😄](<a href="mailto:abc@gmail.com">abc@gmail.com</a>) '
+    + '[😄]( <a href="mailto:abc@gmail.com">abc@gmail.com</a>) '
+    + '[😄] <a href="mailto:abc@gmail.com">abc@gmail.com</a> '
+    + '[😄]((<a href="mailto:abc@gmail.com">abc@gmail.com</a>)) '
+    + '[😄<a href="mailto:abc@gmail.com">abc@gmail.com</a>](<a href="mailto:abc@gmail.com">abc@gmail.com</a>) '
+    + '[😄 <a href="mailto:abc@gmail.com">abc@gmail.com</a> ](<a href="mailto:abc@gmail.com">abc@gmail.com</a>) '
+    expect(parser.replace(testString)).toBe(result);
+});
+
+
 // Markdown style links replaced successfully
 test('Test markdown style links', () => {
     let testString = 'Go to [Expensify](https://www.expensify.com) to learn more. [Expensify](www.expensify.com) [Expensify](expensify.com) [It\'s really the coolest](expensify.com) [`Some` Special cases - + . = , \'](expensify.com/some?query=par|am)';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -60,11 +60,16 @@ export default class ExpensiMark {
                 name: 'email',
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `(?!\\[\\s*\\])\\[([^[\\]]*)]\\(${CONST.REG_EXP.MARKDOWN_EMAIL}\\)`, 'gim'
+                        `(?!\[\s*\])\[([^[\]]*)]\(${CONST.REG_EXP.MARKDOWN_EMAIL}\)`, 'gim'
                     );
                     return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
                 },
-                replacement: (match, g1, g2) => `<a href="mailto:${g2}">${g1.trim()}</a>`,
+                replacement: (match, g1, g2) => {
+                    if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
+                        return match;
+                    }
+                    return `<a href="mailto:${g2}">${g1.trim()}</a>`
+                },
             },
 
             /**

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -68,7 +68,7 @@ export default class ExpensiMark {
                     if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
                         return match;
                     }
-                    return `<a href="mailto:${g2}">${g1.trim()}</a>`
+                    return `<a href="mailto:${g2}">${g1.trim()}</a>`;
                 },
             },
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -60,7 +60,7 @@ export default class ExpensiMark {
                 name: 'email',
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `(?!\[\s*\])\[([^[\]]*)]\(${CONST.REG_EXP.MARKDOWN_EMAIL}\)`, 'gim'
+                        `(?!\\[\\s*\\])\\[([^[\\]]*)]\\(${CONST.REG_EXP.MARKDOWN_EMAIL}\\)`, 'gim'
                     );
                     return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
                 },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ GH_LINK https://github.com/Expensify/App/issues/28544
$ Proposal https://github.com/Expensify/App/issues/28544#issuecomment-1741831052

# Tests
1. Go to any chat on New Expensify
2. In the composer, type a message `[emoji](email)` (for example `[😄](abc@gmail.com)`) and send
3. Verify that in the message sent, emoji is not changed to link

# QA
1. Go to any chat on New Expensify
2. In the composer, type a message `[emoji](email)` (for example `[😄](abc@gmail.com)`) and send
3. Verify that in the message sent, emoji is not changed to link

<details>
<summary>Result</summary>


https://github.com/Expensify/expensify-common/assets/102477862/623ed57c-695a-4cb8-a22e-e6dedb3f7edc





<!-- add screenshots or videos here -->

</details>