### PR TITLE
Fix edit to remove link not working

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -38,3 +38,9 @@ test('Test extract link with ending parentheses', () => {
     const links = ['https://staging.new.expensify.com/details', 'https://staging.new.expensify.com/details', 'https://staging.new.expensify.com/details'];
     expect(parser.extractLinksInMarkdownComment(comment)).toStrictEqual(links);
 });
+
+test('Test extract link from Markdown link syntax', () => {
+    const comment = 'www.google.com https://www.google.com [Expensify](https://new.expensify.com/)';
+    const links = ['https://new.expensify.com/'];
+    expect(parser.extractLinksInMarkdownComment(comment)).toStrictEqual(links);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -771,7 +771,7 @@ export default class ExpensiMark {
      */
     extractLinksInMarkdownComment(comment) {
         try {
-            const htmlString = this.replace(comment);
+            const htmlString = this.replace(comment, {filterRules: ['link']});
 
             // We use same anchor tag template as link and autolink rules to extract link
             const regex = new RegExp(`<a href="${MARKDOWN_URL_REGEX}" target="_blank" rel="noreferrer noopener">`, 'gi');


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/28344

# Tests
1. Go to a chat and add link like
```
https://www.google.com
```
2. Edit the link from
```
[https://www.google.com](https://www.google.com)
``` 
to
```
https://www.google.com
```
3. Save it and verify that link, `https://www.google.com`, is displayed as plain text


https://github.com/Expensify/expensify-common/assets/117511920/a5bb7a43-7dd2-4496-85df-3f656b06df9e



# QA
Same as tests
