### PR TITLE
fix: Can strike-through pre code block.

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -447,6 +447,9 @@ test('Test code fencing with ExpensiMark syntax outside', () => {
 
     codeFenceExample = '_Test1 ```code``` Test2_';
     expect(parser.replace(codeFenceExample)).toBe('_Test1 <pre>code</pre> Test2_');
+
+    codeFenceExample = '~Test1 ```code``` Test2~';
+    expect(parser.replace(codeFenceExample)).toBe('~Test1 <pre>code</pre> Test2~');
 });
 
 test('Test code fencing with additional backticks inside', () => {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -216,7 +216,7 @@ export default class ExpensiMark {
             {
                 name: 'strikethrough',
                 regex: /\B~((?![\s~])[\s\S]*?[^\s~])~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (match, g1) => (this.containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
+                replacement: (match, g1) => (g1.includes('<pre>') || this.containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
             },
             {
                 name: 'newline',


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/24281

# Tests
1. Open any report
2. Paste `~```Code```~`
3. Observe the code block text doesn't gets strike through line and code block creates line break before start and after end

# QA
1. Open any report
2. Paste `~```Code```~`
3. Observe the code block text doesn't gets strike through line and code block creates line break before start and after end

### Demo

https://github.com/Expensify/expensify-common/assets/85894871/a3eeae28-204b-4a1a-9c36-034113c4b2d6

