### PR TITLE
Add const MAX_TRIAL_BONUS_DAYS

### DIFF
--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -38,6 +38,13 @@ export const CONST = {
      */
     MILEAGE_IRS_RATE: (new Date() > new Date(2019, 1, 1)) ? 0.545 : 0.58,
 
+    /**
+     * Display this amount to users to encourage them to book a call
+     * 
+     * @type Number
+     */
+    MAX_TRIAL_BONUS_DAYS: 42,
+    
     COUNTRY: {
         US: 'US',
         AU: 'AU',


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
[Related issue](https://github.com/Expensify/Web-Expensify/pull/39110#discussion_r1355242371)
### Fixed Issues
$ GH_LINK

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

Modified locally the `CONST.jsx` file in `node_modules/expensify-common` and ensured `42` was shown in the RHP for someone who has the NVP `private_eligible50` set to `true` on a brand new account that clicked on Business in the first Inbox task. 

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?

- Support login into an account with `private_eligible50` set to `true`
- Click `Business` in the inbox task
- The RHP should open and you should see the number `42`
