### PR TITLE
Issue-26016 make usermention case insensitive

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1470,3 +1470,17 @@ test('Test autoEmail with markdown of <pre>, <code>, <a>, <mention-user> and <em
 
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+test('Mention', () => {
+    let testString = '@user@domain.com';
+    expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
+
+    testString = '@USER@DOMAIN.COM';
+    expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
+
+    testString = '@USER@domain.com';
+    expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
+
+    testString = '@user@DOMAIN.com';
+    expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
+});

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1476,11 +1476,11 @@ test('Mention', () => {
     expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
 
     testString = '@USER@DOMAIN.COM';
-    expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
+    expect(parser.replace(testString)).toBe('<mention-user>@USER@DOMAIN.COM</mention-user>');
 
     testString = '@USER@domain.com';
-    expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
+    expect(parser.replace(testString)).toBe('<mention-user>@USER@domain.com</mention-user>');
 
     testString = '@user@DOMAIN.com';
-    expect(parser.replace(testString)).toBe('<mention-user>@user@domain.com</mention-user>');
+    expect(parser.replace(testString)).toBe('<mention-user>@user@DOMAIN.com</mention-user>');
 });

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -132,3 +132,17 @@ test('Test remove style tag', () => {
     const testString = '<div><svg><style>.default-avatar_20_svg__st1{fill:#008c59}</style></svg><p>a text</p></div>';
     expect(parser.htmlToText(testString)).toBe('a text');
 });
+
+test('Mention html to markdown', () => {
+    let testString = '<mention-user>@user@domain.com</mention-user>';
+    expect(parser.htmlToText(testString)).toBe('@user@domain.com');
+
+    testString = '<mention-user>@USER@DOMAIN.COM</mention-user>';
+    expect(parser.htmlToText(testString)).toBe('@USER@DOMAIN.COM');
+
+    testString = '<mention-user>@USER@domain.com</mention-user>';
+    expect(parser.htmlToText(testString)).toBe('@USER@domain.com');
+
+    testString = '<mention-user>@user@DOMAIN.com</mention-user>';
+    expect(parser.htmlToText(testString)).toBe('@user@DOMAIN.com');
+});

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -133,7 +133,7 @@ test('Test remove style tag', () => {
     expect(parser.htmlToText(testString)).toBe('a text');
 });
 
-test('Mention html to markdown', () => {
+test('Mention html to text', () => {
     let testString = '<mention-user>@user@domain.com</mention-user>';
     expect(parser.htmlToText(testString)).toBe('@user@domain.com');
 

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -690,17 +690,3 @@ test('Test codeFence copy from selection does not add extra new line', () => {
     testString = '<h3>test heading</h3><div><pre class=\"notranslate\"><code class=\"notranslate\">Code snippet\n</code></pre></div><blockquote><p><a href=\"https://www.example.com\">link</a></p></blockquote>';
     expect(parser.htmlToMarkdown(testString)).toBe('test heading\n```\nCode snippet\n```\n> [link](https://www.example.com)')
 });
-
-test('Mention html to markdown', () => {
-    let testString = '<mention-user>@user@domain.com</mention-user>';
-    expect(parser.htmlToMarkdown(testString)).toBe('@user@domain.com');
-
-    testString = '<mention-user>@USER@DOMAIN.COM</mention-user>';
-    expect(parser.htmlToMarkdown(testString)).toBe('@USER@DOMAIN.COM');
-
-    testString = '<mention-user>@USER@domain.com</mention-user>';
-    expect(parser.htmlToMarkdown(testString)).toBe('@USER@domain.com');
-
-    testString = '<mention-user>@user@DOMAIN.com</mention-user>';
-    expect(parser.htmlToMarkdown(testString)).toBe('@user@DOMAIN.com');
-});

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -690,3 +690,17 @@ test('Test codeFence copy from selection does not add extra new line', () => {
     testString = '<h3>test heading</h3><div><pre class=\"notranslate\"><code class=\"notranslate\">Code snippet\n</code></pre></div><blockquote><p><a href=\"https://www.example.com\">link</a></p></blockquote>';
     expect(parser.htmlToMarkdown(testString)).toBe('test heading\n```\nCode snippet\n```\n> [link](https://www.example.com)')
 });
+
+test('Mention html to markdown', () => {
+    let testString = '<mention-user>@user@domain.com</mention-user>';
+    expect(parser.htmlToMarkdown(testString)).toBe('@user@domain.com');
+
+    testString = '<mention-user>@USER@DOMAIN.COM</mention-user>';
+    expect(parser.htmlToMarkdown(testString)).toBe('@USER@DOMAIN.COM');
+
+    testString = '<mention-user>@USER@domain.com</mention-user>';
+    expect(parser.htmlToMarkdown(testString)).toBe('@USER@domain.com');
+
+    testString = '<mention-user>@user@DOMAIN.com</mention-user>';
+    expect(parser.htmlToMarkdown(testString)).toBe('@user@DOMAIN.com');
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -115,7 +115,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`[a-zA-Z0-9.!$%&+/=?^\`{|}-]?@+${CONST.REG_EXP.EMAIL_PART}(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gm'),
+                regex: new RegExp(`[a-zA-Z0-9.!$%&+/=?^\`{|}-]?@+${CONST.REG_EXP.EMAIL_PART}(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gmi'),
                 replacement: (match) => {
                     if (!Str.isValidMention(match)) {
                         return match;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
[$ GH_LINK](https://github.com/Expensify/App/issues/26016)
https://github.com/Expensify/App/issues/26016

# Tests
Open the app
Open any report
Write '@' to trigger mentions
Select any one mention, make any letter of mention as capital and send
Hover on mention to observe that tooltip doesn't display the right display name and avatar
For same mention as step 4 or select different mention and capitalize all letters and send
Observe that now it is not displayed as mention
