### PR TITLE
Do not allow to parse link with multiline alias text when header markdown is leading

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1427,6 +1427,13 @@ test('Test link with code fence inside the alias text part', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test link with header before the alias multiline text part', () => {
+    const testString = '# [google\ngoogle\ngoogle](https://google.com)';
+
+    const resultString = '<h1>[google</h1>google<br />google](<a href=\"https://google.com\" target=\"_blank\" rel=\"noreferrer noopener\">https://google.com</a>)';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test strikethrough with multiple tilde characters', () => {
     let testString = '~~~hello~~~';
     expect(parser.replace(testString)).toBe('~~<del>hello</del>~~');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -515,6 +515,7 @@ export default class ExpensiMark {
             }
 
             // We don't want to apply link rule if match[1] contains the code block inside the [] of the markdown e.g. [```example```](https://example.com)
+            // , Or match[1] is the multiline alias text which the header markdown precedes to. e.g. # [example\nexample\nexample](https://example.com)
             if (isDoneMatching || match[1].includes('<pre>') || match[1].includes('</h1>')) {
                 replacedText = replacedText.concat(textToCheck.substr(match.index, (match[0].length)));
             } else if (shouldApplyAutoLinkAgain) {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -72,6 +72,11 @@ export default class ExpensiMark {
                 },
             },
 
+            {
+                name: 'heading1',
+                regex: /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm,
+                replacement: '<h1>$1</h1>',
+            },
             /**
              * Converts markdown style links to anchor tags e.g. [Expensify](https://www.expensify.com)
              * We need to convert before the autolink rule since it will not try to create a link
@@ -183,11 +188,6 @@ export default class ExpensiMark {
                 replacement: '$1<a href="mailto:$2">$2</a>',
             },
 
-            {
-                name: 'heading1',
-                regex: /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm,
-                replacement: '<h1>$1</h1>',
-            },
             {
                 name: 'quote',
 
@@ -514,7 +514,7 @@ export default class ExpensiMark {
             }
 
             // We don't want to apply link rule if match[1] contains the code block inside the [] of the markdown e.g. [```example```](https://example.com)
-            if (isDoneMatching || match[1].includes('<pre>')) {
+            if (isDoneMatching || match[1].includes('<pre>') || match[1].includes('</h1>')) {
                 replacedText = replacedText.concat(textToCheck.substr(match.index, (match[0].length)));
             } else if (shouldApplyAutoLinkAgain) {
                 const urlRegex = new RegExp(`^${LOOSE_URL_REGEX}$|^${URL_REGEX}$`, 'i');

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -77,6 +77,7 @@ export default class ExpensiMark {
                 regex: /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm,
                 replacement: '<h1>$1</h1>',
             },
+
             /**
              * Converts markdown style links to anchor tags e.g. [Expensify](https://www.expensify.com)
              * We need to convert before the autolink rule since it will not try to create a link

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -515,7 +515,7 @@ export default class ExpensiMark {
             }
 
             // We don't want to apply link rule if match[1] contains the code block inside the [] of the markdown e.g. [```example```](https://example.com)
-            // , Or match[1] is the multiline alias text which the header markdown precedes to. e.g. # [example\nexample\nexample](https://example.com)
+            // or if match[1] is multiline text preceeded by markdown heading, e.g., # [example\nexample\nexample](https://example.com)
             if (isDoneMatching || match[1].includes('<pre>') || match[1].includes('</h1>')) {
                 replacedText = replacedText.concat(textToCheck.substr(match.index, (match[0].length)));
             } else if (shouldApplyAutoLinkAgain) {


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/26942
Proposal: https://github.com/Expensify/App/issues/26942#issuecomment-1744062072

### Tests
 Same as QA step
### Offline tests
 Same as QA step
### QA
1. Go to any chat
2. In composer, send message as following
```
    # [google1
    google2
    google3](https://www.google.com)
```
3. Verify that the first line ([google1) is parsed as header, and `https://www.google.com` will be parsed as autolink.

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://github.com/Expensify/App/assets/86615752/8e172eb9-689e-4880-bf9b-6bd1eb0807e5)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>


