### PR TITLE
fix the issue that inconsistent highlighting occurs when multiple mentions are used without spaces

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1326,6 +1326,22 @@ test('Test user mention and here mention, which are concatenated without space',
     testString = '@here+1@gmail.com@here';
     resultString = '<mention-user>@here+1@gmail.com</mention-user><mention-here>@here</mention-here>';
     expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here@gmail.com@here@here@gmail.com';
+    resultString = '<mention-user>@here@gmail.com</mention-user><mention-here>@here</mention-here><mention-user>@here@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here@gmail.com@here@here+1@gmail.com';
+    resultString = '<mention-user>@here@gmail.com</mention-user><mention-here>@here</mention-here><mention-user>@here+1@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here+1@gmail.com@here@here+2@gmail.com';
+    resultString = '<mention-user>@here+1@gmail.com</mention-user><mention-here>@here</mention-here><mention-user>@here+2@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here+1@gmail.com@here@here@here+2@gmail.com@here@here@gmail.com';
+    resultString = '<mention-user>@here+1@gmail.com</mention-user><mention-here>@here</mention-here><mention-here>@here</mention-here><mention-user>@here+2@gmail.com</mention-user><mention-here>@here</mention-here><mention-user>@here@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test for mention inside link and email markdown', () => {

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1299,16 +1299,16 @@ test('Test for @here mention without space or supported styling character', () =
 });
 
 test('Test user mention and here mention, which are concatenated without space', () => {
-    let testString = '@aiman.chnaif+2@gmail.com@here';
-    let resultString = '<mention-user>@aiman.chnaif+2@gmail.com</mention-user><mention-here>@here</mention-here>';
+    let testString = '@test.example+2@gmail.com@here';
+    let resultString = '<mention-user>@test.example+2@gmail.com</mention-user><mention-here>@here</mention-here>';
     expect(parser.replace(testString)).toBe(resultString);
 
-    testString = '@here@aiman.chnaif+2@gmail.com';
-    resultString = '<mention-here>@here</mention-here><mention-user>@aiman.chnaif+2@gmail.com</mention-user>';
+    testString = '@here@test.example+2@gmail.com';
+    resultString = '<mention-here>@here</mention-here><mention-user>@test.example+2@gmail.com</mention-user>';
     expect(parser.replace(testString)).toBe(resultString);
 
-    testString = '@aiman.chnaif+2@gmail.com@aiman.chnaif+2@gmail.com';
-    resultString = '<mention-user>@aiman.chnaif+2@gmail.com</mention-user><mention-user>@aiman.chnaif+2@gmail.com</mention-user>';
+    testString = '@test.example+2@gmail.com@test.example+2@gmail.com';
+    resultString = '<mention-user>@test.example+2@gmail.com</mention-user><mention-user>@test.example+2@gmail.com</mention-user>';
     expect(parser.replace(testString)).toBe(resultString);
 
     testString = '@here@here@gmail.com';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1298,6 +1298,36 @@ test('Test for @here mention without space or supported styling character', () =
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test user mention and here mention, which are concatenated without space', () => {
+    let testString = '@aiman.chnaif+2@gmail.com@here';
+    let resultString = '<mention-user>@aiman.chnaif+2@gmail.com</mention-user><mention-here>@here</mention-here>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here@aiman.chnaif+2@gmail.com';
+    resultString = '<mention-here>@here</mention-here><mention-user>@aiman.chnaif+2@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@aiman.chnaif+2@gmail.com@aiman.chnaif+2@gmail.com';
+    resultString = '<mention-user>@aiman.chnaif+2@gmail.com</mention-user><mention-user>@aiman.chnaif+2@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here@here@gmail.com';
+    resultString = '<mention-here>@here</mention-here><mention-user>@here@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here@gmail.com@here';
+    resultString = '<mention-user>@here@gmail.com</mention-user><mention-here>@here</mention-here>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here@here+1@gmail.com';
+    resultString = '<mention-here>@here</mention-here><mention-user>@here+1@gmail.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '@here+1@gmail.com@here';
+    resultString = '<mention-user>@here+1@gmail.com</mention-user><mention-here>@here</mention-here>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test for mention inside link and email markdown', () => {
     const testString = '[@username@expensify.com](expensify.com) '
     + '[_@username@expensify.com_](expensify.com) '

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -115,12 +115,12 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`[a-zA-Z0-9.!$%&+/=?^\`{|}-]?@+${CONST.REG_EXP.EMAIL_PART}(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gm'),
-                replacement: (match) => {
+                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@+${CONST.REG_EXP.EMAIL_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gm'),
+                replacement: (match, g1, g2) => {
                     if (!Str.isValidMention(match)) {
                         return match;
                     }
-                    return `<mention-user>${match}</mention-user>`;
+                    return `${g1}<mention-user>${g2}</mention-user>`;
                 },
             },
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -97,7 +97,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'hereMentions',
-                regex: /([a-zA-Z0-9.!$%&+/=?^`{|}_-]?)(@here)([a-zA-Z0-9.!$%&+/=?^`{|}_-]?)(?=\b)(?!(@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)|((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>))/gm,
+                regex: /([^@*~]?)(@here)([^@*~]?)(?=\b)(?!([\w'#%+-]*@(?:[a-z\d-]+\.)+[a-z]{2,}(?:\s|$|@here))|((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>))/gm,
                 replacement: (match, g1, g2, g3) => {
                     if (!Str.isValidMention(match)) {
                         return match;
@@ -122,6 +122,12 @@ export default class ExpensiMark {
                     }
                     return `<mention-user>${match}</mention-user>`;
                 },
+            },
+
+            {
+                name: 'hereMentionAfterUserMentions',
+                regex: /(<\/mention-user>)(@here)(?=\b)/gm,
+                replacement: '$1<mention-here>$2</mention-here>',
             },
 
             /**

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -103,7 +103,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'hereMentions',
-                regex: /([^@*~]?)(@here)([^@*~]?)(?=\b)(?!([\w'#%+-]*@(?:[a-z\d-]+\.)+[a-z]{2,}(?:\s|$|@here))|((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>))/gm,
+                regex: /([a-zA-Z0-9.!$%&+/=?^`{|}_-]?)(@here)([.!$%&+/=?^`{|}_-]?)(?=\b)(?!([\w'#%+-]*@(?:[a-z\d-]+\.)+[a-z]{2,}(?:\s|$|@here))|((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>))/gm,
                 replacement: (match, g1, g2, g3) => {
                     if (!Str.isValidMention(match)) {
                         return match;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -121,7 +121,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@+${CONST.REG_EXP.EMAIL_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gm'),
+                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@+${CONST.REG_EXP.EMAIL_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
                 replacement: (match, g1, g2) => {
                     if (!Str.isValidMention(match)) {
                         return match;

--- a/lib/str.js
+++ b/lib/str.js
@@ -944,8 +944,7 @@ const Str = {
      */
     isValidMention(mention) {
         // Mentions can start @ proceeded by a space, eg "ping @user@domain.tld"
-        // or by a @here, eg "@here@user@domain.tld"
-        if (/[\s@]/g.test(mention.charAt(0)) || /^@here.*/g.test(mention)) {
+        if (/[\s@]/g.test(mention.charAt(0))) {
             return true;
         }
 

--- a/lib/str.js
+++ b/lib/str.js
@@ -944,7 +944,8 @@ const Str = {
      */
     isValidMention(mention) {
         // Mentions can start @ proceeded by a space, eg "ping @user@domain.tld"
-        if (/[\s@]/g.test(mention.charAt(0))) {
+        // or by a @here, eg "@here@user@domain.tld"
+        if (/[\s@]/g.test(mention.charAt(0)) || /^@here.*/g.test(mention)) {
             return true;
         }
 


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/21753
Proposal: https://github.com/Expensify/App/issues/21753#issuecomment-1759589159

### Tests
1. Go to any chat.
2. Type the following cases
```
@test.example+2@gmail.com@here
@here@test.example+2@gmail.com
@test.example+2@gmail.com@test.example+2@gmail.com
@here@here@gmail.com
@here@gmail.com@here
@here@here+1@gmail.com
@here+1@gmail.com@here
```
3. Observe that all the mentions are highlighted as expected.

### QA
Same as tests step

### Offline tests
Same as tests step

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://github.com/Expensify/expensify-common/assets/86615752/87ea4597-b535-4a9a-aa3c-d5cbef916cd1)



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

