### PR TITLE
Do not allow starting and ending hyphen in local-style urls

### DIFF
--- a/__tests__/URL-test.js
+++ b/__tests__/URL-test.js
@@ -48,6 +48,7 @@ describe('Loose URL validation', () => {
         expect(regexToTest.test('http://a.b')).toBeTruthy();
         expect(regexToTest.test('http://expensify')).toBeTruthy();
         expect(regexToTest.test('http://google.com/abcd')).toBeTruthy();
+        expect(regexToTest.test('http://my.localhost.local-domain')).toBeTruthy();
     });
 
     it('correctly tests invalid urls', () => {
@@ -55,5 +56,11 @@ describe('Loose URL validation', () => {
         expect(regexToTest.test('localhost:3000')).toBeFalsy();
         expect(regexToTest.test('local.url')).toBeFalsy();
         expect(regexToTest.test('https://otherexample.com links get rendered first')).toBeFalsy();
+        expect(regexToTest.test('http://-localhost')).toBeFalsy();
+        expect(regexToTest.test('http://_')).toBeFalsy();
+        expect(regexToTest.test('http://_localhost')).toBeFalsy();
+        expect(regexToTest.test('http://-77.com')).toBeFalsy();
+        expect(regexToTest.test('http://77-.com')).toBeFalsy();
+        expect(regexToTest.test('http://my.localhost....local-domain:8080')).toBeFalsy();
     });
 });

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -11,7 +11,7 @@ const URL_REGEX = `((${URL_WEBSITE_REGEX})${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}
 
 const URL_REGEX_WITH_REQUIRED_PROTOCOL = URL_REGEX.replace(`${URL_PROTOCOL_REGEX}?`, URL_PROTOCOL_REGEX);
 
-const LOOSE_URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}([-\\w]+(\\.[-\\w]+)*)(?:\\:${ALLOWED_PORTS}|\\b|(?=_))`;
+const LOOSE_URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}([a-z0-9](?:[-a-z0-9]*[a-z0-9])?\\.)*(?:[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)(?:\\:${ALLOWED_PORTS}|\\b|(?=_))`;
 const LOOSE_URL_REGEX = `((${LOOSE_URL_WEBSITE_REGEX})${URL_PATH_REGEX}(?:${URL_PARAM_REGEX}|${URL_FRAGMENT_REGEX})*)`;
 
 


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/27080
Proposal: https://github.com/Expensify/App/issues/27080#issuecomment-1763892171

### Tests
1. Go to any chat.
2. Type the following valid local-style urls and observe that it's parsed
```
valid urls
        http://localhost:3000
        https://local.url
        http://a.b
        http://expensify
        http://google.com/abcd
        http://my.localhost.local-domain
```
3. Type the following invalid local-style urls and observe that it's not parsed
```
invalid urls
        localhost:3000
        local.url
        http://-localhost
        http://_
        http://_localhost
        http://-77.com
        http://77-.com
        http://my.localhost....local-domain:8080
```
### QA
Same as tests step

### Offline tests
Same as tests step

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://github.com/Expensify/App/assets/86615752/da310845-63d0-4394-849d-fff9dbb6c221)


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

