### PR TITLE
Enhance ExpensiMark blockquote parsing for Live Markdown Preview

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1491,7 +1491,7 @@ test('Mention', () => {
     expect(parser.replace(testString)).toBe('<mention-user>@user@DOMAIN.com</mention-user>');
 });
 
-describe('edit mode', () => {
+describe('when should keep whitespace flag is enabled', () => {
     test('quote without space', () => {
         const quoteTestStartString = '>Hello world';
         const quoteTestReplacedString = '<blockquote>Hello world</blockquote>';
@@ -1499,14 +1499,14 @@ describe('edit mode', () => {
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
-    test('quote with space', () => {
+    test('quote with single space', () => {
         const quoteTestStartString = '> Hello world';
         const quoteTestReplacedString = '<blockquote> Hello world</blockquote>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
-    test('quote with a lot of spaces', () => {
+    test('quote with multiple spaces', () => {
         const quoteTestStartString = '>     Hello world';
         const quoteTestReplacedString = '<blockquote>     Hello world</blockquote>';
 
@@ -1520,35 +1520,37 @@ describe('edit mode', () => {
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
-    test('mixed blocqoutes', () => {
+    test('separate blockqoutes', () => {
         const quoteTestStartString = '>Lorem ipsum\ndolor\n>sit amet';
         const quoteTestReplacedString = '<blockquote>Lorem ipsum</blockquote><br />dolor<br /><blockquote>sit amet</blockquote>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
-    test('nested quote and heading', () => {
-        const quoteTestStartString = '># Hello world';
-        const quoteTestReplacedString = '<blockquote><h1>Hello world</h1></blockquote>';
+    describe('nested heading in blockquote', () => {
+        test('without spaces', () => {
+            const quoteTestStartString = '># Hello world';
+            const quoteTestReplacedString = '<blockquote><h1>Hello world</h1></blockquote>';
 
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        });
+
+        test('with single space', () => {
+            const quoteTestStartString = '> # Hello world';
+            const quoteTestReplacedString = '<blockquote> <h1>Hello world</h1></blockquote>';
+
+            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        });
+
+        test('with multiple spaces after #', () => {
+            const quoteTestStartString = '>#    Hello world';
+            const quoteTestReplacedString = '<blockquote><h1>   Hello world</h1></blockquote>';
+
+            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        });
     });
 
-    test('nested quote and heading with space between', () => {
-        const quoteTestStartString = '> # Hello world';
-        const quoteTestReplacedString = '<blockquote> <h1>Hello world</h1></blockquote>';
-
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
-    });
-
-    test('nested quote and heading with many spaces after #', () => {
-        const quoteTestStartString = '>#    Hello world';
-        const quoteTestReplacedString = '<blockquote><h1>   Hello world</h1></blockquote>';
-
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
-    });
-
-    describe('trailing whitespace', () => {
+    describe('trailing whitespace after blockquote', () => {
         test('nothing', () => {
             const quoteTestStartString = '>Hello world!';
             const quoteTestReplacedString = '<blockquote>Hello world!</blockquote>';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1501,43 +1501,64 @@ describe('edit mode', () => {
     });
 
     test('multiple quotes', () => {
-        const quoteTestStartString = '> Hello my\n> beautiful\n> world\n';
+        const quoteTestStartString = '>Hello my\n>beautiful\n>world\n';
         const quoteTestReplacedString = '<blockquote>Hello my</blockquote><br /><blockquote>beautiful</blockquote><br /><blockquote>world</blockquote><br />';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
     test('mixed blocqoutes', () => {
-        const quoteTestStartString = '> Lorem ipsum\ndolor\n> sit amet';
+        const quoteTestStartString = '>Lorem ipsum\ndolor\n>sit amet';
         const quoteTestReplacedString = '<blockquote>Lorem ipsum</blockquote><br />dolor<br /><blockquote>sit amet</blockquote>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
     test('nested quote and heading', () => {
-        const quoteTestStartString = '> # Hello world';
+        const quoteTestStartString = '># Hello world';
         const quoteTestReplacedString = '<blockquote><h1>Hello world</h1></blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('quote without space', () => {
+        const quoteTestStartString = '>Hello world';
+        const quoteTestReplacedString = '<blockquote>Hello world</blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('quote with space', () => {
+        const quoteTestStartString = '> Hello world';
+        const quoteTestReplacedString = '<blockquote> Hello world</blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('quote with a lot of spaces', () => {
+        const quoteTestStartString = '>     Hello world';
+        const quoteTestReplacedString = '<blockquote>     Hello world</blockquote>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
     describe('trailing whitespace', () => {
         test('nothing', () => {
-            const quoteTestStartString = '> Hello world!';
+            const quoteTestStartString = '>Hello world!';
             const quoteTestReplacedString = '<blockquote>Hello world!</blockquote>';
 
             expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
         });
 
         test('space', () => {
-            const quoteTestStartString = '> Hello world ';
+            const quoteTestStartString = '>Hello world ';
             const quoteTestReplacedString = '<blockquote>Hello world </blockquote>';
 
             expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
         });
 
         test('newline', () => {
-            const quoteTestStartString = '> Hello world\n';
+            const quoteTestStartString = '>Hello world\n';
             const quoteTestReplacedString = '<blockquote>Hello world</blockquote><br />';
 
             expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1521,6 +1521,13 @@ describe('edit mode', () => {
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
+    test('nested quote and heading with space between', () => {
+        const quoteTestStartString = '> # Hello world';
+        const quoteTestReplacedString = '<blockquote> <h1>Hello world</h1></blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
     test('quote without space', () => {
         const quoteTestStartString = '>Hello world';
         const quoteTestReplacedString = '<blockquote>Hello world</blockquote>';
@@ -1565,3 +1572,5 @@ describe('edit mode', () => {
         });
     });
 });
+
+

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1515,14 +1515,14 @@ describe('when should keep whitespace flag is enabled', () => {
 
     test('multiple quotes', () => {
         const quoteTestStartString = '>Hello my\n>beautiful\n>world\n';
-        const quoteTestReplacedString = '<blockquote>Hello my</blockquote><br /><blockquote>beautiful</blockquote><br /><blockquote>world</blockquote><br />';
+        const quoteTestReplacedString = '<blockquote>Hello my</blockquote>\n<blockquote>beautiful</blockquote>\n<blockquote>world</blockquote>\n';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
     test('separate blockqoutes', () => {
         const quoteTestStartString = '>Lorem ipsum\ndolor\n>sit amet';
-        const quoteTestReplacedString = '<blockquote>Lorem ipsum</blockquote><br />dolor<br /><blockquote>sit amet</blockquote>';
+        const quoteTestReplacedString = '<blockquote>Lorem ipsum</blockquote>\ndolor\n<blockquote>sit amet</blockquote>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
@@ -1567,7 +1567,7 @@ describe('when should keep whitespace flag is enabled', () => {
 
         test('newline', () => {
             const quoteTestStartString = '>Hello world\n';
-            const quoteTestReplacedString = '<blockquote>Hello world</blockquote><br />';
+            const quoteTestReplacedString = '<blockquote>Hello world</blockquote>\n';
 
             expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
         });
@@ -1575,7 +1575,7 @@ describe('when should keep whitespace flag is enabled', () => {
 
     test('quote with other markdowns', () => {
         const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote><br />Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>\nHere is a &gt;quote that did not\n<pre>here&#32;is&#32;a&#32;codefenced&#32;quote\n&gt;it&#32;should&#32;not&#32;be&#32;quoted\n</pre>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1542,6 +1542,13 @@ describe('edit mode', () => {
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
+    test('nested quote and heading with many spaces after #', () => {
+        const quoteTestStartString = '>#    Hello world';
+        const quoteTestReplacedString = '<blockquote><h1>   Hello world</h1></blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
     describe('trailing whitespace', () => {
         test('nothing', () => {
             const quoteTestStartString = '>Hello world!';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -668,7 +668,6 @@ test('Test urls with unmatched closing parentheses autolinks correctly', () => {
             testString: 'google.com/(toto))titi)',
             resultString: '<a href="https://google.com/(toto)" target="_blank" rel="noreferrer noopener">google.com/(toto)</a>)titi)',
         },
-
     ];
     testCases.forEach(testCase => {
         expect(parser.replace(testCase.testString)).toBe(testCase.resultString);

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -668,7 +668,7 @@ test('Test urls with unmatched closing parentheses autolinks correctly', () => {
             testString: 'google.com/(toto))titi)',
             resultString: '<a href="https://google.com/(toto)" target="_blank" rel="noreferrer noopener">google.com/(toto)</a>)titi)',
         },
-        
+
     ];
     testCases.forEach(testCase => {
         expect(parser.replace(testCase.testString)).toBe(testCase.resultString);
@@ -1490,4 +1490,57 @@ test('Mention', () => {
 
     testString = '@user@DOMAIN.com';
     expect(parser.replace(testString)).toBe('<mention-user>@user@DOMAIN.com</mention-user>');
+});
+
+describe('edit mode', () => {
+    test('normal quote', () => {
+        const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
+        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote><br />Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('multiple quotes', () => {
+        const quoteTestStartString = '> Hello my\n> beautiful\n> world\n';
+        const quoteTestReplacedString = '<blockquote>Hello my</blockquote><br /><blockquote>beautiful</blockquote><br /><blockquote>world</blockquote><br />';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('mixed blocqoutes', () => {
+        const quoteTestStartString = '> Lorem ipsum\ndolor\n> sit amet';
+        const quoteTestReplacedString = '<blockquote>Lorem ipsum</blockquote><br />dolor<br /><blockquote>sit amet</blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('nested quote and heading', () => {
+        const quoteTestStartString = '> # Hello world';
+        const quoteTestReplacedString = '<blockquote><h1>Hello world</h1></blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    describe('trailing whitespace', () => {
+        test('nothing', () => {
+            const quoteTestStartString = '> Hello world!';
+            const quoteTestReplacedString = '<blockquote>Hello world!</blockquote>';
+
+            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        });
+
+        test('space', () => {
+            const quoteTestStartString = '> Hello world ';
+            const quoteTestReplacedString = '<blockquote>Hello world </blockquote>';
+
+            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        });
+
+        test('newline', () => {
+            const quoteTestStartString = '> Hello world\n';
+            const quoteTestReplacedString = '<blockquote>Hello world</blockquote><br />';
+
+            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        });
+    });
 });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1493,9 +1493,23 @@ test('Mention', () => {
 });
 
 describe('edit mode', () => {
-    test('normal quote', () => {
-        const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote><br />Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+    test('quote without space', () => {
+        const quoteTestStartString = '>Hello world';
+        const quoteTestReplacedString = '<blockquote>Hello world</blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('quote with space', () => {
+        const quoteTestStartString = '> Hello world';
+        const quoteTestReplacedString = '<blockquote> Hello world</blockquote>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('quote with a lot of spaces', () => {
+        const quoteTestStartString = '>     Hello world';
+        const quoteTestReplacedString = '<blockquote>     Hello world</blockquote>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
@@ -1528,27 +1542,6 @@ describe('edit mode', () => {
         expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
     });
 
-    test('quote without space', () => {
-        const quoteTestStartString = '>Hello world';
-        const quoteTestReplacedString = '<blockquote>Hello world</blockquote>';
-
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
-    });
-
-    test('quote with space', () => {
-        const quoteTestStartString = '> Hello world';
-        const quoteTestReplacedString = '<blockquote> Hello world</blockquote>';
-
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
-    });
-
-    test('quote with a lot of spaces', () => {
-        const quoteTestStartString = '>     Hello world';
-        const quoteTestReplacedString = '<blockquote>     Hello world</blockquote>';
-
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
-    });
-
     describe('trailing whitespace', () => {
         test('nothing', () => {
             const quoteTestStartString = '>Hello world!';
@@ -1571,6 +1564,11 @@ describe('edit mode', () => {
             expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
         });
     });
+
+    test('quote with other markdowns', () => {
+        const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
+        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote><br />Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+    });
 });
-
-

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -205,8 +205,15 @@ export default class ExpensiMark {
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
                 replacement: (g1) => {
-                    const replacedText = this.replace(g1.replace(/^&gt;/gm, ''), {filterRules: ['heading1'], shouldEscapeText: false});
-                    return `<blockquote>${replacedText}</blockquote>`;
+                    // We want to enable 2 options of nested heading inside the blockquote: "># heading" and "> # heading".
+                    // To do this we need to parse body of the quote without first space
+                    let isStartingWithSpace = false;
+                    const textToReplace = g1.replace(/^&gt;( )?/gm, (match, g2) => {
+                        isStartingWithSpace = !!g2;
+                        return '';
+                    });
+                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false});
+                    return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -407,6 +407,18 @@ export default class ExpensiMark {
                 replacement: '',
             },
         ];
+
+        /**
+         * The list of rules that we have to exclude in shouldKeepWhitespaceRules list.
+         * @type {Object[]}
+         */
+        this.whitespaceRulesToDisable = ['newline', 'replacepre', 'replacebr', 'replaceh1br'];
+
+        /**
+         * The list of rules that have to be applied when shouldKeepWhitespace flag is true.
+         * @type {Object[]}
+         */
+        this.shouldKeepWhitespaceRules = this.rules.filter(rule => !this.whitespaceRulesToDisable.includes(rule.name)).map(rule => rule.name);
     }
 
     /**
@@ -423,8 +435,8 @@ export default class ExpensiMark {
     replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepWhitespace = false} = {}) {
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? _.escape(text) : text;
-
-        const rules = _.isEmpty(filterRules) ? this.rules : _.filter(this.rules, rule => _.contains(filterRules, rule.name));
+        const excludeRules = shouldKeepWhitespace ? _.union(this.shouldKeepWhitespaceRules, filterRules) : filterRules;
+        const rules = _.isEmpty(excludeRules) ? this.rules : _.filter(this.rules, rule => _.contains(excludeRules, rule.name));
 
         try {
             rules.forEach((rule) => {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -205,7 +205,7 @@ export default class ExpensiMark {
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
                 replacement: (g1) => {
-                    const replacedText = this.replace(g1.replace(/^&gt;( )?/gm, ''), {filterRules: ['heading1'], shouldEscapeText: false});
+                    const replacedText = this.replace(g1.replace(/^&gt;/gm, ''), {filterRules: ['heading1'], shouldEscapeText: false});
                     return `<blockquote>${replacedText}</blockquote>`;
                 },
             },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -195,14 +195,17 @@ export default class ExpensiMark {
                 // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
-                process: (textToProcess, replacement) => {
+                process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
                     const regex = new RegExp(
-                        /\n?^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)\n?/gm,
+                        /^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm,
                     );
+                    if (shouldKeepWhitespace) {
+                        return textToProcess.replace(regex, replacement);
+                    }
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
                 replacement: (g1) => {
-                    const replacedText = this.replace(g1, {filterRules: ['heading1'], shouldEscapeText: false});
+                    const replacedText = this.replace(g1.replace(/^&gt;( )?/gm, ''), {filterRules: ['heading1'], shouldEscapeText: false});
                     return `<blockquote>${replacedText}</blockquote>`;
                 },
             },
@@ -407,7 +410,7 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    replace(text, {filterRules = [], shouldEscapeText = true} = {}) {
+    replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepWhitespace = false} = {}) {
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? _.escape(text) : text;
 
@@ -421,7 +424,7 @@ export default class ExpensiMark {
                 }
 
                 if (rule.process) {
-                    replacedText = rule.process(replacedText, rule.replacement);
+                    replacedText = rule.process(replacedText, rule.replacement, shouldKeepWhitespace);
                 } else {
                     replacedText = replacedText.replace(rule.regex, rule.replacement);
                 }

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -75,10 +75,8 @@ export default class ExpensiMark {
             {
                 name: 'heading1',
                 process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
-                    if (shouldKeepWhitespace) {
-                        return textToProcess.replace(/^# ( *(?! )(?:(?!<pre>|\n|\r\n).)+)/gm, replacement);
-                    }
-                    return textToProcess.replace(/^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm, replacement);
+                    const regexp = shouldKeepWhitespace ? /^# ( *(?! )(?:(?!<pre>|\n|\r\n).)+)/gm : /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm;
+                    return textToProcess.replace(regexp, replacement);
                 },
                 replacement: '<h1>$1</h1>',
             },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -74,7 +74,12 @@ export default class ExpensiMark {
 
             {
                 name: 'heading1',
-                regex: /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm,
+                process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
+                    if (shouldKeepWhitespace) {
+                        return textToProcess.replace(/^# ( *(?! )(?:(?!<pre>|\n|\r\n).)+)/gm, replacement);
+                    }
+                    return textToProcess.replace(/^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm, replacement);
+                },
                 replacement: '<h1>$1</h1>',
             },
 
@@ -200,11 +205,11 @@ export default class ExpensiMark {
                         /^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm,
                     );
                     if (shouldKeepWhitespace) {
-                        return textToProcess.replace(regex, replacement);
+                        return textToProcess.replace(regex, g1 => replacement(g1, shouldKeepWhitespace));
                     }
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
-                replacement: (g1) => {
+                replacement: (g1, shouldKeepWhitespace = false) => {
                     // We want to enable 2 options of nested heading inside the blockquote: "># heading" and "> # heading".
                     // To do this we need to parse body of the quote without first space
                     let isStartingWithSpace = false;
@@ -212,7 +217,7 @@ export default class ExpensiMark {
                         isStartingWithSpace = !!g2;
                         return '';
                     });
-                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false});
+                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false, shouldKeepWhitespace});
                     return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
             },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR:
- adds new shouldKeepWhitespace flag to the parser.replace function in ExpensiMark, which allows trailing whitespace in blockquotes
- changes quote rule logic when shouldKeepWhitespace is true
- allows trailing whitespace in blockquote in edit mode
- allows leading spaces in blockquote in edit mode

https://github.com/Expensify/expensify-common/assets/39538890/8a4de1fe-c2c4-423f-929e-57728961c01c


### Fixed Issues
$ https://github.com/Expensify/App/issues/31178
$ https://github.com/Expensify/App/issues/31179
$ https://github.com/Expensify/App/issues/31182

# Tests
To test these changes I've added proper tests connected to all needed behaviors for Live Markdown Preview. To test it by yourself you will need [example app](https://github.com/tomekzaw/MarkdownTextInput/tree/%40Skalakid/expensify-common-fixes).

# QA
Same as tests
