### PR TITLE
Fix bug with characters after @here mention

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1418,6 +1418,17 @@ test('Test here mention with @here@here', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test here mention with @herex', () => {
+    const testString = '@herex';
+    expect(parser.replace(testString)).toBe(testString);
+});
+
+test('Test here mention with @here!', () => {
+    const testString = '@here!';
+    const resultString = '<mention-here>@here</mention-here>!';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test link with code fence inside the alias text part', () => {
     const testString = '[```code```](google.com) '
         + '[test ```code``` test](google.com)';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1270,7 +1270,10 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' @here@'
     + ' @here$'
     + ' @here^'
-    + ' @here(';
+    + ' @here('
+    + ' @here.'
+    + ' @here!'
+    + ' @here?';
 
     const resultString = '<mention-here>@here</mention-here>'
     + ' <em><mention-here>@here</mention-here></em>'
@@ -1288,7 +1291,10 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' <mention-here>@here</mention-here>@'
     + ' <mention-here>@here</mention-here>$'
     + ' <mention-here>@here</mention-here>^'
-    + ' <mention-here>@here</mention-here>(';
+    + ' <mention-here>@here</mention-here>('
+    + ' <mention-here>@here</mention-here>.'
+    + ' <mention-here>@here</mention-here>!'
+    + ' <mention-here>@here</mention-here>?';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -1415,17 +1421,6 @@ test('Test here mention with @here@', () => {
 test('Test here mention with @here@here', () => {
     const testString = '@here@here';
     const resultString = '<mention-here>@here</mention-here><mention-here>@here</mention-here>';
-    expect(parser.replace(testString)).toBe(resultString);
-});
-
-test('Test here mention with @herex', () => {
-    const testString = '@herex';
-    expect(parser.replace(testString)).toBe(testString);
-});
-
-test('Test here mention with @here!', () => {
-    const testString = '@here!';
-    const resultString = '<mention-here>@here</mention-here>!';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1273,7 +1273,8 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' @here('
     + ' @here.'
     + ' @here!'
-    + ' @here?';
+    + ' @here?'
+    + ' @herex';
 
     const resultString = '<mention-here>@here</mention-here>'
     + ' <em><mention-here>@here</mention-here></em>'
@@ -1294,7 +1295,8 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' <mention-here>@here</mention-here>('
     + ' <mention-here>@here</mention-here>.'
     + ' <mention-here>@here</mention-here>!'
-    + ' <mention-here>@here</mention-here>?';
+    + ' <mention-here>@here</mention-here>?'
+    + ' @herex';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1262,6 +1262,7 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' @here_123'
     + ' @here_abc'
     + ' @here123'
+    + ' @herea'
     + ' @hereabc'
     + ' @here abc'
     + ' @here*'
@@ -1273,8 +1274,7 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' @here('
     + ' @here.'
     + ' @here!'
-    + ' @here?'
-    + ' @herex';
+    + ' @here?';
 
     const resultString = '<mention-here>@here</mention-here>'
     + ' <em><mention-here>@here</mention-here></em>'
@@ -1284,6 +1284,7 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' @here_123'
     + ' @here_abc'
     + ' @here123'
+    + ' @herea'
     + ' @hereabc'
     + ' <mention-here>@here</mention-here> abc'
     + ' <mention-here>@here</mention-here>*'
@@ -1295,8 +1296,7 @@ test('Test for @here mention with italic, bold and strikethrough styles', () => 
     + ' <mention-here>@here</mention-here>('
     + ' <mention-here>@here</mention-here>.'
     + ' <mention-here>@here</mention-here>!'
-    + ' <mention-here>@here</mention-here>?'
-    + ' @herex';
+    + ' <mention-here>@here</mention-here>?';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -103,7 +103,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'hereMentions',
-                regex: /([a-zA-Z0-9.!$%&+/=?^`{|}_-]?)(@here)([a-zA-Z0-9.!$%&+/=?^`{|}_-]?)(?=\b)(?!(@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)|((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>))/gm,
+                regex: /([a-zA-Z0-9.!$%&+/=?^`{|}_-]?)(@here)([.!$%&+/=?^`{|}_-]?)(?=\b)(?!(@[a-zA-Z0-9-]+?(\.[a-zA-Z]+)+)|((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>))/gm,
                 replacement: (match, g1, g2, g3) => {
                     if (!Str.isValidMention(match)) {
                         return match;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
Disabled writing @here mentions together with letters and numbers at the end. Now only punctuation characters are acceptable 

### Fixed Issues
$ https://github.com/Expensify/App/issues/31180

# Tests
1. Open Expensify App
2. Open chat
3. Write "@herex" - it shouldn't be parsed into mention
4. Write "@here!" - it should be parsed into mention like: `@here`!

# QA
Same as tests
