### PR TITLE
Do not allow to parse link with multiline alias text when header markdown is leading- fix regression issues

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -27,6 +27,12 @@ test('Test heading markdown replacement', () => {
 
     testString = '# Heading should have only one new line after it.\n\n';
     expect(parser.replace(testString)).toBe('<h1>Heading should have only one new line after it.</h1><br />');
+
+    testString = '# hello test.com';
+    expect(parser.replace(testString)).toBe('<h1>hello <a href=\"https://test.com\" target=\"_blank\" rel=\"noreferrer noopener\">test.com</a></h1>');
+
+    testString = '# hello test@gmail.com';
+    expect(parser.replace(testString)).toBe('<h1>hello <a href=\"mailto:test@gmail.com\">test@gmail.com</a></h1>');
 });
 
 // Sections starting with > are successfully wrapped with <blockquote></blockquote>

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -139,7 +139,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `(?![^<]*>|[^<>]*<\\/)([_*~]*?)${MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`,
+                        `(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`,
                         'gi',
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);
@@ -183,7 +183,7 @@ export default class ExpensiMark {
             {
                 name: 'autoEmail',
                 regex: new RegExp(
-                    `([^\\w'#%+-]|^)${CONST.REG_EXP.MARKDOWN_EMAIL}(?!((?:(?!<a).)+)?<\\/a>|[^<>]*<\\/(?!em))`,
+                    `([^\\w'#%+-]|^)${CONST.REG_EXP.MARKDOWN_EMAIL}(?!((?:(?!<a).)+)?<\\/a>|[^<>]*<\\/(?!em|h1))`,
                     'gim',
                 ),
                 replacement: '$1<a href="mailto:$2">$2</a>',


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/26942
Proposal: https://github.com/Expensify/App/issues/26942#issuecomment-1744062072

### Tests
 Same as QA step
### Offline tests
 Same as QA step
### QA
1. Go to any chat
2. In composer, send message as following
```
    # [google1
    google2
    google3](https://www.google.com)
```
3. Verify that the first line ([google1) is parsed as header, and `https://www.google.com` will be parsed as autolink.

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://github.com/Expensify/App/assets/86615752/8e172eb9-689e-4880-bf9b-6bd1eb0807e5)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>


