### PR TITLE
Issue 26490 remove replacebr

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1467,16 +1467,48 @@ test('Test strikethrough with link with URL that contains tilde', () => {
 test('Linebreak between end of text and start of code block should be remained', () => {
     const testCases = [
         {
-            testString: '```\ncode\n```\ntext\n```\ncode\n```',
-            resultString: '<pre>code<br /></pre>text<br /><pre>code<br /></pre>',
+            testString: '```\ncode1\n```\ntext\n```\ncode2\n```',
+            resultString: '<pre>code1<br /></pre>text<br /><pre>code2<br /></pre>',
         },
         {
-            testString: 'A\n```\ncode\n```',
-            resultString: 'A<br /><pre>code<br /></pre>',
+            testString: 'text\n```\ncode\n```',
+            resultString: 'text<br /><pre>code<br /></pre>',
         },
         {
             testString: '|\n```\ncode\n```',
             resultString: '|<br /><pre>code<br /></pre>',
+        },
+        {
+            testString: 'text1```code```text2',
+            resultString: 'text1<pre>code</pre>text2',
+        },
+        {
+            testString: 'text1 ``` code ``` text2',
+            resultString: 'text1 <pre>&#32;code&#32;</pre> text2',
+        },
+        {
+            testString: 'text1\n```code```\ntext2',
+            resultString: 'text1<br /><pre>code</pre>text2',
+        },
+        {
+            testString: 'text1\n``` code ```\ntext2',
+            resultString: 'text1<br /><pre>&#32;code&#32;</pre>text2',
+        },
+        {
+            testString: 'text1\n```\n\ncode\n```\ntext2',
+            resultString: 'text1<br /><pre><br />code<br /></pre>text2',
+        },
+        {
+            testString: 'text1\n```\n\ncode\n\n```\ntext2',
+            resultString: 'text1<br /><pre><br />code<br /><br /></pre>text2',
+        },
+        {
+            testString: 'text1\n```\n\n\ncode\n\n```\ntext2',
+            resultString: 'text1<br /><pre><br /><br />code<br /><br /></pre>text2',
+        },
+        {
+            testString: 'text1\n```\n\ncode\n\n\n```\ntext2',
+            resultString: 'text1<br /><pre><br />code<br /><br /><br /></pre>text2',
         },
     ];
     testCases.forEach(({testString, resultString}) => {

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1412,3 +1412,14 @@ test('Test strikethrough with link with URL that contains tilde', () => {
     testString = '~[Example Link](https://example.com/?~example=~~~ex~)~';
     expect(parser.replace(testString)).toBe('<del><a href="https://example.com/?~example=~~~ex~" target="_blank" rel="noreferrer noopener">Example Link</a></del>');
 });
+
+test('Linebreak between end of text and start of code block should be remained', () => {
+    let testString = '```\ncode\n```\ntext\n```\ncode\n```';
+    expect(parser.replace(testString)).toBe('<pre>code<br /></pre>text<br /><pre>code<br /></pre>');
+
+    testString = 'A\n```\ncode\n```';
+    expect(parser.replace(testString)).toBe('A<br /><pre>code<br /></pre>');
+
+    testString = '|\n```\ncode\n```';
+    expect(parser.replace(testString)).toBe('|<br /><pre>code<br /></pre>');
+});

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1465,14 +1465,23 @@ test('Test strikethrough with link with URL that contains tilde', () => {
 });
 
 test('Linebreak between end of text and start of code block should be remained', () => {
-    let testString = '```\ncode\n```\ntext\n```\ncode\n```';
-    expect(parser.replace(testString)).toBe('<pre>code<br /></pre>text<br /><pre>code<br /></pre>');
-
-    testString = 'A\n```\ncode\n```';
-    expect(parser.replace(testString)).toBe('A<br /><pre>code<br /></pre>');
-
-    testString = '|\n```\ncode\n```';
-    expect(parser.replace(testString)).toBe('|<br /><pre>code<br /></pre>');
+    const testCases = [
+        {
+            testString: '```\ncode\n```\ntext\n```\ncode\n```',
+            resultString: '<pre>code<br /></pre>text<br /><pre>code<br /></pre>',
+        },
+        {
+            testString: 'A\n```\ncode\n```',
+            resultString: 'A<br /><pre>code<br /></pre>',
+        },
+        {
+            testString: '|\n```\ncode\n```',
+            resultString: '|<br /><pre>code<br /></pre>',
+        },
+    ];
+    testCases.forEach(({testString, resultString}) => {
+        expect(parser.replace(testString)).toBe(resultString);
+    });
 });
 
 test('Test autoEmail with markdown of <pre>, <code>, <a>, <mention-user> and <em> tag', () => {

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -32,7 +32,7 @@ test('Test heading markdown replacement', () => {
 // Sections starting with > are successfully wrapped with <blockquote></blockquote>
 test('Test quote markdown replacement', () => {
     const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not <pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+    const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a &gt;quote that did not<br /><pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />&gt;it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
 
     expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
 });
@@ -921,7 +921,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence at the same line', () => {
     const testString = 'The next line should be quoted\n>Hello,I’mtext\nThe next line should not be quoted\n```>Hello,I’mtext```\nsince its inside a codefence';
 
-    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted <pre>&gt;Hello,I’mtext</pre>since its inside a codefence';
+    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted<br /><pre>&gt;Hello,I’mtext</pre>since its inside a codefence';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -929,7 +929,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence at the end of the text', () => {
     const testString = 'The next line should be quoted\n>Hello,I’mtext\nThe next line should not be quoted\n```>Hello,I’mtext```';
 
-    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted <pre>&gt;Hello,I’mtext</pre>';
+    const resultString = 'The next line should be quoted<br /><blockquote>Hello,I’mtext</blockquote>The next line should not be quoted<br /><pre>&gt;Hello,I’mtext</pre>';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -937,7 +937,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement with text matching inside and outside codefence with quotes at the end of the text', () => {
     const testString = 'The next line should be quoted\n```>Hello,I’mtext```\nThe next line should not be quoted\n>Hello,I’mtext';
 
-    const resultString = 'The next line should be quoted <pre>&gt;Hello,I’mtext</pre>The next line should not be quoted<br /><blockquote>Hello,I’mtext</blockquote>';
+    const resultString = 'The next line should be quoted<br /><pre>&gt;Hello,I’mtext</pre>The next line should not be quoted<br /><blockquote>Hello,I’mtext</blockquote>';
 
     expect(parser.replace(testString)).toBe(resultString);
 });
@@ -945,7 +945,7 @@ test('Test quotes markdown replacement with text matching inside and outside cod
 test('Test quotes markdown replacement and removing <br/> from <br/><pre> and </pre><br/>', () => {
     const testString = 'The next line should be quoted\n```>Hello,I’mtext```\nThe next line should not be quoted';
 
-    const resultString = 'The next line should be quoted <pre>&gt;Hello,I’mtext</pre>The next line should not be quoted';
+    const resultString = 'The next line should be quoted<br /><pre>&gt;Hello,I’mtext</pre>The next line should not be quoted';
 
     expect(parser.replace(testString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -692,14 +692,23 @@ test('Test codeFence copy from selection does not add extra new line', () => {
 });
 
 test('Linebreak should be remained for text between code block', () => {
-    let testString = '<pre>code<br></pre>text<br><pre>code<br></pre>';
-    expect(parser.htmlToMarkdown(testString)).toBe('```\ncode\n```\ntext\n```\ncode\n```');
-
-    testString = 'A<br><pre>code<br></pre>';
-    expect(parser.htmlToMarkdown(testString)).toBe('A\n```\ncode\n```');
-
-    testString = '|<br><pre>code<br></pre>';
-    expect(parser.htmlToMarkdown(testString)).toBe('|\n```\ncode\n```');
+    const testCases = [
+        {
+            testString: '<pre>code<br></pre>text<br><pre>code<br></pre>',
+            resultString: '```\ncode\n```\ntext\n```\ncode\n```',
+        },
+        {
+            testString: 'A<br><pre>code<br></pre>',
+            resultString: 'A\n```\ncode\n```',
+        },
+        {
+            testString: '|<br><pre>code<br></pre>',
+            resultString: '|\n```\ncode\n```',
+        },
+    ];
+    testCases.forEach(({testString, resultString}) => {
+        expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+    });
 });
 
 test('Mention html to markdown', () => {

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -694,16 +694,48 @@ test('Test codeFence copy from selection does not add extra new line', () => {
 test('Linebreak should be remained for text between code block', () => {
     const testCases = [
         {
-            testString: '<pre>code<br></pre>text<br><pre>code<br></pre>',
-            resultString: '```\ncode\n```\ntext\n```\ncode\n```',
+            testString: '<pre>code1<br></pre>text<br><pre>code2<br></pre>',
+            resultString: '```\ncode1\n```\ntext\n```\ncode2\n```',
         },
         {
-            testString: 'A<br><pre>code<br></pre>',
-            resultString: 'A\n```\ncode\n```',
+            testString: 'text<br><pre>code<br></pre>',
+            resultString: 'text\n```\ncode\n```',
         },
         {
             testString: '|<br><pre>code<br></pre>',
             resultString: '|\n```\ncode\n```',
+        },
+        {
+            testString: 'text1<pre>code</pre>text2',
+            resultString: 'text1```\ncode\n```\ntext2',
+        },
+        {
+            testString: 'text1 <pre>&#32;code&#32;</pre> text2',
+            resultString: 'text1 ```\n code \n```\n text2',
+        },
+        {
+            testString: 'text1<br><pre>code</pre>text2',
+            resultString: 'text1\n```\ncode\n```\ntext2',
+        },
+        {
+            testString: 'text1<br><pre>&#32;code&#32;</pre>text2',
+            resultString: 'text1\n```\n code \n```\ntext2',
+        },
+        {
+            testString: 'text1<br><pre><br>code<br></pre>text2',
+            resultString: 'text1\n```\n\ncode\n```\ntext2',
+        },
+        {
+            testString: 'text1<br><pre><br>code<br><br></pre>text2',
+            resultString: 'text1\n```\n\ncode\n\n```\ntext2',
+        },
+        {
+            testString: 'text1<br><pre><br><br>code<br><br></pre>text2',
+            resultString: 'text1\n```\n\n\ncode\n\n```\ntext2',
+        },
+        {
+            testString: 'text1<br><pre><br>code<br><br><br></pre>text2',
+            resultString: 'text1\n```\n\ncode\n\n\n```\ntext2',
         },
     ];
     testCases.forEach(({testString, resultString}) => {

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -690,3 +690,14 @@ test('Test codeFence copy from selection does not add extra new line', () => {
     testString = '<h3>test heading</h3><div><pre class=\"notranslate\"><code class=\"notranslate\">Code snippet\n</code></pre></div><blockquote><p><a href=\"https://www.example.com\">link</a></p></blockquote>';
     expect(parser.htmlToMarkdown(testString)).toBe('test heading\n```\nCode snippet\n```\n> [link](https://www.example.com)')
 });
+
+test('Linebreak should be remained for text between code block', () => {
+    let testString = '<pre>code<br></pre>text<br><pre>code<br></pre>';
+    expect(parser.htmlToMarkdown(testString)).toBe('```\ncode\n```\ntext\n```\ncode\n```');
+
+    testString = 'A<br><pre>code<br></pre>';
+    expect(parser.htmlToMarkdown(testString)).toBe('A\n```\ncode\n```');
+
+    testString = '|<br><pre>code<br></pre>';
+    expect(parser.htmlToMarkdown(testString)).toBe('|\n```\ncode\n```');
+});

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -1,5 +1,5 @@
 declare type Replacement = (...args: string[]) => string;
-declare type Name = "codeFence" | "inlineCodeBlock" | "email" | "link" | "hereMentions" | "userMentions" | "autoEmail" | "autolink" | "quote" | "italic" | "bold" | "strikethrough" | "heading1" | "newline" | "replacepre" | "replacebr" | "listItem" | "exclude" | "anchor" | "breakline" | "blockquoteWrapHeadingOpen" | "blockquoteWrapHeadingClose" | "blockElementOpen" | "blockElementClose" | "stripTag";
+declare type Name = "codeFence" | "inlineCodeBlock" | "email" | "link" | "hereMentions" | "userMentions" | "autoEmail" | "autolink" | "quote" | "italic" | "bold" | "strikethrough" | "heading1" | "newline" | "replacepre" | "listItem" | "exclude" | "anchor" | "breakline" | "blockquoteWrapHeadingOpen" | "blockquoteWrapHeadingClose" | "blockElementOpen" | "blockElementClose" | "stripTag";
 declare type Rule = {
     name: Name;
     process?: (textToProcess: string, replacement: Replacement) => string;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -230,12 +230,6 @@ export default class ExpensiMark {
                 replacement: '</pre>',
             },
             {
-                // We're removing <br /> because when <br /> and <pre> occur together, an extra line is added.
-                name: 'replacebr',
-                regex: /<br\s*[/]?><pre>\s*/gi,
-                replacement: ' <pre>',
-            },
-            {
                 // We're removing <br /> because when <h1> and <br /> occur together, an extra line is added.
                 name: 'replaceh1br',
                 regex: /<\/h1><br\s*[/]?>/gi,


### PR DESCRIPTION
This PR:
- removes the `replacebr` rule option inside `ExpensiMark.rules`

### Fixed Issues
$ https://github.com/Expensify/App/issues/26490
$ https://github.com/Expensify/App/issues/16982

# Tests
Unit testing
1. Updated existing tests which are affected by this change to pass
2. Added new unit testing

Testing in the `expensify-app`
1. On your local dev environment of `expensify-app`, open `node_modules/expensify-common/lib/ExpensiMark.js` file
2. Remove `replacebr` rule
3. Run the app and test with the following recordings

Test Strings
````
```
code1
```
text
```
code2
```
````
````
|
```
code
```
````
````
```
code

```
````
````
message1```code```message2
````
````
message1 ``` code ``` message2
````
````
message1
```code```
message2
````
````
message1
``` code ```
message2
````
````
message1
```

code
```
message2
````
````
message1
```

code

```
message2
````
````
message1
```


code

```
message2
````
````
message1
```

code


```
message2
````


https://github.com/Expensify/expensify-common/assets/30532000/05da9434-565c-41d5-8ddf-a5f5cd9f9727

https://github.com/Expensify/expensify-common/assets/30532000/4fd9da4a-8995-4c49-9282-f6c131a3ad91

https://github.com/Expensify/expensify-common/assets/30532000/671a105d-2af7-4f8d-9f1f-40218b50cd5b

https://github.com/Expensify/expensify-common/assets/30532000/941a2d8c-40ce-42c6-82bb-203c0f15c846

https://github.com/Expensify/expensify-common/assets/30532000/d9b475ee-0f8e-4c3a-abd7-454108805e3e

# QA
Same as test
