### PR TITLE
Fix/28946 Mentioning an email with double @ sign results in an invalid email mention

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1117,6 +1117,12 @@ test('Test for user mention with @username@domain.com', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test for user mention with @@username@domain.com', () => {
+    const testString = '@@username@expensify.com';
+    const resultString = '@<mention-user>@username@expensify.com</mention-user>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 test('Test for user mention with @phoneNumber@domain.sms', () => {
     const testString = '@+19728974297@expensify.sms';
     const resultString = '<mention-user>@+19728974297@expensify.sms</mention-user>';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -128,7 +128,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@+${CONST.REG_EXP.EMAIL_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
+                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
                 replacement: (match, g1, g2) => {
                     if (!Str.isValidMention(match)) {
                         return match;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
Removed the `+` quantifier from the `userMentions` regex because this resulted in all the @ signs being matched when a mention had multiple preceding @ signs. 

For example, the match looked like this `@@user@expensify.com`, and clicking it showed a user with `@user@expensify.com` as their email in the RHP. Trying to message this user then resulted in an error because their email address was invalid.

With this change, the match now looks like this: @`@user@expensify.com`, which, upon clicking/tapping, shows the valid email `user@expensify.com` in the RHP, so the user can now be messaged without errors. 

**Please Note:** I've altered the linking below slightly in accordance to this [comment](https://github.com/Expensify/expensify-common/pull/607#issuecomment-1821707573) because doing it this way assigns the correct people to review. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/28946
$ https://github.com/Expensify/App/issues/28946#issuecomment-1750185844

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?

The 'Test for user mention with @@username@domain.com' test in `ExpensiMark-HTML-test.js`.

```javascript
test('Test for user mention with @@username@domain.com', () => {
    const testString = '@@username@expensify.com';
    const resultString = '@<mention-user>@username@expensify.com</mention-user>';
    expect(parser.replace(testString)).toBe(resultString);
});
```

2. What tests did you perform that validates your changed worked?

Running `npm run test` resulted in all tests passing. 

In addition, typing '@@user@expensify.com' and then sending resulted in the correct match: @`@user@expensify.com`.

# QA
1. What does QA need to do to validate your changes?

- Log into an account and open a report 
- Type '@' in the composer followed by the valid email of someone you've chatted with before. You can also optionally select one from the mentions suggestions list.
- Place the cursor at the beginning of the composer, type another '@' sign, and then send the message. 
- Verify that only the first '@' sign before the email and the email is highlighted e.g. @`@user@expensify.com`.

1. What areas to they need to test for regressions?

You can repeat the steps above in a workspace chat, group chat, thread chat, and task thread chat (minus the logging into an account step). 
