### PR TITLE
Do not apply Italic marckdown for multiline-quote message

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -74,6 +74,23 @@ test('Test italic markdown replacement with word boundary and undercores', () =>
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
+test('Test quote markdown combined multi-line italic/bold/strikethrough markdown replacement', () => {
+    let testString = '_test\n> test_';
+    let replacedString = '_test<br /><blockquote>test_</blockquote>';
+
+    expect(parser.replace(testString)).toBe(replacedString);
+
+    testString = '*test\n> test*';
+    replacedString = '*test<br /><blockquote>test*</blockquote>';
+
+    expect(parser.replace(testString)).toBe(replacedString);
+
+    testString = '~test\n> test~';
+    replacedString = '~test<br /><blockquote>test~</blockquote>';
+
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 // Words wrapped in ~ successfully replaced with <del></del>
 test('Test strikethrough markdown replacement', () => {
     const strikethroughTestStartString = 'This is a ~sentence,~ and it has some ~punctuation, words, and spaces~. ~test~ ~ testing~ test~test~test. ~ testing ~ ~testing ~';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -163,7 +163,7 @@ export default class ExpensiMark {
                     return `${g1}<a href="${href}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
                 },
             },
-            
+
             {
                 name: 'quote',
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -163,6 +163,34 @@ export default class ExpensiMark {
                     return `${g1}<a href="${href}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
                 },
             },
+            
+            {
+                name: 'quote',
+
+                // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
+                // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
+                // inline code blocks. A single prepending space should be stripped if it exists
+                process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
+                    const regex = new RegExp(
+                        /^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm,
+                    );
+                    if (shouldKeepWhitespace) {
+                        return textToProcess.replace(regex, g1 => replacement(g1, shouldKeepWhitespace));
+                    }
+                    return this.modifyTextForQuote(regex, textToProcess, replacement);
+                },
+                replacement: (g1, shouldKeepWhitespace = false) => {
+                    // We want to enable 2 options of nested heading inside the blockquote: "># heading" and "> # heading".
+                    // To do this we need to parse body of the quote without first space
+                    let isStartingWithSpace = false;
+                    const textToReplace = g1.replace(/^&gt;( )?/gm, (match, g2) => {
+                        isStartingWithSpace = !!g2;
+                        return '';
+                    });
+                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false, shouldKeepWhitespace});
+                    return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
+                },
+            },
             {
                 /**
                  * Use \b in this case because it will match on words, letters,
@@ -196,39 +224,12 @@ export default class ExpensiMark {
             {
                 name: 'autoEmail',
                 regex: new RegExp(
-                    `([^\\w'#%+-]|^)${CONST.REG_EXP.MARKDOWN_EMAIL}(?!((?:(?!<a).)+)?<\\/a>|[^<>]*<\\/(?!em|h1))`,
+                    `([^\\w'#%+-]|^)${CONST.REG_EXP.MARKDOWN_EMAIL}(?!((?:(?!<a).)+)?<\\/a>|[^<>]*<\\/(?!em|h1|blockquote))`,
                     'gim',
                 ),
                 replacement: '$1<a href="mailto:$2">$2</a>',
             },
 
-            {
-                name: 'quote',
-
-                // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
-                // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
-                // inline code blocks. A single prepending space should be stripped if it exists
-                process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
-                    const regex = new RegExp(
-                        /^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm,
-                    );
-                    if (shouldKeepWhitespace) {
-                        return textToProcess.replace(regex, g1 => replacement(g1, shouldKeepWhitespace));
-                    }
-                    return this.modifyTextForQuote(regex, textToProcess, replacement);
-                },
-                replacement: (g1, shouldKeepWhitespace = false) => {
-                    // We want to enable 2 options of nested heading inside the blockquote: "># heading" and "> # heading".
-                    // To do this we need to parse body of the quote without first space
-                    let isStartingWithSpace = false;
-                    const textToReplace = g1.replace(/^&gt;( )?/gm, (match, g2) => {
-                        isStartingWithSpace = !!g2;
-                        return '';
-                    });
-                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false, shouldKeepWhitespace});
-                    return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
-                },
-            },
             {
                 // Use \B in this case because \b doesn't match * or ~.
                 // \B will match everything that \b doesn't, so it works


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/26941
Proposal: https://github.com/Expensify/App/issues/26941#issuecomment-1850051964

### Tests
1. Go to any chat.
2. Type the following test strings and observe that it's parsed as expected
```
_test
> test_

*test
> test*

~test
> test~
```
### QA
Same as tests step

### Offline tests
Same as tests step

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://github.com/Expensify/App/assets/86615752/edff1a20-a346-45b0-85e8-a85a6e13e2f3)


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

