### PR TITLE
fix-#30823: Keep consistency to parse bold/italic/strikethrough markdown

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1734,4 +1734,16 @@ test('Test italic/bold/strikethrough markdown to keep consistency', () => {
     testString = '~This~is~strikethrough~test~';
     resultString = '<del>This~is~strikethrough~test</del>';
     expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '_This_is_italic_test____';
+    resultString = '<em>This_is_italic_test</em>___';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '*This*is*bold*test****';
+    resultString = '<strong>This*is*bold*test</strong>***';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '~This~is~strikethrough~test~~~~';
+    resultString = '<del>This~is~strikethrough~test</del>~~~';
+    expect(parser.replace(testString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1721,3 +1721,17 @@ test('Test code fence within inline code', () => {
     testString = 'Hello world ```block```space`test` Hello world';
     expect(parser.replace(testString)).toBe('Hello world <pre>block</pre>space<code>test</code> Hello world');
 });
+
+test('Test italic/bold/strikethrough markdown to keep consistency', () => {
+    let testString = '_This_is_italic_test_';
+    let resultString = '<em>This_is_italic_test</em>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '*This*is*bold*test*';
+    resultString = '<strong>This*is*bold*test</strong>';
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '~This~is~strikethrough~test~';
+    resultString = '<del>This~is~strikethrough~test</del>';
+    expect(parser.replace(testString)).toBe(resultString);
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -234,7 +234,7 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*((?=\S)(([^\s*]|\s(?!\*))+?))\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B\*((?![\s*])[\s\S]*?[^\s*])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: (match, g1) => (g1.includes('<pre>') || this.containsNonPairTag(g1) ? match : `<strong>${g1}</strong>`),
             },
             {


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/30823
Proposal: https://github.com/Expensify/App/issues/30823#issuecomment-1792055791

### Tests
1. Go to any chat.
2. Type the following test strings and observe that it's parsed as expected
```
_test_test_test_
*test*test*test*
~test~test~test~
```
### QA
Same as tests step

### Offline tests
Same as tests step

### Screenshots/Videos
<details>
<summary>Web</summary>

![image](https://github.com/Expensify/App/assets/86615752/c6107bc0-e97c-44e9-b449-7b7c356eb3db)
<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->

</details>

