### PR TITLE
Data html attributes

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1632,40 +1632,40 @@ test('Mention', () => {
     expect(parser.replace(testString)).toBe('<mention-user>@user@DOMAIN.com</mention-user>');
 });
 
-describe('when should keep whitespace flag is enabled', () => {
+describe('when should keep raw input flag is enabled', () => {
     test('quote without space', () => {
         const quoteTestStartString = '>Hello world';
         const quoteTestReplacedString = '<blockquote>Hello world</blockquote>';
 
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
     });
 
     test('quote with single space', () => {
         const quoteTestStartString = '> Hello world';
         const quoteTestReplacedString = '<blockquote> Hello world</blockquote>';
 
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
     });
 
     test('quote with multiple spaces', () => {
         const quoteTestStartString = '>     Hello world';
         const quoteTestReplacedString = '<blockquote>     Hello world</blockquote>';
 
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
     });
 
     test('multiple quotes', () => {
         const quoteTestStartString = '>Hello my\n>beautiful\n>world\n';
         const quoteTestReplacedString = '<blockquote>Hello my</blockquote>\n<blockquote>beautiful</blockquote>\n<blockquote>world</blockquote>\n';
 
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
     });
 
     test('separate blockqoutes', () => {
         const quoteTestStartString = '>Lorem ipsum\ndolor\n>sit amet';
         const quoteTestReplacedString = '<blockquote>Lorem ipsum</blockquote>\ndolor\n<blockquote>sit amet</blockquote>';
 
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
     });
 
     describe('nested heading in blockquote', () => {
@@ -1673,21 +1673,21 @@ describe('when should keep whitespace flag is enabled', () => {
             const quoteTestStartString = '># Hello world';
             const quoteTestReplacedString = '<blockquote><h1>Hello world</h1></blockquote>';
 
-            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+            expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
         });
 
         test('with single space', () => {
             const quoteTestStartString = '> # Hello world';
             const quoteTestReplacedString = '<blockquote> <h1>Hello world</h1></blockquote>';
 
-            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+            expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
         });
 
         test('with multiple spaces after #', () => {
             const quoteTestStartString = '>#    Hello world';
             const quoteTestReplacedString = '<blockquote><h1>   Hello world</h1></blockquote>';
 
-            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+            expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
         });
     });
 
@@ -1696,29 +1696,70 @@ describe('when should keep whitespace flag is enabled', () => {
             const quoteTestStartString = '>Hello world!';
             const quoteTestReplacedString = '<blockquote>Hello world!</blockquote>';
 
-            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+            expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
         });
 
         test('space', () => {
             const quoteTestStartString = '>Hello world ';
             const quoteTestReplacedString = '<blockquote>Hello world </blockquote>';
 
-            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+            expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
         });
 
         test('newline', () => {
             const quoteTestStartString = '>Hello world\n';
             const quoteTestReplacedString = '<blockquote>Hello world</blockquote>\n';
 
-            expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+            expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
         });
     });
 
     test('quote with other markdowns', () => {
         const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>\nHere is a &gt;quote that did not\n<pre>here&#32;is&#32;a&#32;codefenced&#32;quote\n&gt;it&#32;should&#32;not&#32;be&#32;quoted\n</pre>';
+        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>\nHere is a &gt;quote that did not\n<pre data-code-raw=\"\nhere is a codefenced quote\n&amp;gt;it should not be quoted\n\">here&#32;is&#32;a&#32;codefenced&#32;quote\n&gt;it&#32;should&#32;not&#32;be&#32;quoted\n</pre>';
 
-        expect(parser.replace(quoteTestStartString, {shouldKeepWhitespace: true})).toBe(quoteTestReplacedString);
+        expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
+    });
+
+    test('codeBlock with newlines', () => {
+        const quoteTestStartString = '```\nhello world\n```';
+        const quoteTestReplacedString = '<pre data-code-raw="\nhello world\n">hello&#32;world\n</pre>';
+
+        expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
+    });
+
+    describe('links with raw data attributes', () => {
+        test('autoLink', () => {
+            const testString = 'google.com';
+            const resultString = '<a href="https://google.com" data-raw-href="google.com" data-link-variant="auto" target="_blank" rel="noreferrer noopener">google.com</a>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+
+        test('labeled link', () => {
+            const testString = '[Google](google.com)';
+            const resultString = '<a href="https://google.com" data-raw-href="google.com" data-link-variant="labeled" target="_blank" rel="noreferrer noopener">Google</a>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+    });
+
+    describe('mails with raw data attributes', () => {
+        test('autoMail', () => {
+            const testString = 'mail@mail.com';
+            const resultString = '<a href="mailto:mail@mail.com" data-raw-href="mail@mail.com" data-link-variant="auto">mail@mail.com</a>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+
+        test('labeled mail', () => {
+            const testString = '[mail](mailto:mail@mail.com)';
+            const resultString = '<a href="mailto:mail@mail.com" data-raw-href="mailto:mail@mail.com" data-link-variant="labeled">mail</a>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+
+        test('labeled mail with styled label', () => {
+            const testString = '[*mail*](mailto:mail@mail.com)';
+            const resultString = '<a href="mailto:mail@mail.com" data-raw-href="mailto:mail@mail.com" data-link-variant="labeled"><strong>mail</strong></a>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
     });
 });
     

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -23,7 +23,7 @@ export default class ExpensiMark {
      * @param options.shouldEscapeText=true - Whether or not the text should be escaped
      * @param options.shouldKeepRawInput=false - Whether or not the raw input should be kept and returned
      */
-    replace(text: string, { filterRules, shouldEscapeText }?: {
+    replace(text: string, { filterRules, shouldEscapeText, shouldKeepRawInput }?: {
         filterRules?: string[];
         shouldEscapeText?: boolean;
         shouldKeepRawInput?: boolean;

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -21,10 +21,12 @@ export default class ExpensiMark {
      * @param options.filterRules=[] - An array of name of rules as defined in this class.
      * If not provided, all available rules will be applied.
      * @param options.shouldEscapeText=true - Whether or not the text should be escaped
+     * @param options.shouldKeepRawInput=false - Whether or not the raw input should be kept and returned
      */
     replace(text: string, { filterRules, shouldEscapeText }?: {
         filterRules?: string[];
         shouldEscapeText?: boolean;
+        shouldKeepRawInput?: boolean;
     }): string;
     /**
      * Checks matched URLs for validity and replace valid links with html elements

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -36,6 +36,11 @@ export default class ExpensiMark {
                     const group = textWithinFences.replace(/(?:(?![\n\r])\s)/g, '&#32;');
                     return `<pre>${group}</pre>`;
                 },
+                rawInputReplacement: (match, __, textWithinFences) => {
+                    const withinFences = match.replace(/(?:&#x60;&#x60;&#x60;)([\s\S]*?)(?:&#x60;&#x60;&#x60;)/g, '$1');
+                    const group = textWithinFences.replace(/(?:(?![\n\r])\s)/g, '&#32;');
+                    return `<pre data-code-raw="${_.escape(withinFences)}">${group}</pre>`;
+                }
             },
 
             /**
@@ -59,11 +64,11 @@ export default class ExpensiMark {
              */
             {
                 name: 'email',
-                process: (textToProcess, replacement) => {
+                process: (textToProcess, replacement, shouldKeepRawInput) => {
                     const regex = new RegExp(
                         `(?!\\[\\s*\\])\\[([^[\\]]*)]\\((mailto:)?${CONST.REG_EXP.MARKDOWN_EMAIL}\\)`, 'gim'
                     );
-                    return this.modifyTextForEmailLinks(regex, textToProcess, replacement);
+                    return this.modifyTextForEmailLinks(regex, textToProcess, replacement, shouldKeepRawInput);
                 },
                 replacement: (match, g1, g2) => {
                     if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
@@ -74,12 +79,21 @@ export default class ExpensiMark {
                     const formattedLabel = label === href ? g2 : label;
                     return `<a href="${href}">${formattedLabel}</a>`;
                 },
+                rawInputReplacement: (match, g1, g2, g3) => {
+                    if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
+                        return match;
+                    }
+
+                    const dataRawHref = g2 ? g2 + g3 : g3;
+                    const href = `mailto:${g3}`;
+                    return `<a href="${href}" data-raw-href="${dataRawHref}" data-link-variant="labeled">${g1}</a>`;
+                }
             },
 
             {
                 name: 'heading1',
-                process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
-                    const regexp = shouldKeepWhitespace ? /^# ( *(?! )(?:(?!<pre>|\n|\r\n).)+)/gm : /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm;
+                process: (textToProcess, replacement, shouldKeepRawInput = false) => {
+                    const regexp = shouldKeepRawInput ? /^# ( *(?! )(?:(?!<pre>|\n|\r\n).)+)/gm : /^# +(?! )((?:(?!<pre>|\n|\r\n).)+)/gm;
                     return textToProcess.replace(regexp, replacement);
                 },
                 replacement: '<h1>$1</h1>',
@@ -100,6 +114,12 @@ export default class ExpensiMark {
                     }
                     return `<a href="${Str.sanitizeURL(g2)}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
                 },
+                rawInputReplacement: (match, g1, g2) => {
+                    if (g1.match(CONST.REG_EXP.EMOJIS) || !g1.trim()) {
+                        return match;
+                    }
+                    return `<a href="${Str.sanitizeURL(g2)}" data-raw-href="${g2}" data-link-variant="labeled" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
+                }
             },
 
             /**
@@ -162,6 +182,10 @@ export default class ExpensiMark {
                     const href = Str.sanitizeURL(g2);
                     return `${g1}<a href="${href}" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
                 },
+                rawInputReplacement: (_match, g1, g2) => {
+                    const href = Str.sanitizeURL(g2);
+                    return `${g1}<a href="${href}" data-raw-href="${g2}" data-link-variant="auto" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
+                }
             },
 
             {
@@ -170,16 +194,16 @@ export default class ExpensiMark {
                 // We also want to capture a blank line before or after the quote so that we do not add extra spaces.
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
-                process: (textToProcess, replacement, shouldKeepWhitespace = false) => {
+                process: (textToProcess, replacement, shouldKeepRawInput = false) => {
                     const regex = new RegExp(
                         /^&gt; *(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm,
                     );
-                    if (shouldKeepWhitespace) {
-                        return textToProcess.replace(regex, g1 => replacement(g1, shouldKeepWhitespace));
+                    if (shouldKeepRawInput) {
+                        return textToProcess.replace(regex, g1 => replacement(g1, shouldKeepRawInput));
                     }
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },
-                replacement: (g1, shouldKeepWhitespace = false) => {
+                replacement: (g1, shouldKeepRawInput = false) => {
                     // We want to enable 2 options of nested heading inside the blockquote: "># heading" and "> # heading".
                     // To do this we need to parse body of the quote without first space
                     let isStartingWithSpace = false;
@@ -187,7 +211,7 @@ export default class ExpensiMark {
                         isStartingWithSpace = !!g2;
                         return '';
                     });
-                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false, shouldKeepWhitespace});
+                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false, shouldKeepRawInput});
                     return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
             },
@@ -228,6 +252,7 @@ export default class ExpensiMark {
                     'gim',
                 ),
                 replacement: '$1<a href="mailto:$2">$2</a>',
+                rawInputReplacement: '$1<a href="mailto:$2" data-raw-href="$2" data-link-variant="auto">$2</a>',
             },
 
             {
@@ -437,10 +462,10 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepWhitespace = false} = {}) {
+    replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false} = {}) {
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? _.escape(text) : text;
-        const excludeRules = shouldKeepWhitespace ? _.union(this.shouldKeepWhitespaceRules, filterRules) : filterRules;
+        const excludeRules = shouldKeepRawInput ? _.union(this.shouldKeepWhitespaceRules, filterRules) : filterRules;
         const rules = _.isEmpty(excludeRules) ? this.rules : _.filter(this.rules, rule => _.contains(excludeRules, rule.name));
 
         try {
@@ -449,11 +474,11 @@ export default class ExpensiMark {
                 if (rule.pre) {
                     replacedText = rule.pre(replacedText);
                 }
-
+                const replacementFunction = shouldKeepRawInput && rule.rawInputReplacement ? rule.rawInputReplacement : rule.replacement;
                 if (rule.process) {
-                    replacedText = rule.process(replacedText, rule.replacement, shouldKeepWhitespace);
+                    replacedText = rule.process(replacedText, replacementFunction, shouldKeepRawInput);
                 } else {
-                    replacedText = replacedText.replace(rule.regex, rule.replacement);
+                    replacedText = replacedText.replace(rule.regex, replacementFunction);
                 }
 
                 // Post-process text after applying regex
@@ -585,10 +610,11 @@ export default class ExpensiMark {
      * @param {RegExp} regex
      * @param {String} textToCheck
      * @param {Function} replacement
+     * @param {Boolean} shouldKeepRawInput
      *
      * @returns {String}
      */
-    modifyTextForEmailLinks(regex, textToCheck, replacement) {
+    modifyTextForEmailLinks(regex, textToCheck, replacement, shouldKeepRawInput) {
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;
@@ -602,7 +628,10 @@ export default class ExpensiMark {
                 filterRules: ['bold', 'strikethrough', 'italic'],
                 shouldEscapeText: false,
             });
-            replacedText = replacedText.concat(replacement(match[0], linkText, match[3]));
+
+            // rawInputReplacment needs to be called with additional parameters from match
+            const replacedMatch = shouldKeepRawInput ? replacement(match[0], linkText, match[2], match[3]) : replacement(match[0], linkText, match[3]);
+            replacedText = replacedText.concat(replacedMatch);
             startIndex = match.index + (match[0].length);
 
             // Now we move to the next match that the js regex found in the text


### PR DESCRIPTION
This PR extends usage of the `shouldKeepWhitespace` flag which was created for Live Markdown Preview. 
- changes the name of the flag to `shouldKeepRawInput` to indicate extended usability of the flag
- based on this flag new replacement method can be called if implemented for every rule.
- new replacement method should return similar HTML structure as normal replacement but enrich the tag with unmodified values of input which is necessary for Live Markdown Preview
- unmodified values are exposed by `rawInputReplacement` functions as new HTML attributes:
   - `data-code-raw` - contains escaped version of code block, new lines/whitespaces included
   - `data-raw-href` - contains unmodified version of the link/email
   - `data-link-variant` - contains information whether the link was typed as labeled link or as auto link
   - link labels are passed unmodified


https://github.com/Expensify/expensify-common/assets/61146594/77efc88b-423f-43f9-b781-f5516dc71ef6



### Fixed Issues
$ https://github.com/Expensify/App/issues/33026
$ https://github.com/Expensify/App/issues/31181

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
New unit tests were implemented in order to test the changes. To test it by yourself you will need [example app](https://github.com/tomekzaw/react-native-markdown-text-input/tree/remove-newline-char-codeblock).

1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
  Same as tests
1. What areas to they need to test for regressions?
  This PR shouldn't introduce any changes within parsing the messages while sending.  We can ensure it by checking how links/mails are parsed while being send within the expensify app
