### PR TITLE
Prevent parsing backticks if are only content of inline code block

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -410,6 +410,16 @@ test('Test inline code blocks', () => {
     expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is <code>JavaScript</code>. How about you?');
 });
 
+test('Test inline code with one backtick as content', () => {
+    const inlineCodeStartString = '```';
+    expect(parser.replace(inlineCodeStartString)).toBe('&#x60;&#x60;&#x60;');
+});
+
+test('Test inline code with multiple backtick symbols as content', () => {
+    const inlineCodeStartString = '``````';
+    expect(parser.replace(inlineCodeStartString)).toBe('&#x60;&#x60;&#x60;&#x60;&#x60;&#x60;');
+});
+
 test('Test inline code blocks with ExpensiMark syntax inside', () => {
     const inlineCodeStartString = '`This is how you can write ~strikethrough~, *bold*, and _italics_`';
     expect(parser.replace(inlineCodeStartString)).toBe('<code>This is how you can write ~strikethrough~, *bold*, and _italics_</code>');
@@ -1067,7 +1077,7 @@ test('Test for backticks with no content', () => {
 // Code-fence with no content is not replaced with <pre>
 test('Test for codefence with no content', () => {
     const testString = '```   ```';
-    const resultString = '<code>&#x60;</code>   <code>&#x60;</code>';
+    const resultString = '&#x60;&#x60;&#x60;   &#x60;&#x60;&#x60;';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -49,7 +49,15 @@ export default class ExpensiMark {
                 // so capture the first and third group and place them in the replacement.
                 // but we should not replace backtick symbols if they include <pre> tags between them.
                 regex: /(\B|_|)&#x60;(?:(?!(?:(?!&#x60;).)*?<pre>))(.*?\S.*?)&#x60;(\B|_|)(?!&#x60;|[^<]*<\/pre>)/g,
-                replacement: '$1<code>$2</code>$3',
+                replacement: (match, g1, g2, g3) => {
+                    const regex = /^[&#x60;]+$/i;
+
+                    // if content of the inline code block is only backtick symbols, we should not replace them with <code> tag
+                    if (regex.test(g2)) {
+                        return match;
+                    }
+                    return `${g1}<code>${g2}</code>${g3}`;
+                }
             },
 
             /**


### PR DESCRIPTION
This PR modifies the replacement function for inline code blocks. Now, the function checks if the content consists only of backtick symbols. If yes, the unmodified match string is returned; otherwise, the behavior should remain unchanged.

I opted to implement this check within the replacement function rather than inside the already established regex. This decision was made because incorporating this check inside the regex was challenging without introducing regressions (especially with the ` ``` ``` ` string). Moreover, splitting it should be beneficial for code readability.

### Fixed Issues
$ https://github.com/Expensify/App/issues/31493

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
two unit test are added to the test suite to cover prime examples of this issue: ` ``` ` and ` `````` ` which should ensure that no matter how long is the sequence of backticks, as long as they are only symbols inside the content it will not parse
1. What tests did you perform that validates your changed worked?
Run all unit tests and cross-check inside newDot

# QA
1. What does QA need to do to validate your changes?
Testing is quite straight forward. Inside newDot chat any sequence of backticks (wihtout any other char) shouldn't be parsed (fe. ` ``````` ` or ` ``````````` `)
1. What areas to they need to test for regressions?
Since this PR only modifies the ExpensiMark part responsible for parsing inline code blocks, any regressions might occur while users are typing such markdown. To ensure that no regressions are introduced, besides unit tests, existing regression tests involving inline code blocks can be rerun.
