### PR TITLE
Stop escaping codeFence data-code-raw attribute data

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1726,7 +1726,7 @@ describe('when should keep raw input flag is enabled', () => {
 
     test('quote with other markdowns', () => {
         const quoteTestStartString = '>This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
-        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>\nHere is a &gt;quote that did not\n<pre data-code-raw=\"\nhere is a codefenced quote\n&amp;gt;it should not be quoted\n\">here&#32;is&#32;a&#32;codefenced&#32;quote\n&gt;it&#32;should&#32;not&#32;be&#32;quoted\n</pre>';
+        const quoteTestReplacedString = '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>\nHere is a &gt;quote that did not\n<pre data-code-raw=\"\nhere is a codefenced quote\n&gt;it should not be quoted\n\">here&#32;is&#32;a&#32;codefenced&#32;quote\n&gt;it&#32;should&#32;not&#32;be&#32;quoted\n</pre>';
 
         expect(parser.replace(quoteTestStartString, {shouldKeepRawInput: true})).toBe(quoteTestReplacedString);
     });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -45,7 +45,7 @@ export default class ExpensiMark {
                 rawInputReplacement: (match, __, textWithinFences) => {
                     const withinFences = match.replace(/(?:&#x60;&#x60;&#x60;)([\s\S]*?)(?:&#x60;&#x60;&#x60;)/g, '$1');
                     const group = textWithinFences.replace(/(?:(?![\n\r])\s)/g, '&#32;');
-                    return `<pre data-code-raw="${_.escape(withinFences)}">${group}</pre>`;
+                    return `<pre data-code-raw="${withinFences}">${group}</pre>`;
                 }
             },
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR is a follow up for [live markdown preview web PR](https://github.com/Expensify/App/issues/27977) as there was discovered a bug which prevent parsing when special character was inside codeFence fe. ` ``` one > two ``` `.

To fix this issue we shouldn't escape data inside codeFence `data-code-raw` attribute so the input and output of the parser will be the same for the `react-native-live-markdown` library

### Fixed Issues
$ https://github.com/Expensify/App/issues/27977

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
There are already lots of unit tests present for covering this behaviour. All relevant ones were adjusted to new behaviour
1. What tests did you perform that validates your changed worked?
I've checked it on example app of `react-native-live-markdown` library which we are using for text input inside expensify app

To test the behaviour you should use example app of the [react-native-live-markdown library](https://github.com/Expensify/react-native-live-markdown). To do so:
1. change the expensify-common version inside `/parser` directory and reinstall dependencies (`npm install`)
2. build parser output file (`npm run build`)
3. Build and open example app on desired platform (iOS/Android/Web)
4. Type in code fence with special character inside it (fe. ` ``` one > two ``` `)
5. Verify that input is parsed as codeFence properly

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
There should be no regressions involved as I are only changing the behaviour of html attributed used only in `react-native-live-markdown` library. Any regression are possible only after new version of `react-native-live-markdown` library is present inside E/App
