### PR TITLE
Added support for phone mention without `expensify.sms` suffix 

### DIFF
--- a/lib/CONST.d.ts
+++ b/lib/CONST.d.ts
@@ -252,6 +252,10 @@ export declare const CONST: {
          */
         readonly EMAIL_PART: "([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
         /**
+        * Regex matching a text containing an e164 format phone number
+        */
+        readonly PHONE_PART: "\\+?[1-9]\\d{1,14}";
+        /**
          * Regular expression to check that a basic name is valid
          */
         readonly FREE_NAME: RegExp;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -162,7 +162,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
+                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART}|@${CONST.REG_EXP.PHONE_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
                 replacement: (match, g1, g2) => {
                     if (!Str.isValidMention(match)) {
                         return match;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR will introduce support for phone mention without `expensify.sms` suffix.
@c3024 @jasperhuangg 
One question I have is now I have not made `+` sign to be mandatory in the beginning of the mention but we can make it mandatory. Need your thoughts on this.
### Fixed Issues
$ https://github.com/Expensify/App/issues/33902

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
