### PR TITLE
fix: prevent matching of urls nested inside tags

### DIFF
--- a/__tests__/URL-test.js
+++ b/__tests__/URL-test.js
@@ -19,6 +19,12 @@ describe('Strict URL validation', () => {
             expect(regexToTest.test('https://google.com:65536')).toBeFalsy();
             expect(regexToTest.test('smtp://google.com')).toBeFalsy();
         });
+
+        it('should not match urls inside tags', () => {
+            const regexToTest = new RegExp(`^${URL_REGEX_WITH_REQUIRED_PROTOCOL}$`, 'i');
+            expect(regexToTest.test('<code>http://google.com/</code>')).toBeFalsy();
+            expect(regexToTest.test('<pre>http://google.com/</pre>')).toBeFalsy();
+        });
     });
 
     describe('Optional protocol for URL', () => {

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -2,7 +2,8 @@ import TLD_REGEX from './tlds';
 
 const ALLOWED_PORTS = '([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])';
 const URL_PROTOCOL_REGEX = '((ht|f)tps?:\\/\\/)';
-const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?=(?<label>[-a-z0-9]*[a-z0-9]))\\k<label>?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))(?!@(?:[a-z\\d-]+\\.)+[a-z]{2,})`;
+const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?=(?<label>[-a-z0-9]*[a-z0-9]))\\k<label>?\\.)+\
+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))(?!@(?:[a-z\\d-]+\\.)+[a-z]{2,})`;
 const addEscapedChar = reg => `(?:${reg}|&(?:amp|#x27);)`;
 const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?\\/${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/)*`;
 const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~]')}*)?`;

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -2,7 +2,7 @@ import TLD_REGEX from './tlds';
 
 const ALLOWED_PORTS = '([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])';
 const URL_PROTOCOL_REGEX = '((ht|f)tps?:\\/\\/)';
-const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))(?!@(?:[a-z\\d-]+\\.)+[a-z]{2,})`;
+const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?=(?<label>[-a-z0-9]*[a-z0-9]))\\k<label>?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))(?!@(?:[a-z\\d-]+\\.)+[a-z]{2,})`;
 const addEscapedChar = reg => `(?:${reg}|&(?:amp|#x27);)`;
 const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?\\/${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/)*`;
 const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~]')}*)?`;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This PR improves the performance of URL parsing regular expression by preventing matching of urls nested inside html tags like `<code>`, `<pre>` etc. This was causing performance issues on mobile devices. The PR adds an early return in regex matching by excluding links inside tags and there by avoiding the need to validate the string for possible TLDs which is more than 10K characters long.


### Fixed Issues
$ GH_LINK https://github.com/Expensify/App/issues/34324

Details: https://github.com/Expensify/App/issues/34324#issuecomment-1895303313

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
New test cases were added to verify that urls nested inside tags are not matched.

2. What tests did you perform that validates your changed worked?
Tested with Expensify App to make sure that url parsing is working as expected.

Follow steps below:

 1. Update package json to use this branch for expensify-commons
```bash
"expensify-common": "git+ssh://git@github.com/Expensify/expensify-common.git#8239f30ea92dc493f582813b9684558a0af386fd",
```
 2. Install packages via `npm i`
 3. Start the app
 4. Verify that url parsing in chat threads are working as expected.

# QA
1. What does QA need to do to validate your changes?
Same as tests
2. What areas to they need to test for regressions?
This PR shouldn't introduce any regression related to URL validation and parsing within Expensify app.

