### PR TITLE
add user private domain and logins to replace

### DIFF
--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -22,11 +22,15 @@ export default class ExpensiMark {
      * If not provided, all available rules will be applied.
      * @param options.shouldEscapeText=true - Whether or not the text should be escaped
      * @param options.shouldKeepRawInput=false - Whether or not the raw input should be kept and returned
+     * @param options.currentUserPrivateDomain - Private domain of the current user.
+     * @param options.allPersonalDetailLogins - List of personal detail login
      */
-    replace(text: string, { filterRules, shouldEscapeText, shouldKeepRawInput }?: {
+    replace(text: string, { filterRules, shouldEscapeText, shouldKeepRawInput, currentUserPrivateDomain, allPersonalDetailLogins}?: {
         filterRules?: string[];
         shouldEscapeText?: boolean;
         shouldKeepRawInput?: boolean;
+        currentUserPrivateDomain?: string;
+        allPersonalDetailLogins?: string[]
     }): string;
     /**
      * Checks matched URLs for validity and replace valid links with html elements

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -156,8 +156,12 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
-                replacement: (match, g1, g2) => {
+                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART}|@${CONST.REG_EXP.PHONE_PART}|@([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*))(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
+                replacement: (match, g1, g2, currentUserPrivateDomain, allPersonalDetailLogins) => {
+                    const mention = g2.substring(1);
+                    if (!Str.isValidEmail(mention) && currentUserPrivateDomain && allPersonalDetailLogins.includes(`${mention}@${currentUserPrivateDomain}`)) {
+                        return `${g1}<mention-user>${g2}@${currentUserPrivateDomain}</mention-user>`;
+                    }
                     if (!Str.isValidMention(match)) {
                         return match;
                     }
@@ -470,7 +474,9 @@ export default class ExpensiMark {
      *
      * @returns {String}
      */
-    replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false} = {}) {
+    replace(text, {
+        filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false, currentUserPrivateDomain = '', allPersonalDetailLogins = []
+    } = {}) {
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? _.escape(text) : text;
         const excludeRules = shouldKeepRawInput ? _.union(this.shouldKeepWhitespaceRules, filterRules) : filterRules;
@@ -485,6 +491,8 @@ export default class ExpensiMark {
                 const replacementFunction = shouldKeepRawInput && rule.rawInputReplacement ? rule.rawInputReplacement : rule.replacement;
                 if (rule.process) {
                     replacedText = rule.process(replacedText, replacementFunction, shouldKeepRawInput);
+                } else if (rule.name === 'userMentions') {
+                    replacedText = replacedText.replace(rule.regex, (match, g1, g2) => replacementFunction(match, g1, g2, currentUserPrivateDomain, allPersonalDetailLogins));
                 } else {
                     replacedText = replacedText.replace(rule.regex, replacementFunction);
                 }


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/35532

# Tests
1. Create a room with 4 members: 2 on the same private domain, 1 on another private domain, and 1 on a public domain
2. Draft a message that includes mentions for each user.
3. Verify that when mentioning a user on the same private domain, the search result for the mention should not include the domain for the user's email
4. Verify that when mentioning a user on a public domain or on a different private domain, the behavior should remain largely as it is, though we will now prepend an @ to the front of the login details when showing the mention options in search.

# QA
1. Create a room with 4 members: 2 on the same private domain, 1 on another private domain, and 1 on a public domain
2. Draft a message that includes mentions for each user.
3. Verify that when mentioning a user on the same private domain, the search result for the mention should not include the domain for the user's email
4. Verify that when mentioning a user on a public domain or on a different private domain, the behavior should remain largely as it is, though we will now prepend an @ to the front of the login details when showing the mention options in search.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/113963320/c9deb8f0-f22b-40e7-9778-f0ab0c93a253


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/113963320/3bc926b1-11e5-4dc1-bd58-23ac7db4191a


</details>
