### PR TITLE
Add support for nested quotes

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1829,3 +1829,60 @@ test('Test italic/bold/strikethrough markdown to keep consistency', () => {
     resultString = '<del>This~is~strikethrough~test</del>~~~';
     expect(parser.replace(testString)).toBe(resultString);
 });
+
+
+describe('multi-level blockquote', () => {
+    test('test max level of blockquote (3)', () => {
+        const quoteTestStartString = '>>>>> Hello world';
+        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>&gt;&gt; Hello world</blockquote></blockquote></blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+    test('multi-level blockquote with single space', () => {
+        const quoteTestStartString = '> > > Hello world';
+        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>Hello world</blockquote></blockquote></blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+    test('multi-level blockquote with multiple spaces', () => {
+        const quoteTestStartString = '>  >   >      Hello world';
+        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>Hello world</blockquote></blockquote></blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+
+    test('multi-level blockquote with mixed spaces', () => {
+        const quoteTestStartString = '>  > >   Hello world';
+        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>Hello world</blockquote></blockquote></blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+
+    test('multi-level blockquote with diffrent syntax', () => {
+        const quoteTestStartString = '> > _Hello_ *world*';
+        const quoteTestReplacedString = '<blockquote><blockquote><em>Hello</em> <strong>world</strong></blockquote></blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+
+    test('multi-level blockquote with nested heading', () => {
+        const quoteTestStartString = '> > # Hello world';
+        const quoteTestReplacedString = '<blockquote><blockquote><h1>Hello world</h1></blockquote></blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+
+    test('multiline multi-level blockquote', () => {
+        const quoteTestStartString = '> > Hello my\n> > beautiful\n> > world\n';
+        const quoteTestReplacedString = '<blockquote><blockquote>Hello my<br />beautiful<br />world</blockquote></blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+
+    test('multiline blockquote with diffrent levels', () => {
+        const quoteTestStartString = '> > > Hello my\n> > beautiful\n> world\n';
+        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>Hello my</blockquote>beautiful</blockquote>world</blockquote>';
+
+        expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+    });
+});

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -216,10 +216,22 @@ export default class ExpensiMark {
                     // To do this we need to parse body of the quote without first space
                     let isStartingWithSpace = false;
                     const textToReplace = g1.replace(/^&gt;( )?/gm, (match, g2) => {
-                        isStartingWithSpace = !!g2;
-                        return '';
+                        if (shouldKeepRawInput) {
+                            isStartingWithSpace = !!g2;
+                            return '';
+                        }
+                        return match;
                     });
-                    const replacedText = this.replace(textToReplace, {filterRules: ['heading1'], shouldEscapeText: false, shouldKeepRawInput});
+                    const filterRules = ['heading1'];
+
+                    // if we don't reach the max quote depth we allow the recursive call to process possible quote
+                    if (this.currentQuoteDepth < this.maxQuoteDepth) {
+                        filterRules.push('quote');
+                        this.currentQuoteDepth++;
+                    }
+
+                    const replacedText = this.replace(textToReplace, {filterRules, shouldEscapeText: false, shouldKeepRawInput});
+                    this.currentQuoteDepth = 1;
                     return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
             },
@@ -456,7 +468,19 @@ export default class ExpensiMark {
          * The list of rules that have to be applied when shouldKeepWhitespace flag is true.
          * @type {Object[]}
          */
-        this.shouldKeepWhitespaceRules = this.rules.filter(rule => !this.whitespaceRulesToDisable.includes(rule.name)).map(rule => rule.name);
+        this.shouldKeepWhitespaceRules = this.rules.filter(rule => !this.whitespaceRulesToDisable.includes(rule.name));
+
+        /**
+         * maxQuoteDepth is the maximum depth of nested quotes that we want to support.
+         * @type {Number}
+         */
+        this.maxQuoteDepth = 2;
+
+        /**
+         * currentQuoteDepth is the current depth of nested quotes that we are processing.
+         * @type {Number}
+         */
+        this.currentQuoteDepth = 0;
     }
 
     /**
@@ -473,8 +497,8 @@ export default class ExpensiMark {
     replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false} = {}) {
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? _.escape(text) : text;
-        const excludeRules = shouldKeepRawInput ? _.union(this.shouldKeepWhitespaceRules, filterRules) : filterRules;
-        const rules = _.isEmpty(excludeRules) ? this.rules : _.filter(this.rules, rule => _.contains(excludeRules, rule.name));
+        const enabledRules = shouldKeepRawInput ? this.shouldKeepWhitespaceRules : this.rules;
+        const rules = _.isEmpty(filterRules) ? enabledRules : _.filter(this.rules, rule => _.contains(filterRules, rule.name));
 
         try {
             rules.forEach((rule) => {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -474,7 +474,7 @@ export default class ExpensiMark {
          * maxQuoteDepth is the maximum depth of nested quotes that we want to support.
          * @type {Number}
          */
-        this.maxQuoteDepth = 2;
+        this.maxQuoteDepth = 3;
 
         /**
          * currentQuoteDepth is the current depth of nested quotes that we are processing.


### PR DESCRIPTION
This PR adds support for nested quotes. Maximal level of quotes is set to *3*. 
Additionally it fixes bug with double removal of `>` symbol

### Fixed Issues
$ https://github.com/Expensify/App/issues/36227

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?

Every test involving writing messages with quotes will be relevant in this case, as the behaviour of single quotes shouldn't be changed. In addition, every such a test can be tweaked to check nested quotes case simply by adding additional `>` symbol
1. What tests did you perform that validates your changed worked?
I've checked it by running all unit tests and by linking it in E/App and checking in chat itself

I'm going to add additional unit tests which should be sufficient to cover all popular cases. Morove manual testing inside E/App.

# QA
1. What does QA need to do to validate your changes?
Typing any message with multiple quotes (f.e `> > > Hello world`)
1. What areas to they need to test for regressions?
Chat/Quotes

Anything regarding quotes should be tested, as quite big chunk of code regarding quotes were changed here
