### PR TITLE
Revert #651

### DIFF
--- a/__tests__/URL-test.js
+++ b/__tests__/URL-test.js
@@ -19,12 +19,6 @@ describe('Strict URL validation', () => {
             expect(regexToTest.test('https://google.com:65536')).toBeFalsy();
             expect(regexToTest.test('smtp://google.com')).toBeFalsy();
         });
-
-        it('should not match urls inside tags', () => {
-            const regexToTest = new RegExp(`^${URL_REGEX_WITH_REQUIRED_PROTOCOL}$`, 'i');
-            expect(regexToTest.test('<code>http://google.com/</code>')).toBeFalsy();
-            expect(regexToTest.test('<pre>http://google.com/</pre>')).toBeFalsy();
-        });
     });
 
     describe('Optional protocol for URL', () => {

--- a/lib/Url.js
+++ b/lib/Url.js
@@ -2,8 +2,7 @@ import TLD_REGEX from './tlds';
 
 const ALLOWED_PORTS = '([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])';
 const URL_PROTOCOL_REGEX = '((ht|f)tps?:\\/\\/)';
-const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?=(?<label>[-a-z0-9]*[a-z0-9]))\\k<label>?\\.)+\
-(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))(?!@(?:[a-z\\d-]+\\.)+[a-z]{2,})`;
+const URL_WEBSITE_REGEX = `${URL_PROTOCOL_REGEX}?((?:www\\.)?[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\\.)+(?:${TLD_REGEX})(?:\\:${ALLOWED_PORTS}|\\b|(?=_))(?!@(?:[a-z\\d-]+\\.)+[a-z]{2,})`;
 const addEscapedChar = reg => `(?:${reg}|&(?:amp|#x27);)`;
 const URL_PATH_REGEX = `(?:${addEscapedChar('[.,=(+$!*]')}?\\/${addEscapedChar('[-\\w$@.+!*:(),=%~]')}*${addEscapedChar('[-\\w~@:%)]')}|\\/)*`;
 const URL_PARAM_REGEX = `(?:\\?${addEscapedChar('[-\\w$@.+!*()\\/,=%{}:;\\[\\]\\|_|~]')}*)?`;


### PR DESCRIPTION

<!-- Add an explanation of the change or anything fishy that is going on -->


This reverts commit 83ae6194b3e4feb363ea9d061085a7ab76e35ffb where we modified the `URL_WEBSITE_REGEX` to prevent excessive backtracking. This however caused regression https://github.com/Expensify/App/issues/37472. So reverting the commit to unblock other PRs. Will raise a new PR with fix.

### Fixed Issues
$ https://github.com/Expensify/App/issues/37472

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
