### PR TITLE
Support new API formats in Network.jsx

### DIFF
--- a/lib/Log.jsx
+++ b/lib/Log.jsx
@@ -13,7 +13,7 @@ import Logger from './Logger';
  * @return {Promise}
  */
 function serverLoggingCallback(logger, params) {
-    return API(Network('/api.php')).logToServer(params);
+    return API(Network('/api/')).logToServer(params);
 }
 
 /**

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -33,7 +33,7 @@ export default function Network(endpoint) {
     let isNavigatingAway = false;
 
     // If URL ends in `/` we're using /api/command format.
-    let isNewURLFormat = endpoint[endpoint.length - 1] === '/';
+    const isNewURLFormat = endpoint[endpoint.length - 1] === '/';
 
     if (!endpoint) {
         throw new Error('Cannot instantiate Network without an url endpoint');

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -62,13 +62,12 @@ export default function Network(endpoint) {
          */
         post(parameters) {
             // Build request
+            let newURL = endpoint;
             if (isNewURLFormat) {
                 // Remove command from parameters and use it in the URL
                 const command = parameters.command;
                 delete parameters.command;
-                const newURL = `${endpoint}${command}`;
-            } else {
-                const newURL = endpoint;
+                newURL = `${endpoint}${command}`;
             }
 
             const settings = {

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -32,7 +32,7 @@ export default function Network(endpoint) {
     // A flag that turns true when the user navigates away
     let isNavigatingAway = false;
 
-    // If URL ends in `/` we're using /api/command format.
+    // If URL ends in `/` we're using /api/{command} format.
     const isNewURLFormat = endpoint[endpoint.length - 1] === '/';
 
     if (!endpoint) {
@@ -61,7 +61,6 @@ export default function Network(endpoint) {
         post(parameters) {
             // Build request
             let newURL = endpoint;
-            let settings = {};
             if (isNewURLFormat) {
                 // Remove command from parameters and use it in the URL
                 const command = parameters.command;
@@ -69,7 +68,7 @@ export default function Network(endpoint) {
                 newURL = `${endpoint}${command}`;
             }
 
-            settings = {...settings,
+            const settings = {
                 url: newURL,
                 type: 'POST',
                 data: parameters,
@@ -78,6 +77,7 @@ export default function Network(endpoint) {
             let shouldUseFormData = false;
 
             // Add the API command to our URL (for console debugging purposes)
+            // Note that parameters.command is empty if we're using the new API format and this will do nothing.
             settings.url = addCommandToUrl(parameters.command, settings.url);
 
             // Check to see if parameters contains a File or Blob object

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -32,6 +32,9 @@ export default function Network(endpoint) {
     // A flag that turns true when the user navigates away
     let isNavigatingAway = false;
 
+    // If URL ends in `/` we're using /api/command format.
+    let isNewURLFormat = endpoint[endpoint.length - 1] === '/';
+
     if (!endpoint) {
         throw new Error('Cannot instantiate Network without an url endpoint');
     }
@@ -59,8 +62,17 @@ export default function Network(endpoint) {
          */
         post(parameters) {
             // Build request
+            if (isNewURLFormat) {
+                // Remove command from parameters and use it in the URL
+                const command = parameters.command;
+                delete parameters.command;
+                const newURL = `${endpoint}${command}`;
+            } else {
+                const newURL = endpoint;
+            }
+
             const settings = {
-                url: endpoint,
+                url: newURL,
                 type: 'POST',
                 data: parameters,
                 xhrFields: { withCredentials: true },

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -63,14 +63,16 @@ export default function Network(endpoint) {
         post(parameters) {
             // Build request
             let newURL = endpoint;
+            let settings = {};
             if (isNewURLFormat) {
                 // Remove command from parameters and use it in the URL
                 const command = parameters.command;
                 delete parameters.command;
                 newURL = `${endpoint}${command}`;
+                settings.crossDomain = true;
             }
 
-            const settings = {
+            settings = {...settings,
                 url: newURL,
                 type: 'POST',
                 data: parameters,

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -41,6 +41,8 @@ export default function Network(endpoint) {
         isNavigatingAway = true;
     };
 
+    $.ajaxSetup({xhrFields: { withCredentials: true } });
+
     return {
         /**
          * @param {String} url to fetch

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -69,7 +69,7 @@ export default function Network(endpoint) {
                 const command = parameters.command;
                 delete parameters.command;
                 newURL = `${endpoint}${command}`;
-                settings.crossDomain = true;
+                console.log('Using new URL format');
             }
 
             settings = {...settings,
@@ -104,6 +104,8 @@ export default function Network(endpoint) {
                 settings.contentType = false;
                 settings.data = formData;
             }
+
+            console.log(settings, $);
 
             return $.ajax(settings);
         },

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -63,6 +63,7 @@ export default function Network(endpoint) {
                 url: endpoint,
                 type: 'POST',
                 data: parameters,
+                xhrFields: { withCredentials: true },
             };
             const formData = new FormData();
             let shouldUseFormData = false;

--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -44,8 +44,6 @@ export default function Network(endpoint) {
         isNavigatingAway = true;
     };
 
-    $.ajaxSetup({xhrFields: { withCredentials: true } });
-
     return {
         /**
          * @param {String} url to fetch
@@ -69,14 +67,12 @@ export default function Network(endpoint) {
                 const command = parameters.command;
                 delete parameters.command;
                 newURL = `${endpoint}${command}`;
-                console.log('Using new URL format');
             }
 
             settings = {...settings,
                 url: newURL,
                 type: 'POST',
                 data: parameters,
-                xhrFields: { withCredentials: true },
             };
             const formData = new FormData();
             let shouldUseFormData = false;
@@ -104,8 +100,6 @@ export default function Network(endpoint) {
                 settings.contentType = false;
                 settings.data = formData;
             }
-
-            console.log(settings, $);
 
             return $.ajax(settings);
         },


### PR DESCRIPTION
If API uses a new format `/api/command?` then this will properly strip out the command and add it to the URL. 

Off hold since we patched Salt/our nginx config on secure, web prod and staging.

### Fixed Issues
For https://github.com/Expensify/Web-Expensify/pull/41231

# Tests
1. With the other PRs listed in the original, test Web-E, App, Web-Secure, etc. and see that `/api/{command}` properly handles all commands and returns the expected values, while logs show little to no difference in the actual request received. 

# QA
N/A
