### PR TITLE
Add support for inline image Markdown - attribute fix

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1931,4 +1931,10 @@ describe('Image markdown conversion to html tag', () => {
         const resultString = '<img src=\"https://example.com/image.png\" alt=\"test&quot; onerror=&quot;alert(&#x27;xss&#x27;)\" />';
         expect(parser.replace(testString)).toBe(resultString);
     });
+
+    test('No html inside the src attribute', () => {
+        const testString = '![`code`](https://example.com/image.png)';
+        const resultString = '<img src="https://example.com/image.png" alt="<code>code</code>" />';
+        expect(parser.replace(testString)).toBe(resultString);
+    })
 });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1779,14 +1779,14 @@ describe('when should keep raw input flag is enabled', () => {
         });
     });
 });
-    
+
 test('Test code fence within inline code', () => {
     let testString = 'Hello world `(```test```)` Hello world';
     expect(parser.replace(testString)).toBe('Hello world &#x60;(<pre>test</pre>)&#x60; Hello world');
-    
+
     testString = 'Hello world `(```test\ntest```)` Hello world';
     expect(parser.replace(testString)).toBe('Hello world &#x60;(<pre>test<br />test</pre>)&#x60; Hello world');
-    
+
     testString = 'Hello world ```(`test`)``` Hello world';
     expect(parser.replace(testString)).toBe('Hello world <pre>(&#x60;test&#x60;)</pre> Hello world');
 
@@ -1893,12 +1893,9 @@ describe('Image markdown conversion to html tag', () => {
         expect(parser.replace(testString)).toBe(resultString);
     });
 
-    // Currently any markdown used inside the square brackets is converted to html string in the alt attribute
-    // The attributes should only contain plain text, but it doesn't seem possible to convert markdown to plain text
-    // or let the parser know not to convert markdown to html for html attributes
-    xtest('Image with alt text containing markdown', () => {
-        const testString = '![*bold* _italic_ ~strike~](https://example.com/image.png)';
-        const resultString = '<img src="https://example.com/image.png" alt="*bold* _italic_ ~strike~" />';
+    test('Image with alt text containing markdown', () => {
+        const testString = '![# fake-heading *bold* _italic_ ~strike~ [:-)]](https://example.com/image.png)';
+        const resultString = '<img src="https://example.com/image.png" alt="# fake-heading &ast;bold&ast; &lowbar;italic&lowbar; &#126;strike&#126; &lbrack;:-)&rbrack;" />';
         expect(parser.replace(testString)).toBe(resultString);
     });
 

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -769,4 +769,10 @@ describe('Image tag conversion to markdown', () => {
         const resultString = '![https://example.com/image.png](https://example.com/image.png)';
         expect(parser.htmlToMarkdown(testString)).toBe(resultString);
    });
+
+    test('Image with alt text containing escaped markdown', () => {
+        const testString = '<img src="https://example.com/image.png" alt="&ast;bold&ast; &lowbar;italic&lowbar; &#126;strike&#126;" />';
+        const resultString = '![*bold* _italic_ ~strike~](https://example.com/image.png)';
+        expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+    });
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -113,12 +113,13 @@ export default class ExpensiMark {
              * Converts markdown style images to img tags e.g. ![Expensify](https://www.expensify.com/attachment.png)
              * We need to convert before linking rules since they will not try to create a link from an existing img
              * tag.
+             * Additional sanitization is done to the alt attribute to prevent parsing it further to html by later rules.
              */
             {
                 name: 'image',
                 regex: MARKDOWN_IMAGE_REGEX,
-                replacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}" alt="${g1}" />`,
-                rawInputReplacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}" alt="${g1}" data-raw-href="${g2}" data-link-variant="labeled" />`
+                replacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}" alt="${this.escapeMarkdownEntities(g1)}" />`,
+                rawInputReplacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}" alt="${this.escapeMarkdownEntities(g1)}" data-raw-href="${g2}" data-link-variant="labeled" />`
             },
 
             /**
@@ -944,5 +945,28 @@ export default class ExpensiMark {
         const linksInOld = this.extractLinksInMarkdownComment(oldComment);
         const linksInNew = this.extractLinksInMarkdownComment(newComment);
         return linksInOld === undefined || linksInNew === undefined ? [] : _.difference(linksInOld, linksInNew);
+    }
+
+    /**
+     * Replace MD characters with their HTML entity equivalent
+     * @param {String} text
+     * @return {String}
+     */
+    escapeMarkdownEntities(text) {
+        // A regex pattern matching special MD characters we'd like to escape
+        const pattern = /([*_{}[\]~])/g;
+
+        // A map of MD characters to their HTML entity equivalent
+        const entities = {
+            '*': '&ast;',
+            _: '&lowbar;',
+            '{': '&lbrace;',
+            '}': '&rbrace;',
+            '[': '&lbrack;',
+            ']': '&rbrack;',
+            '~': '&#126;',
+        };
+
+        return text.replace(pattern, char => entities[char] || char);
     }
 }

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -198,7 +198,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>|.+\/>))`,
+                        `(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>|.+\\/>))`,
                         'gi',
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -198,7 +198,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(
-                        `(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`,
+                        `(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\/a>|[^<]*(<\/pre>|<\/code>|.+\/>))`,
                         'gi',
                     );
                     return this.modifyTextForUrlLinks(regex, textToProcess, replacement);


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR is an optional followup for https://github.com/Expensify/expensify-common/pull/658 if we'd like to patch a problem where image attribute content is being parsed to HTML as detailed in: https://github.com/Expensify/expensify-common/pull/658#discussion_r1508088239

### Fixed Issues
$ https://github.com/Expensify/App/issues/37246

# Tests
1. **Unit/Integration Tests Covering the Change:**
   - The changes are covered by unit tests added to `ExpensiMark-HTML-test.js` and `ExpensiMark-Markdown-test.js`. These tests validate that MD content designated for the `alt` attribute is escaped as HTML entities so it isn't converted to html tags by following rules
   
2. **Tests Performed to Validate Changes:**
   - Ran all newly added tests and ensured they pass, verifying the correct conversion of markdown to HTML `<img>` tags and vice versa.
   - Manually tested the parsing of markdown containing images in various formats and contexts to ensure the output matches expectations.
   - Checked the handling of invalid image URLs to ensure they remain unchanged, as expected.

# QA
1. **QA Validation Steps:**
   - Test the handling of invalid Markdown image syntax, such as using a broken or incorrectly formatted URL (e.g., `![image](invalid-link)`). These should not be parsed and ought to remain displayed as the raw Markdown text, without conversion or rendering as an image.
