### PR TITLE
Prevent bold, italic, strikethrough, and auto link when the content is a codefence

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -477,12 +477,19 @@ test('Test code fencing with ExpensiMark syntax outside', () => {
 
     codeFenceExample = '*Test1 ```code``` Test2*';
     expect(parser.replace(codeFenceExample)).toBe('*Test1 <pre>code</pre> Test2*');
+    expect(parser.replace(codeFenceExample, {shouldKeepRawInput: true})).toBe('*Test1 <pre data-code-raw=\"code\">code</pre> Test2*');
 
     codeFenceExample = '_Test1 ```code``` Test2_';
     expect(parser.replace(codeFenceExample)).toBe('_Test1 <pre>code</pre> Test2_');
+    expect(parser.replace(codeFenceExample, {shouldKeepRawInput: true})).toBe('_Test1 <pre data-code-raw=\"code\">code</pre> Test2_');
 
     codeFenceExample = '~Test1 ```code``` Test2~';
     expect(parser.replace(codeFenceExample)).toBe('~Test1 <pre>code</pre> Test2~');
+    expect(parser.replace(codeFenceExample, {shouldKeepRawInput: true})).toBe('~Test1 <pre data-code-raw=\"code\">code</pre> Test2~');
+
+    codeFenceExample = '[```code```](google.com)';
+    expect(parser.replace(codeFenceExample)).toBe('[<pre>code</pre>](<a href=\"https://google.com\" target=\"_blank\" rel=\"noreferrer noopener\">google.com</a>)');
+    expect(parser.replace(codeFenceExample, {shouldKeepRawInput: true})).toBe('[<pre data-code-raw=\"code\">code</pre>](<a href=\"https://google.com\" data-raw-href=\"google.com\" data-link-variant=\"auto\" target=\"_blank\" rel=\"noreferrer noopener\">google.com</a>)');
 });
 
 test('Test code fencing with additional backticks inside', () => {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -251,7 +251,7 @@ export default class ExpensiMark {
 
                 // We want to add extraLeadingUnderscores back before the <em> tag unless textWithinUnderscores starts with valid email
                 replacement: (match, extraLeadingUnderscores, textWithinUnderscores) => {
-                    if (textWithinUnderscores.includes('<pre>') || this.containsNonPairTag(textWithinUnderscores)) {
+                    if (textWithinUnderscores.includes('</pre>') || this.containsNonPairTag(textWithinUnderscores)) {
                         return match;
                     }
                     if (String(textWithinUnderscores).match(`^${CONST.REG_EXP.MARKDOWN_EMAIL}`)) {
@@ -282,12 +282,12 @@ export default class ExpensiMark {
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
                 regex: /\B\*((?![\s*])[\s\S]*?[^\s*])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (match, g1) => (g1.includes('<pre>') || this.containsNonPairTag(g1) ? match : `<strong>${g1}</strong>`),
+                replacement: (match, g1) => (g1.includes('</pre>') || this.containsNonPairTag(g1) ? match : `<strong>${g1}</strong>`),
             },
             {
                 name: 'strikethrough',
                 regex: /\B~((?![\s~])[\s\S]*?[^\s~])~\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (match, g1) => (g1.includes('<pre>') || this.containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
+                replacement: (match, g1) => (g1.includes('</pre>') || this.containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
             },
             {
                 name: 'newline',
@@ -609,7 +609,7 @@ export default class ExpensiMark {
 
             // We don't want to apply link rule if match[1] contains the code block inside the [] of the markdown e.g. [```example```](https://example.com)
             // or if match[1] is multiline text preceeded by markdown heading, e.g., # [example\nexample\nexample](https://example.com)
-            if (isDoneMatching || match[1].includes('<pre>') || match[1].includes('</h1>')) {
+            if (isDoneMatching || match[1].includes('</pre>') || match[1].includes('</h1>')) {
                 replacedText = replacedText.concat(textToCheck.substr(match.index, (match[0].length)));
             } else if (shouldApplyAutoLinkAgain) {
                 const urlRegex = new RegExp(`^${LOOSE_URL_REGEX}$|^${URL_REGEX}$`, 'i');


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/37533

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
The ExpensiMark-HTML-test.js is updated to include the new changes case.

1. What tests did you perform that validates your changed worked?
Ran the unit test.
Testing in App (Android & iOS only):
- Type these markdowns into composer:
```
~```a```~
*```b```*
_```c```_
[```d```](google.com)
```

- Verify the strikethrough, bold, italic, and auto link isn't applied

_to be able to test these changes, you need to apply the code change to react-native-live-markdown-parser.js_
<img width="354" alt="image" src="https://github.com/Expensify/expensify-common/assets/50919443/82f9f4c8-bdfd-4736-8613-3c5f5b8b7a8d">

_find all occurrences of `includes('<pre>')` and replace it with `includes('</pre>')`_


https://github.com/Expensify/expensify-common/assets/50919443/52715995-693c-4f38-a9f4-871c4e966dea



# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
Same as Test above