### PR TITLE
Fix blockquotes limiting in ExpensiMark

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -226,13 +226,13 @@ export default class ExpensiMark {
                     const filterRules = ['heading1'];
 
                     // if we don't reach the max quote depth we allow the recursive call to process possible quote
-                    if (this.currentQuoteDepth < this.maxQuoteDepth) {
+                    if (this.currentQuoteDepth < this.maxQuoteDepth - 1) {
                         filterRules.push('quote');
                         this.currentQuoteDepth++;
                     }
 
                     const replacedText = this.replace(textToReplace, {filterRules, shouldEscapeText: false, shouldKeepRawInput});
-                    this.currentQuoteDepth = 1;
+                    this.currentQuoteDepth = 0;
                     return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
             },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR fix blockquote limiting bug that appears when pasting more than 3 `>` and text after them. ExpensiMark on first parsing returns 4 blockquotes instead of 3 (limit is 3)

https://github.com/Expensify/expensify-common/assets/39538890/78e6dc5c-c90b-4e5c-8f62-5577e2396ead

### Fixed Issues
$ https://github.com/Expensify/App/issues/36227

# Tests
1. Open New Dot App on native devices
2. Write inside the Composer `>>>> Test`
3. Input should show only 3 blockquotes
4. Send the message
5. Verify if sent message has only 3 blockquotes

# QA
Verify if with this changes bug is fixed on all native platforms or on the [web live markdown PR](https://github.com/Expensify/App/pull/38152)