### PR TITLE
Validate phone numbers in different formats

### DIFF
--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -189,3 +189,24 @@ describe('Str.isValidEmail', () => {
         expect(Str.isValidEmail('a@a.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl')).toBeFalsy();
     });
 });
+
+
+describe('Str.isValidPhone', () => {
+    it('Correctly identifies valid phone numbers', () => {
+        // Significant part of phone
+        expect(Str.isValidPhone('4404589784')).toBeTruthy();
+        // International standard
+        expect(Str.isValidPhone('+1 440-458-9784')).toBeTruthy();
+        // E.164 standard
+        expect(Str.isValidPhone('+14404589784')).toBeTruthy();
+        // US national standard
+        expect(Str.isValidPhone('(440) 458-9784')).toBeTruthy();
+        expect(Str.isValidPhone('123.456.7890')).toBeTruthy();
+    });
+});
+
+describe('Str.isValidE164Phone', () => {
+    it('Correctly identifies valid E.164 phone numbers', () => {
+        expect(Str.isValidE164Phone('+14404589784')).toBeTruthy();
+    });
+});

--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -1,6 +1,6 @@
 import Str from '../lib/str';
 
-const buildTestURLForType = (type) => `https://chat.expensify.com/chat-attachments/5/w_eadf5d35cfce6a98e2dd3607cf8463b1e46219e4.${type}?authToken=12345`;
+const buildTestURLForType = type => `https://chat.expensify.com/chat-attachments/5/w_eadf5d35cfce6a98e2dd3607cf8463b1e46219e4.${type}?authToken=12345`;
 
 describe('Str.isImage', () => {
     it('Correctly identifies all valid image types', () => {
@@ -114,7 +114,7 @@ describe('Str.isValidEmail', () => {
         expect(Str.isValidEmail('test@gmail')).toBeFalsy();
         expect(Str.isValidEmail('@gmail.com')).toBeFalsy();
         expect(Str.isValidEmail('usernamelongerthan64charactersshouldnotworkaccordingtorfc822whichisusedbyphp@gmail.com')).toBeFalsy();
-        
+
         // Domain length (63 chars in each label)
         expect(Str.isValidEmail('test@asjjssjdjdjdjdjdjjeiwiwiwowkdjdjdieikdjfidekjcjdkekejdcjdkeekcj.com')).toBeTruthy();
         expect(Str.isValidEmail('abc@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.km')).toBeTruthy();
@@ -190,17 +190,20 @@ describe('Str.isValidEmail', () => {
     });
 });
 
-describe('Str.isValidPhone', () => {
+describe('Str.isValidPhoneFormat', () => {
     it('Correctly identifies valid phone numbers', () => {
         // Significant part of phone
-        expect(Str.isValidPhone('4404589784')).toBeTruthy();
+        expect(Str.isValidPhoneFormat('4404589784')).toBeTruthy();
+
         // International standard
-        expect(Str.isValidPhone('+1 440-458-9784')).toBeTruthy();
+        expect(Str.isValidPhoneFormat('+1 440-458-9784')).toBeTruthy();
+
         // E.164 standard
-        expect(Str.isValidPhone('+14404589784')).toBeTruthy();
+        expect(Str.isValidPhoneFormat('+14404589784')).toBeTruthy();
+
         // US national standard
-        expect(Str.isValidPhone('(440) 458-9784')).toBeTruthy();
-        expect(Str.isValidPhone('123.456.7890')).toBeTruthy();
+        expect(Str.isValidPhoneFormat('(440) 458-9784')).toBeTruthy();
+        expect(Str.isValidPhoneFormat('123.456.7890')).toBeTruthy();
     });
 });
 

--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -190,7 +190,6 @@ describe('Str.isValidEmail', () => {
     });
 });
 
-
 describe('Str.isValidPhone', () => {
     it('Correctly identifies valid phone numbers', () => {
         // Significant part of phone

--- a/lib/CONST.d.ts
+++ b/lib/CONST.d.ts
@@ -258,7 +258,7 @@ export declare const CONST: {
         /**
         * Regex matching a text containing an E.164 format phone number
         */
-        readonly E164_PHONE_PART: "\\+[1-9]\\d{1,14}";
+        readonly PHONE_PART: "\\+[1-9]\\d{1,14}";
         /**
          * Regular expression to check that a basic name is valid
          */

--- a/lib/CONST.d.ts
+++ b/lib/CONST.d.ts
@@ -252,9 +252,13 @@ export declare const CONST: {
          */
         readonly EMAIL_PART: "([\\w\\-\\+\\'#]+(?:\\.[\\w\\-\\'\\+]+)*@(?:[\\w\\-]+\\.)+[a-z]{2,})";
         /**
+         * Regex matching a text containing general phone number
+         */
+        readonly GENERAL_PHONE_PART: RegExp,
+        /**
         * Regex matching a text containing an E.164 format phone number
         */
-        readonly PHONE_PART: "\\+[1-9]\\d{1,14}";
+        readonly E164_PHONE_PART: "\\+[1-9]\\d{1,14}";
         /**
          * Regular expression to check that a basic name is valid
          */

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -40,11 +40,11 @@ export const CONST = {
 
     /**
      * Display this amount to users to encourage them to book a call
-     * 
+     *
      * @type Number
      */
     MAX_TRIAL_BONUS_DAYS: 42,
-    
+
     COUNTRY: {
         US: 'US',
         AU: 'AU',
@@ -297,7 +297,7 @@ export const CONST = {
 
         /**
         * Regex matching a text containing general phone number
-        * 
+        *
         * @type RegExp
         */
         GENERAL_PHONE_PART: /(\+\d{1,2}\s?)?(\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}/,
@@ -364,6 +364,7 @@ export const CONST = {
          * @type RegExp
          */
         EMOJIS: /[\p{Extended_Pictographic}\u200d\u{1f1e6}-\u{1f1ff}\u{1f3fb}-\u{1f3ff}\u{e0020}-\u{e007f}\u20E3\uFE0F]|[#*0-9]\uFE0F?\u20E3/gu,
+
         /**
          * Regex matching an text containing an Emoji that can be a single emoji or made up by some different emojis
          *
@@ -544,7 +545,7 @@ export const CONST = {
         'notifications@expensify.com',
     ],
 
-     /**
+    /**
      * Emails that the user shouldn't submit reports to nor share reports with
      * Any changes here should be reflected in the PHP constant,
      * which is located in _constant.php and also named INVALID_APPROVER_AND_SHAREE_EMAILS

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -305,7 +305,7 @@ export const CONST = {
         /**
         * Regex matching a text containing an E.164 format phone number
         */
-        E164_PHONE_PART: '\\+[1-9]\\d{1,14}',
+        PHONE_PART: '\\+[1-9]\\d{1,14}',
 
         /**
          * Regular expression to check that a basic name is valid

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -296,9 +296,16 @@ export const CONST = {
         EMAIL_PART: EMAIL_BASE_REGEX,
 
         /**
+        * Regex matching a text containing general phone number
+        * 
+        * @type RegExp
+        */
+        GENERAL_PHONE_PART: /(\+\d{1,2}\s?)?(\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}/,
+
+        /**
         * Regex matching a text containing an E.164 format phone number
         */
-        PHONE_PART: '\\+[1-9]\\d{1,14}',
+        E164_PHONE_PART: '\\+[1-9]\\d{1,14}',
 
         /**
          * Regular expression to check that a basic name is valid

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -180,12 +180,12 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART}|@${CONST.REG_EXP.E164_PHONE_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
+                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART}|@${CONST.REG_EXP.PHONE_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
                 replacement: (match, g1, g2) => {
                     if (!Str.isValidMention(match)) {
                         return match;
                     }
-                    const phoneRegex = new RegExp(`^@${CONST.REG_EXP.E164_PHONE_PART}$`);
+                    const phoneRegex = new RegExp(`^@${CONST.REG_EXP.PHONE_PART}$`);
                     return `${g1}<mention-user>${g2}${phoneRegex.test(g2) ? `@${CONST.SMS.DOMAIN}` : ''}</mention-user>`;
                 },
             },

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -180,12 +180,12 @@ export default class ExpensiMark {
              */
             {
                 name: 'userMentions',
-                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART}|@${CONST.REG_EXP.PHONE_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
+                regex: new RegExp(`(@here|[a-zA-Z0-9.!$%&+=?^\`{|}-]?)(@${CONST.REG_EXP.EMAIL_PART}|@${CONST.REG_EXP.E164_PHONE_PART})(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gim'),
                 replacement: (match, g1, g2) => {
                     if (!Str.isValidMention(match)) {
                         return match;
                     }
-                    const phoneRegex = new RegExp(`^@${CONST.REG_EXP.PHONE_PART}$`);
+                    const phoneRegex = new RegExp(`^@${CONST.REG_EXP.E164_PHONE_PART}$`);
                     return `${g1}<mention-user>${g2}${phoneRegex.test(g2) ? `@${CONST.SMS.DOMAIN}` : ''}</mention-user>`;
                 },
             },

--- a/lib/str.d.ts
+++ b/lib/str.d.ts
@@ -476,6 +476,15 @@ declare const Str: {
      */
     boldify(text: string, regexp: RegExp): string;
     /**
+     * Check for whether a phone number is valid in different formats/standards. For example:
+     * significant: 4404589784
+     * international: +1 440-458-9784
+     * e164: +14404589784
+     * national: (440) 458-978
+     * 123.456.7890
+     */
+    isValidPhone(phone: string): boolean;
+    /**
      * Check for whether a phone number is valid according to E.164 standard.
      * @param phone
      */

--- a/lib/str.d.ts
+++ b/lib/str.d.ts
@@ -478,7 +478,7 @@ declare const Str: {
     /**
      * Check for whether a phone number is valid.
      * @param phone
-     * @deprecated use isValidE164Phone instead
+     * @deprecated use isValidE164Phone to validate E.164 phone numbers or isValidPhoneFormat to validate phone numbers in general
      */
     isValidPhone(phone: string): boolean;
     /**

--- a/lib/str.d.ts
+++ b/lib/str.d.ts
@@ -476,12 +476,9 @@ declare const Str: {
      */
     boldify(text: string, regexp: RegExp): string;
     /**
-     * Check for whether a phone number is valid in different formats/standards. For example:
-     * significant: 4404589784
-     * international: +1 440-458-9784
-     * e164: +14404589784
-     * national: (440) 458-9784
-     * 123.456.7890
+     * Check for whether a phone number is valid.
+     * @param phone
+     * @deprecated use isValidE164Phone instead
      */
     isValidPhone(phone: string): boolean;
     /**
@@ -489,6 +486,16 @@ declare const Str: {
      * @param phone
      */
     isValidE164Phone(phone: string): boolean;
+    /**
+     * Check for whether a phone number is valid in different formats/standards. For example:
+     * significant: 4404589784
+     * international: +1 440-458-9784
+     * e164: +14404589784
+     * national: (440) 458-9784
+     * 123.456.7890
+     * @param phone
+     */
+    isValidPhoneFormat(phone: string): boolean;
     /**
      * We validate mentions by checking if it's first character is an allowed character.
      *

--- a/lib/str.d.ts
+++ b/lib/str.d.ts
@@ -476,10 +476,10 @@ declare const Str: {
      */
     boldify(text: string, regexp: RegExp): string;
     /**
-     * Check for whether a phone number is valid.
+     * Check for whether a phone number is valid according to E.164 standard.
      * @param phone
      */
-    isValidPhone(phone: string): boolean;
+    isValidE164Phone(phone: string): boolean;
     /**
      * We validate mentions by checking if it's first character is an allowed character.
      *
@@ -493,7 +493,7 @@ declare const Str: {
      */
     removeSMSDomain(text: string): string;
     /**
-     * Returns true if the text is a valid phone number with our SMS domain removed
+     * Returns true if the text is a valid E.164 phone number with our SMS domain removed
      *
      * @param text
      */

--- a/lib/str.js
+++ b/lib/str.js
@@ -936,6 +936,21 @@ const Str = {
     },
 
     /**
+     * Check for whether a phone number is valid in different formats/standards. For example:
+     * significant: 4404589784
+     * international: +1 440-458-9784
+     * e164: +14404589784
+     * national: (440) 458-978
+     * 123.456.7890
+     * @param {String} phone
+     *
+     * @return {bool}
+     */
+    isValidPhone(phone) {
+        return CONST.REG_EXP.GENERAL_PHONE_PART.test(phone);
+    },
+
+    /**
      * We validate mentions by checking if it's first character is an allowed character.
      *
      * @param {String} mention

--- a/lib/str.js
+++ b/lib/str.js
@@ -926,16 +926,6 @@ const Str = {
     },
 
     /**
-     * Check for whether a phone number is valid according to E.164 standard.
-     * @param {String} phone
-     *
-     * @return {bool}
-     */
-    isValidE164Phone(phone) {
-        return CONST.SMS.E164_REGEX.test(phone);
-    },
-
-    /**
      * Check for whether a phone number is valid in different formats/standards. For example:
      * significant: 4404589784
      * international: +1 440-458-9784
@@ -948,6 +938,16 @@ const Str = {
      */
     isValidPhone(phone) {
         return CONST.REG_EXP.GENERAL_PHONE_PART.test(phone);
+    },
+
+    /**
+     * Check for whether a phone number is valid according to E.164 standard.
+     * @param {String} phone
+     *
+     * @return {bool}
+     */
+    isValidE164Phone(phone) {
+        return CONST.SMS.E164_REGEX.test(phone);
     },
 
     /**

--- a/lib/str.js
+++ b/lib/str.js
@@ -930,7 +930,7 @@ const Str = {
      * significant: 4404589784
      * international: +1 440-458-9784
      * e164: +14404589784
-     * national: (440) 458-978
+     * national: (440) 458-9784
      * 123.456.7890
      * @param {String} phone
      *

--- a/lib/str.js
+++ b/lib/str.js
@@ -930,7 +930,7 @@ const Str = {
      * @param {String} phone
      *
      * @return {bool}
-     * @deprecated use isValidE164Phone instead
+     * @deprecated use isValidE164Phone to validate E.164 phone numbers or isValidPhoneFormat to validate phone numbers in general
      */
     isValidPhone(phone) {
         return CONST.SMS.E164_REGEX.test(phone);

--- a/lib/str.js
+++ b/lib/str.js
@@ -926,12 +926,12 @@ const Str = {
     },
 
     /**
-     * Check for whether a phone number is valid.
+     * Check for whether a phone number is valid according to E.164 standard.
      * @param {String} phone
      *
      * @return {bool}
      */
-    isValidPhone(phone) {
+    isValidE164Phone(phone) {
         return CONST.SMS.E164_REGEX.test(phone);
     },
 
@@ -965,13 +965,13 @@ const Str = {
     },
 
     /**
-     * Returns true if the text is a valid phone number with our SMS domain removed
+     * Returns true if the text is a valid E.164 phone number with our SMS domain removed
      *
      * @param {String} text
      * @return {String}
      */
     isSMSLogin(text) {
-        return this.isValidPhone(this.removeSMSDomain(text));
+        return this.isValidE164Phone(this.removeSMSDomain(text));
     },
 
     /**

--- a/lib/str.js
+++ b/lib/str.js
@@ -926,18 +926,14 @@ const Str = {
     },
 
     /**
-     * Check for whether a phone number is valid in different formats/standards. For example:
-     * significant: 4404589784
-     * international: +1 440-458-9784
-     * e164: +14404589784
-     * national: (440) 458-9784
-     * 123.456.7890
+     * Check for whether a phone number is valid.
      * @param {String} phone
      *
      * @return {bool}
+     * @deprecated use isValidE164Phone instead
      */
     isValidPhone(phone) {
-        return CONST.REG_EXP.GENERAL_PHONE_PART.test(phone);
+        return CONST.SMS.E164_REGEX.test(phone);
     },
 
     /**
@@ -948,6 +944,21 @@ const Str = {
      */
     isValidE164Phone(phone) {
         return CONST.SMS.E164_REGEX.test(phone);
+    },
+
+    /**
+     * Check for whether a phone number is valid in different formats/standards. For example:
+     * significant: 4404589784
+     * international: +1 440-458-9784
+     * e164: +14404589784
+     * national: (440) 458-9784
+     * 123.456.7890
+     * @param {String} phone
+     *
+     * @return {bool}
+     */
+    isValidPhoneFormat(phone) {
+        return CONST.REG_EXP.GENERAL_PHONE_PART.test(phone);
     },
 
     /**


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

Current `isValidPhone` function only validates E.164 standard phone numbers but not others causing misunderstandings and worng usages. This PR:
1. Mark `isValidPhone` as deprecated
2. Replace `isValidPhone` with `isValidE164Phone`
3. Add a new `isValidPhoneFormat` to validate phone numbers in different formats

```
significant: 4404589784
international: +1 440-458-9784
e164: +14404589784
national: (440) 458-9784
123.456.7890
```

### Fixed Issues
$ https://github.com/Expensify/App/issues/37723

# Tests
**1. What unit/integration tests cover your change? What autoQA tests cover your change?**

This is a renaming refactor so no need to add new unit tests.

**2. What tests did you perform that validates your changed worked?**

- Test in Expensify App follow these steps:

1. Go to Workspace > Bank account.
4. Initiate the add BA flow
5. Proceed to Company's phone number step
6. Enter a random US number in national format `(xxx) xxx-xxxx`, e.g., "(440) 458-9784"
7. Press Next
8. Verify that the phone number is parsed successfully

# QA

**1. What does QA need to do to validate your changes?**

Test in Expensify App follow these steps:

1. Go to Workspace > Bank account.
2. Initiate the add BA flow
3. Proceed to Company's phone number step
4. Enter a random US number in national format `(xxx) xxx-xxxx`, e.g., "(440) 458-9784"
5. Press Next
6. Verify that the phone number is parsed successfully


**2. What areas to they need to test for regressions?**

NA

# Screenshots

https://github.com/Expensify/expensify-common/assets/113963320/51e85355-96ae-43b4-a010-bbf2be1a7c18

