### PR TITLE
Allow indented text in quotes

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1090,6 +1090,13 @@ test('Test quotes markdown replacement with text includes blank quotes', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test quotes markdown replacement with text includes multiple spaces', () => {
+    const quoteTestStartString = '>No indent\n>   Keep both  \n>     Keep leading ';
+    const quoteTestReplacedString = '<blockquote>No indent<br />  Keep both  <br />    Keep leading</blockquote>';
+
+    expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
+});
+
 test('Single char matching', () => {
     const testString = ' *1* char _1_ char ~1~ char';
     const resultString = ' <strong>1</strong> char <em>1</em> char <del>1</del> char';
@@ -1862,14 +1869,14 @@ describe('multi-level blockquote', () => {
     });
     test('multi-level blockquote with multiple spaces', () => {
         const quoteTestStartString = '>  >   >      Hello world';
-        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>Hello world</blockquote></blockquote></blockquote>';
+        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>     Hello world</blockquote></blockquote></blockquote>';
 
         expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
     });
 
     test('multi-level blockquote with mixed spaces', () => {
         const quoteTestStartString = '>  > >   Hello world';
-        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>Hello world</blockquote></blockquote></blockquote>';
+        const quoteTestReplacedString = '<blockquote><blockquote><blockquote>  Hello world</blockquote></blockquote></blockquote>';
 
         expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
     });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1091,9 +1091,8 @@ test('Test quotes markdown replacement with text includes blank quotes', () => {
 });
 
 test('Test quotes markdown replacement with text includes multiple spaces', () => {
-    const quoteTestStartString = '>No indent\n>   Keep both  \n>     Keep leading ';
-    const quoteTestReplacedString = '<blockquote>No indent<br />  Keep both  <br />    Keep leading</blockquote>';
-
+    const quoteTestStartString = '>   Indented\n>No indent\n>   Indented  \n> >   Nested indented  \n>     Indented ';
+    const quoteTestReplacedString = '<blockquote>  Indented<br />No indent<br />  Indented  <br /><blockquote>  Nested indented  </blockquote>    Indented </blockquote>';
     expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
 });
 
@@ -1171,7 +1170,7 @@ test('Test heading1 markdown replacement with line break before or after the hea
 
 test('Test heading1 markdown replacement when heading appear after the quote', () => {
     const testString = '> quote \n# heading 1 after the quote.\nHere is a multi-line\ncomment that contains *bold* string.';
-    expect(parser.replace(testString)).toBe('<blockquote>quote</blockquote><h1>heading 1 after the quote.</h1>Here is a multi-line<br />comment that contains <strong>bold</strong> string.');
+    expect(parser.replace(testString)).toBe('<blockquote>quote </blockquote><h1>heading 1 after the quote.</h1>Here is a multi-line<br />comment that contains <strong>bold</strong> string.');
 });
 
 // Valid text that should match for user mentions

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -874,13 +874,13 @@ export default class ExpensiMark {
             let textToFormat = textToCheck.split('\n').map((row) => {
                 const quoteContent = row[4] === ' ' ? row.substr(5) : row.substr(4);
                 if (quoteContent.trim().startsWith('&gt;')) {
-                    return quoteContent.trim();
+                    return quoteContent.trimStart();
                 }
                 return quoteContent;
             }).join('\n');
 
             // Remove leading and trailing line breaks
-            textToFormat = textToFormat.trimEnd().replace(/^\s*\n/, '');
+            textToFormat = textToFormat.replace(/^\n*|\n*$/g, '');
             return replacement(textToFormat);
         }
         return textToCheck;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -873,7 +873,7 @@ export default class ExpensiMark {
             // Remove '&gt;' and trim the spaces between nested quotes
             let textToFormat = textToCheck.split('\n').map((row) => {
                 const quoteContent = row[4] === ' ' ? row.substr(5) : row.substr(4);
-                if (quoteContent.trim().startsWith('&gt;')) {
+                if (quoteContent.trimStart().startsWith('&gt;')) {
                     return quoteContent.trimStart();
                 }
                 return quoteContent;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -870,11 +870,17 @@ export default class ExpensiMark {
      */
     formatTextForQuote(regex, textToCheck, replacement) {
         if (textToCheck.match(regex)) {
-            // Remove '&gt;' and trim each line of quote content
-            let textToFormat = textToCheck.split('\n').map(row => row.substr(4).trim()).join('\n');
-
+            // Remove '&gt;' and trim the spaces between nested quotes
+            let textToFormat = textToCheck.split('\n').map(row => {
+                const quoteContent = row[4] === ' ' ? row.substr(5) : row.substr(4);
+                if (quoteContent.trim().startsWith('&gt;')) {
+                    return quoteContent.trim();
+                }
+                return quoteContent;
+            }).join('\n');
+    
             // Remove leading and trailing line breaks
-            textToFormat = textToFormat.trim();
+            textToFormat = textToFormat.trimEnd().replace(/^\s*\n/, '');
             return replacement(textToFormat);
         }
         return textToCheck;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -871,14 +871,14 @@ export default class ExpensiMark {
     formatTextForQuote(regex, textToCheck, replacement) {
         if (textToCheck.match(regex)) {
             // Remove '&gt;' and trim the spaces between nested quotes
-            let textToFormat = textToCheck.split('\n').map(row => {
+            let textToFormat = textToCheck.split('\n').map((row) => {
                 const quoteContent = row[4] === ' ' ? row.substr(5) : row.substr(4);
                 if (quoteContent.trim().startsWith('&gt;')) {
                     return quoteContent.trim();
                 }
                 return quoteContent;
             }).join('\n');
-    
+
             // Remove leading and trailing line breaks
             textToFormat = textToFormat.trimEnd().replace(/^\s*\n/, '');
             return replacement(textToFormat);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -880,7 +880,7 @@ export default class ExpensiMark {
             }).join('\n');
 
             // Remove leading and trailing line breaks
-            textToFormat = textToFormat.replace(/^\n*|\n*$/g, '');
+            textToFormat = textToFormat.replace(/^\n+|\n+$/g, '');
             return replacement(textToFormat);
         }
         return textToCheck;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This PR enables indented text to show as is (do not trim the spaces) in quotes.

### Fixed Issues
$ https://github.com/Expensify/App/issues/38156

# Tests
**1. What unit/integration tests cover your change? What autoQA tests cover your change?**

The `ExpensiMark-HTML-test.js` is updated to include the new test cases and modify existing tests to match with new expected behaviors.

**2. What tests did you perform that validates your changed worked?**

- Run the unit test.
- Test in Expensify App follow these steps:

1. Send a quote message with indentation:

```
> No indent
>     Indented 4
```

2. Verify the `Indented 4` line shows with 4-space indentation in quote

# QA
**1. What does QA need to do to validate your changes?**

Test in Expensify App follow these steps:

1. Send a quote message with indentation:

```
> No indent
>     Indented 4
```

2. Verify the `Indented 4` line shows with 4-space indentation in quote

**2. What areas to they need to test for regressions?**

# Screenshots

https://github.com/Expensify/expensify-common/assets/113963320/beb8e130-03e0-487d-932e-ddef9952ebb5


