### PR TITLE
Fixed phone number regex

### DIFF
--- a/__tests__/Str-test.js
+++ b/__tests__/Str-test.js
@@ -204,6 +204,9 @@ describe('Str.isValidPhoneFormat', () => {
         // US national standard
         expect(Str.isValidPhoneFormat('(440) 458-9784')).toBeTruthy();
         expect(Str.isValidPhoneFormat('123.456.7890')).toBeTruthy();
+
+        // Invalid numbers
+        expect(Str.isValidPhoneFormat('=15123456789')).toBeFalsy();
     });
 });
 

--- a/lib/CONST.jsx
+++ b/lib/CONST.jsx
@@ -295,7 +295,7 @@ export const CONST = {
         *
         * @type RegExp
         */
-        GENERAL_PHONE_PART: /(\+\d{1,2}\s?)?(\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}/,
+        GENERAL_PHONE_PART: /^(\+\d{1,2}\s?)?(\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/,
 
         /**
         * Regex matching a text containing an E.164 format phone number


### PR DESCRIPTION
Corrected the phone number regex by adding the startswith(^) and endswith($) characters. Follow-up of PR https://github.com/Expensify/expensify-common/pull/672
cc: @grgia 

### Fixed Issues
$ https://github.com/Expensify/App/issues/37723
https://github.com/Expensify/App/issues/37723#issuecomment-2036724546

# Tests
1. Unit tests have been updated in tests/Str-test.js to cover invalid number scenario.

https://github.com/Expensify/expensify-common/assets/14358475/d2970351-7f52-45e3-8d29-f996de12f9b2

