### PR TITLE
fix LHN preview shows incorrect message with attachment

### DIFF
--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -149,5 +149,5 @@ test('Mention html to text', () => {
 
 test('Test replacement for <img> tags', () => {
     const testString = '<img src="https://example.com/image.png" alt="Image description" />';
-    expect(parser.htmlToText(testString)).toBe('(image of: Image description)');
+    expect(parser.htmlToText(testString)).toBe('[Attachment]');
 });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -476,7 +476,7 @@ export default class ExpensiMark {
             {
                 name: 'image',
                 regex: /<img[^><]*src\s*=\s*(['"])(.*?)\1(?:[^><]*alt\s*=\s*(['"])(.*?)\3)?[^><]*>*(?![^<][\s\S]*?(<\/pre>|<\/code>))/gi,
-                replacement: '(image of: $4)',
+                replacement: '[Attachment]',
             },
             {
                 name: 'stripTag',


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/38877

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. Go to staging.new.expensify.com
2. Go to any chat
3. Send a message with inline image markdown. Example:
```
An inline image and some text ![off](https://images.unsplash.com/photo-1709983723739-d72ea88434dd?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
```

4. Go to a different chat
5. Go back to the chat in Step 3
6. Verify that LHN preview will show "text [Attachment]" format after returning to the same chat