### PR TITLE
fix bold markdown display incorrectly

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -298,7 +298,7 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /\B\*((?![\s*])[\s\S]*?[^\s*])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                regex: /\B\*(?![^<]*(?:<\/pre>|<\/code>|<\/a>))((?![\s*])[\s\S]*?[^\s*])\*\B(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
                 replacement: (match, g1) => (g1.includes('</pre>') || this.containsNonPairTag(g1) ? match : `<strong>${g1}</strong>`),
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ Issue: https://github.com/Expensify/App/issues/38522
$ Proposal: https://github.com/Expensify/App/issues/38522#issuecomment-2009006697

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. Open any report
2. Compose a multiline message with bold and codeblock:
``` 
bold
```*not a bold*```
This is *bold* 
```
3. Should render
bold
```*not a bold*```
This is **bold**

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/113963320/b4cf5890-8de7-432f-abbf-d10a478cb3ad





</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->



https://github.com/Expensify/expensify-common/assets/113963320/ceb2595d-5dc9-442a-8fc8-5068823f7955






</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
- I encountered an issue with my ios native device. Will update ASAP


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/Expensify/expensify-common/assets/113963320/6ca2c178-a396-4092-9a41-388f7fdcd0a1



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/expensify-common/assets/113963320/5a7bd8fd-f3ac-41c8-a166-8c888de6e7c2




</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/expensify-common/assets/113963320/0b311530-308f-47e2-b167-5d01a75dc65b





</details>

