### PR TITLE
Add possibility to pass additional info for Html -> markdown parser

### DIFF
--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -133,7 +133,7 @@ test('Test remove style tag', () => {
     expect(parser.htmlToText(testString)).toBe('a text');
 });
 
-test('Mention html to text', () => {
+test('Mention user html to text', () => {
     let testString = '<mention-user>@user@domain.com</mention-user>';
     expect(parser.htmlToText(testString)).toBe('@user@domain.com');
 
@@ -145,6 +145,36 @@ test('Mention html to text', () => {
 
     testString = '<mention-user>@user@DOMAIN.com</mention-user>';
     expect(parser.htmlToText(testString)).toBe('@user@DOMAIN.com');
+
+    const extras = {
+        "accountIdToName": {
+            "1234": "@user@domain.com"
+        }
+    }
+    testString = '<mention-user accountID="1234" />';
+    expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
+});
+
+test('Mention report html to text', () => {
+    let testString = '<mention-report>#room-name</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#room-name');
+
+    testString = '<mention-report>#ROOM-NAME</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#ROOM-NAME');
+
+    testString = '<mention-report>#ROOM-name</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#ROOM-name');
+
+    testString = '<mention-report>#room-NAME</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#room-NAME');
+
+    const extras = {
+        "reportIdToName": {
+            "1234": "#room-name"
+        }
+    }
+    testString = '<mention-report reportID="1234" />';
+    expect(parser.htmlToText(testString, extras)).toBe('#room-name');
 });
 
 test('Test replacement for <img> tags', () => {

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -147,10 +147,13 @@ test('Mention user html to text', () => {
     expect(parser.htmlToText(testString)).toBe('@user@DOMAIN.com');
 
     const extras = {
-        "accountIdToName": {
-            "1234": "@user@domain.com"
-        }
-    }
+        accountIdToName: {
+            '1234': 'user@domain.com',
+        },
+    };
+    testString = '<mention-user accountID="1234"/>';
+    expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
+
     testString = '<mention-user accountID="1234" />';
     expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
 });
@@ -169,10 +172,13 @@ test('Mention report html to text', () => {
     expect(parser.htmlToText(testString)).toBe('#room-NAME');
 
     const extras = {
-        "reportIdToName": {
-            "1234": "#room-name"
-        }
-    }
+        reportIdToName: {
+            '1234': '#room-name',
+        },
+    };
+    testString = '<mention-report reportID="1234"/>';
+    expect(parser.htmlToText(testString, extras)).toBe('#room-name');
+
     testString = '<mention-report reportID="1234" />';
     expect(parser.htmlToText(testString, extras)).toBe('#room-name');
 });

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -743,7 +743,7 @@ test('Linebreak should be remained for text between code block', () => {
     });
 });
 
-test('Mention html to markdown', () => {
+test('Mention user html to markdown', () => {
     let testString = '<mention-user>@user@domain.com</mention-user>';
     expect(parser.htmlToMarkdown(testString)).toBe('@user@domain.com');
 
@@ -755,6 +755,36 @@ test('Mention html to markdown', () => {
 
     testString = '<mention-user>@user@DOMAIN.com</mention-user>';
     expect(parser.htmlToMarkdown(testString)).toBe('@user@DOMAIN.com');
+
+    const extras = {
+        "accountIdToName": {
+            "1234": "@user@domain.com"
+        }
+    }
+    testString = '<mention-user accountID="1234" />';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
+});
+
+test('Mention report html to markdown', () => {
+    let testString = '<mention-report>#room-name</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#room-name');
+
+    testString = '<mention-report>#ROOM-NAME</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#ROOM-NAME');
+
+    testString = '<mention-report>#ROOM-name</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#ROOM-name');
+
+    testString = '<mention-report>#room-NAME</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#room-NAME');
+
+    const extras = {
+        "reportIdToName": {
+            "1234": "#room-name"
+        }
+    }
+    testString = '<mention-report reportID="1234" />';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
 });
 
 describe('Image tag conversion to markdown', () => {

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -4,14 +4,16 @@ import ExpensiMark from '../lib/ExpensiMark';
 const parser = new ExpensiMark();
 
 test('Test bold HTML replacement', () => {
-    const boldTestStartString = 'This is a <strong>sentence,</strong> and it has some <strong>punctuation, words, and spaces</strong>. '
-        + '<strong>test</strong> * testing* test*test*test. * testing * *testing * '
-        + 'This is a <b>sentence,</b> and it has some <b>punctuation, words, and spaces</b>. '
-        + '<b>test</b> * testing* test*test*test. * testing * *testing *';
-    const boldTestReplacedString = 'This is a *sentence,* and it has some *punctuation, words, and spaces*. '
-        + '*test* * testing* test*test*test. * testing * *testing * '
-        + 'This is a *sentence,* and it has some *punctuation, words, and spaces*. '
-        + '*test* * testing* test*test*test. * testing * *testing *';
+    const boldTestStartString =
+        'This is a <strong>sentence,</strong> and it has some <strong>punctuation, words, and spaces</strong>. ' +
+        '<strong>test</strong> * testing* test*test*test. * testing * *testing * ' +
+        'This is a <b>sentence,</b> and it has some <b>punctuation, words, and spaces</b>. ' +
+        '<b>test</b> * testing* test*test*test. * testing * *testing *';
+    const boldTestReplacedString =
+        'This is a *sentence,* and it has some *punctuation, words, and spaces*. ' +
+        '*test* * testing* test*test*test. * testing * *testing * ' +
+        'This is a *sentence,* and it has some *punctuation, words, and spaces*. ' +
+        '*test* * testing* test*test*test. * testing * *testing *';
 
     expect(parser.htmlToMarkdown(boldTestStartString)).toBe(boldTestReplacedString);
 });
@@ -24,10 +26,12 @@ test('Test multi-line bold HTML replacement', () => {
 });
 
 test('Test italic HTML replacement', () => {
-    const italicTestStartString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _ '
-        + 'This is a <i>sentence,</i> and it has some <i>punctuation, words, and spaces</i>. <i>test</i> _ testing_ test_test_test. _ test _ _test _';
-    const italicTestReplacedString = 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _ '
-        + 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _';
+    const italicTestStartString =
+        'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _ ' +
+        'This is a <i>sentence,</i> and it has some <i>punctuation, words, and spaces</i>. <i>test</i> _ testing_ test_test_test. _ test _ _test _';
+    const italicTestReplacedString =
+        'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _ ' +
+        'This is a _sentence,_ and it has some _punctuation, words, and spaces_. _test_ _ testing_ test_test_test. _ test _ _test _';
     expect(parser.htmlToMarkdown(italicTestStartString)).toBe(italicTestReplacedString);
 });
 
@@ -40,7 +44,8 @@ test('Test multi-line italic HTML replacement', () => {
 
 // Words wrapped in <del></del> or <s></s> successfully replaced with ~
 test('Test strikethrough HTML replacement', () => {
-    const strikethroughTestStartString = 'This is a <del>sentence,</del> and it has some <del>punctuation, words, and spaces</del>. <s>test</s> ~ testing~ test~test~test. ~ testing ~ ~testing ~';
+    const strikethroughTestStartString =
+        'This is a <del>sentence,</del> and it has some <del>punctuation, words, and spaces</del>. <s>test</s> ~ testing~ test~test~test. ~ testing ~ ~testing ~';
     const strikethroughTestReplacedString = 'This is a ~sentence,~ and it has some ~punctuation, words, and spaces~. ~test~ ~ testing~ test~test~test. ~ testing ~ ~testing ~';
     expect(parser.htmlToMarkdown(strikethroughTestStartString)).toBe(strikethroughTestReplacedString);
 });
@@ -87,7 +92,8 @@ test('Test HTML string with attributes', () => {
 });
 
 test('Test HTML string with spcial Tags', () => {
-    const testString = '<html>\n<body>\n<!--StartFragment--><span style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">test message</span><!--EndFragment-->\n</body>\n</html>\n';
+    const testString =
+        '<html>\n<body>\n<!--StartFragment--><span style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">test message</span><!--EndFragment-->\n</body>\n</html>\n';
     const resultString = 'test message';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
@@ -136,13 +142,15 @@ test('Test HTML string with encoded entities', () => {
 });
 
 test('Test HTML string with blockquote', () => {
-    const testString = '<blockquote><p>This GH seems to assume that there will be something in the paste\nbuffer when you copy block-quoted text out of slack. But when I dump\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\nbuffer, then dump it into terminal, there\'s nothing. And if I dump it </blockquote>'
-        + '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>'
-        + '<blockquote style="color:red;" data-label="note">line1 <em>lorem ipsum</em></blockquote>';
+    const testString =
+        "<blockquote><p>This GH seems to assume that there will be something in the paste\nbuffer when you copy block-quoted text out of slack. But when I dump\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\nbuffer, then dump it into terminal, there's nothing. And if I dump it </blockquote>" +
+        '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>' +
+        '<blockquote style="color:red;" data-label="note">line1 <em>lorem ipsum</em></blockquote>';
 
-    const resultString = '> This GH seems to assume that there will be something in the paste\n> buffer when you copy block-quoted text out of slack. But when I dump\n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> buffer, then dump it into terminal, there\'s nothing. And if I dump it\n'
-        + '> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n'
-        + '> line1 _lorem ipsum_';
+    const resultString =
+        "> This GH seems to assume that there will be something in the paste\n> buffer when you copy block-quoted text out of slack. But when I dump\n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> buffer, then dump it into terminal, there's nothing. And if I dump it\n" +
+        '> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n' +
+        '> line1 _lorem ipsum_';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
@@ -156,40 +164,44 @@ test('Test HTML string with InlineCodeBlock', () => {
 });
 
 test('Test wrapped anchor tags', () => {
-    const wrappedUrlTestStartString = '<del><a href="https://www.example.com" target="_blank">https://www.example.com</a></del> <em><a href="http://www.test.com" target="_blank">http://www.test.com</a></em>'
-        + ' <strong><a href="http://www.asdf.com/_test" target="_blank">http://www.asdf.com/_test</a></strong>';
-    const wrappedUrlTestReplacedString = '~[https://www.example.com](https://www.example.com)~ _[http://www.test.com](http://www.test.com)_ *[http://www.asdf.com/_test](http://www.asdf.com/_test)*';
+    const wrappedUrlTestStartString =
+        '<del><a href="https://www.example.com" target="_blank">https://www.example.com</a></del> <em><a href="http://www.test.com" target="_blank">http://www.test.com</a></em>' +
+        ' <strong><a href="http://www.asdf.com/_test" target="_blank">http://www.asdf.com/_test</a></strong>';
+    const wrappedUrlTestReplacedString =
+        '~[https://www.example.com](https://www.example.com)~ _[http://www.test.com](http://www.test.com)_ *[http://www.asdf.com/_test](http://www.asdf.com/_test)*';
     expect(parser.htmlToMarkdown(wrappedUrlTestStartString)).toBe(wrappedUrlTestReplacedString);
 });
 
 test('Test acnchor tags convesion to markdown style link with various styles', () => {
-    const testString = 'Go to <del><a href="https://www.expensify.com" target="_blank">Expensify</a></del> '
-        + '<em><a href="https://www.expensify.com" target="_blank">Expensify</a></em> '
-        + '<strong><a href="https://www.expensify.com" target="_blank">Expensify</a></strong> '
-        + '<a href="https://www.expensify.com" target="_blank">Expensify!</a> '
-        + '<a href="https://www.expensify.com" target="_blank">Expensify?</a> '
-        + '<a href="https://www.expensify-test.com" target="_blank">Expensify</a> '
-        + '<a href="https://www.expensify-test.com" target="_blank"><strong>Expensify</strong></a> '
-        + '<a href="https://www.expensify-test.com" target="_blank">test.com</a> '
-        + '<a href="https://www.expensify-test.com" target="_blank"><em>italic</em> <del>strikethrough</del> test.com</a> '
-        + '<a href="https://www.text.com/_root_folder/1" target="_blank">https://www.text.com/_root_folder/1</a> '
-        + '<a href="https://www.expensify.com/settings?param={%22section%22:%22account%22}" target="_blank">Expensify</a> '
-        + '<a href="https://www.expensify.com/settings?param=(%22section%22+%22account%22)" target="_blank">Expensify</a> '
-        + '<a href="https://www.expensify.com/settings?param=[%22section%22:%22account%22]" target="_blank">Expensify</a>';
+    const testString =
+        'Go to <del><a href="https://www.expensify.com" target="_blank">Expensify</a></del> ' +
+        '<em><a href="https://www.expensify.com" target="_blank">Expensify</a></em> ' +
+        '<strong><a href="https://www.expensify.com" target="_blank">Expensify</a></strong> ' +
+        '<a href="https://www.expensify.com" target="_blank">Expensify!</a> ' +
+        '<a href="https://www.expensify.com" target="_blank">Expensify?</a> ' +
+        '<a href="https://www.expensify-test.com" target="_blank">Expensify</a> ' +
+        '<a href="https://www.expensify-test.com" target="_blank"><strong>Expensify</strong></a> ' +
+        '<a href="https://www.expensify-test.com" target="_blank">test.com</a> ' +
+        '<a href="https://www.expensify-test.com" target="_blank"><em>italic</em> <del>strikethrough</del> test.com</a> ' +
+        '<a href="https://www.text.com/_root_folder/1" target="_blank">https://www.text.com/_root_folder/1</a> ' +
+        '<a href="https://www.expensify.com/settings?param={%22section%22:%22account%22}" target="_blank">Expensify</a> ' +
+        '<a href="https://www.expensify.com/settings?param=(%22section%22+%22account%22)" target="_blank">Expensify</a> ' +
+        '<a href="https://www.expensify.com/settings?param=[%22section%22:%22account%22]" target="_blank">Expensify</a>';
 
-    const resultString = 'Go to ~[Expensify](https://www.expensify.com)~ '
-        + '_[Expensify](https://www.expensify.com)_ '
-        + '*[Expensify](https://www.expensify.com)* '
-        + '[Expensify!](https://www.expensify.com) '
-        + '[Expensify?](https://www.expensify.com) '
-        + '[Expensify](https://www.expensify-test.com) '
-        + '[*Expensify*](https://www.expensify-test.com) '
-        + '[test.com](https://www.expensify-test.com) '
-        + '[_italic_ ~strikethrough~ test.com](https://www.expensify-test.com) '
-        + '[https://www.text.com/_root_folder/1](https://www.text.com/_root_folder/1) '
-        + '[Expensify](https://www.expensify.com/settings?param={%22section%22:%22account%22}) '
-        + '[Expensify](https://www.expensify.com/settings?param=(%22section%22+%22account%22)) '
-        + '[Expensify](https://www.expensify.com/settings?param=[%22section%22:%22account%22])';
+    const resultString =
+        'Go to ~[Expensify](https://www.expensify.com)~ ' +
+        '_[Expensify](https://www.expensify.com)_ ' +
+        '*[Expensify](https://www.expensify.com)* ' +
+        '[Expensify!](https://www.expensify.com) ' +
+        '[Expensify?](https://www.expensify.com) ' +
+        '[Expensify](https://www.expensify-test.com) ' +
+        '[*Expensify*](https://www.expensify-test.com) ' +
+        '[test.com](https://www.expensify-test.com) ' +
+        '[_italic_ ~strikethrough~ test.com](https://www.expensify-test.com) ' +
+        '[https://www.text.com/_root_folder/1](https://www.text.com/_root_folder/1) ' +
+        '[Expensify](https://www.expensify.com/settings?param={%22section%22:%22account%22}) ' +
+        '[Expensify](https://www.expensify.com/settings?param=(%22section%22+%22account%22)) ' +
+        '[Expensify](https://www.expensify.com/settings?param=[%22section%22:%22account%22])';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
@@ -219,165 +231,167 @@ test('Test anchor tags where links ending with a closing parentheses', () => {
 });
 
 test('Test anchor tags where links are markdown style email link with various styles', () => {
-    const testString = 'Go to <del><a href="mailto:concierge@expensify.com">Expensify</a></del> '
-        + '<em><a href="mailto:concierge@expensify.com">Expensify</a></em> '
-        + '<strong><a href="mailto:concierge@expensify.com">Expensify</a></strong> '
-        + '<a href="mailto:no-concierge1@expensify.com">Expensify!</a> '
-        + '<a href="mailto:concierge?@expensify.com">Expensify?</a> '
-        + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">Applause</a> '
-        + '<a href="mailto:concierge@expensify.com"></a>'
-        + '<a href="mailto:concierge@expensify.com">   </a>'
-        + '<a href="mailto:concierge@expensify.com"> Expensify </a>'
-        + '<a href="mailto:concierge@expensify.com"> Expensify Email </a>'
-        + '<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>'
-        + '<a href="mailto:concierge@expensify.com">concierge-other@expensify.com</a>'
-        + '<a href="mailto:concierge@expensify.com">(Expensify)</a>'
-        + '[Expensify <a href="mailto:test@expensify.com">Test</a> Test](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)'
-        + '[Expensify <a href="mailto:concierge@expensify.com">Test</a>'
-        + '[Expensify ]Test](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)';
+    const testString =
+        'Go to <del><a href="mailto:concierge@expensify.com">Expensify</a></del> ' +
+        '<em><a href="mailto:concierge@expensify.com">Expensify</a></em> ' +
+        '<strong><a href="mailto:concierge@expensify.com">Expensify</a></strong> ' +
+        '<a href="mailto:no-concierge1@expensify.com">Expensify!</a> ' +
+        '<a href="mailto:concierge?@expensify.com">Expensify?</a> ' +
+        '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">Applause</a> ' +
+        '<a href="mailto:concierge@expensify.com"></a>' +
+        '<a href="mailto:concierge@expensify.com">   </a>' +
+        '<a href="mailto:concierge@expensify.com"> Expensify </a>' +
+        '<a href="mailto:concierge@expensify.com"> Expensify Email </a>' +
+        '<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>' +
+        '<a href="mailto:concierge@expensify.com">concierge-other@expensify.com</a>' +
+        '<a href="mailto:concierge@expensify.com">(Expensify)</a>' +
+        '[Expensify <a href="mailto:test@expensify.com">Test</a> Test](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)' +
+        '[Expensify <a href="mailto:concierge@expensify.com">Test</a>' +
+        '[Expensify ]Test](<a href="mailto:concierge@expensify.com">concierge@expensify.com</a>)';
 
-    const resultString = 'Go to ~[Expensify](concierge@expensify.com)~ '
-        + '_[Expensify](concierge@expensify.com)_ '
-        + '*[Expensify](concierge@expensify.com)* '
-        + '[Expensify!](no-concierge1@expensify.com) '
-        + '[Expensify?](concierge?@expensify.com) '
-        + '[Applause](applausetester+qaabecciv@applause.expensifail.com) '
-        + '[](concierge@expensify.com)'
-        + '[   ](concierge@expensify.com)'
-        + '[ Expensify ](concierge@expensify.com)'
-        + '[ Expensify Email ](concierge@expensify.com)'
-        + 'concierge@expensify.com'
-        + '[concierge-other@expensify.com](concierge@expensify.com)'
-        + '[(Expensify)](concierge@expensify.com)'
-        + '[Expensify [Test](test@expensify.com) Test](concierge@expensify.com)'
-        + '[Expensify [Test](concierge@expensify.com)'
-        + '[Expensify ]Test](concierge@expensify.com)';
+    const resultString =
+        'Go to ~[Expensify](concierge@expensify.com)~ ' +
+        '_[Expensify](concierge@expensify.com)_ ' +
+        '*[Expensify](concierge@expensify.com)* ' +
+        '[Expensify!](no-concierge1@expensify.com) ' +
+        '[Expensify?](concierge?@expensify.com) ' +
+        '[Applause](applausetester+qaabecciv@applause.expensifail.com) ' +
+        '[](concierge@expensify.com)' +
+        '[   ](concierge@expensify.com)' +
+        '[ Expensify ](concierge@expensify.com)' +
+        '[ Expensify Email ](concierge@expensify.com)' +
+        'concierge@expensify.com' +
+        '[concierge-other@expensify.com](concierge@expensify.com)' +
+        '[(Expensify)](concierge@expensify.com)' +
+        '[Expensify [Test](test@expensify.com) Test](concierge@expensify.com)' +
+        '[Expensify [Test](concierge@expensify.com)' +
+        '[Expensify ]Test](concierge@expensify.com)';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test anchor tags with general email link', () => {
-    const testString = 'Go to <a href="mailto:concierge@expensify.com">concierge@expensify.com</a> '
-        + '<a href="mailto:no-concierge@expensify.com">no-concierge@expensify.com</a> '
-        + '<a href="mailto:concierge!@expensify.com">concierge!@expensify.com</a> '
-        + '<a href="mailto:concierge1?@expensify.com">concierge1?@expensify.com</a> '
-        + '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">applausetester+qaabecciv@applause.expensifail.com</a> ';
-    const resultString = 'Go to concierge@expensify.com '
-        + 'no-concierge@expensify.com '
-        + 'concierge!@expensify.com '
-        + 'concierge1?@expensify.com '
-        + 'applausetester+qaabecciv@applause.expensifail.com ';
+    const testString =
+        'Go to <a href="mailto:concierge@expensify.com">concierge@expensify.com</a> ' +
+        '<a href="mailto:no-concierge@expensify.com">no-concierge@expensify.com</a> ' +
+        '<a href="mailto:concierge!@expensify.com">concierge!@expensify.com</a> ' +
+        '<a href="mailto:concierge1?@expensify.com">concierge1?@expensify.com</a> ' +
+        '<a href="mailto:applausetester+qaabecciv@applause.expensifail.com">applausetester+qaabecciv@applause.expensifail.com</a> ';
+    const resultString =
+        'Go to concierge@expensify.com ' + 'no-concierge@expensify.com ' + 'concierge!@expensify.com ' + 'concierge1?@expensify.com ' + 'applausetester+qaabecciv@applause.expensifail.com ';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test anchor tags where links have inconsistent starting and closing parens', () => {
-    const testString = '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
-        + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) '
-        + '(<a href="https://google.com/" target="_blank">google</a>) '
-        + '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>))) '
-        + '(((<a href="http://google.com/(something)?after=parens" target="_blank">google</a> '
-        + '(<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>) '
-        + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> '
-        + '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
-        + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) '
-        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat)</a> '
-        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click here to see a cool cat)</a> '
-        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat</a> '
-        + '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click * $ &amp; here to see a cool cat</a> ';
+    const testString =
+        '<a href="http://google.com/(something)?after=parens" target="_blank">google</a> ' +
+        '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>) ' +
+        '(<a href="https://google.com/" target="_blank">google</a>) ' +
+        '(<a href="http://google.com/(something)?after=parens" target="_blank">google</a>))) ' +
+        '(((<a href="http://google.com/(something)?after=parens" target="_blank">google</a> ' +
+        '(<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>) ' +
+        '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> ' +
+        '(((<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ' +
+        '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a>))) ' +
+        '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat)</a> ' +
+        '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click here to see a cool cat)</a> ' +
+        '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo (click here to see a cool cat</a> ' +
+        '<a href="https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg" target="_blank">Yo click * $ &amp; here to see a cool cat</a> ';
 
-    const resultString = '[google](http://google.com/(something)?after=parens) '
-        + '([google](http://google.com/(something)?after=parens)) '
-        + '([google](https://google.com/)) '
-        + '([google](http://google.com/(something)?after=parens)))) '
-        + '((([google](http://google.com/(something)?after=parens) '
-        + '([http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens)) '
-        + '((([http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens) '
-        + '((([http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens)))) '
-        + '[http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens)))) '
-        + '[Yo (click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
-        + '[Yo click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
-        + '[Yo (click here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) '
-        + '[Yo click * $ & here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) ';
+    const resultString =
+        '[google](http://google.com/(something)?after=parens) ' +
+        '([google](http://google.com/(something)?after=parens)) ' +
+        '([google](https://google.com/)) ' +
+        '([google](http://google.com/(something)?after=parens)))) ' +
+        '((([google](http://google.com/(something)?after=parens) ' +
+        '([http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens)) ' +
+        '((([http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens) ' +
+        '((([http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens)))) ' +
+        '[http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens)))) ' +
+        '[Yo (click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) ' +
+        '[Yo click here to see a cool cat)](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) ' +
+        '[Yo (click here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) ' +
+        '[Yo click * $ & here to see a cool cat](https://c8.alamy.com/compes/ha11pc/cookie-cat-con-sombrero-de-cowboy-y-sun-glass-ha11pc.jpg) ';
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test anchor tags replacements', () => {
-    const urlTestStartString = 'Testing '
-        + '<a href="http://foo.com" target="_blank">foo.com</a> \n'
-        + '<a href="http://www.foo.com" target="_blank">www.foo.com</a> \n'
-        + '<a href="http://www.foo.com" target="_blank">http://www.foo.com</a> \n'
-        + '<a href="http://foo.com/blah_blah" target="_blank">http://foo.com/blah_blah</a> \n'
-        + '<a href="http://foo.com/blah_blah/" target="_blank">http://foo.com/blah_blah/</a> \n'
-        + '<a href="http://foo.com/blah_blah_(wikipedia)" target="_blank">http://foo.com/blah_blah_(wikipedia)</a> \n'
-        + '<a href="http://www.example.com/wpstyle/?p=364" target="_blank">http://www.example.com/wpstyle/?p=364</a> \n'
-        + '<a href="https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux" target="_blank">https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux</a> \n'
-        + '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> \n'
-        + '<a href="http://code.google.com/events/#&amp;product=browser" target="_blank">http://code.google.com/events/#&amp;product=browser</a> \n'
-        + '<a href="http://foo.bar/?q=Test%20URL-encoded%20stuff" target="_blank">http://foo.bar/?q=Test%20URL-encoded%20stuff</a> \n'
-        + '<a href="http://www.test.com/path?param=123#123" target="_blank">http://www.test.com/path?param=123#123</a> \n'
-        + '<a href="http://1337.net" target="_blank">http://1337.net</a> \n'
-        + '<a href="http://a.b-c.de/" target="_blank">http://a.b-c.de/</a> \n'
-        + '<a href="https://sd1.sd2.docs.google.com/" target="_blank">https://sd1.sd2.docs.google.com/</a> \n'
-        + '<a href="https://expensify.cash/#/r/1234" target="_blank">https://expensify.cash/#/r/1234</a> \n'
-        + '<a href="https://github.com/Expensify/ReactNativeChat/pull/6.45" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/6.45</a> \n'
-        + '<a href="https://github.com/Expensify/Expensify/issues/143,231" target="_blank">https://github.com/Expensify/Expensify/issues/143,231</a> \n'
-        + '<a href="http://testRareTLDs.beer" target="_blank">testRareTLDs.beer</a> \n'
-        + '<a href="mailto:test@expensify.com">test@expensify.com</a> \n'
-        + 'test.completelyFakeTLD \n'
-        + '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878</a>) \n'
-        + '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled</a> \n'
-        + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> \n'
-        + '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> \n'
-        + 'mm..food \n'
-        + '<a href="http://upwork.com/jobs/~016781e062ce860b84" target="_blank">upwork.com/jobs/~016781e062ce860b84</a> \n'
-        + '<a href="https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))" target="_blank">https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))</a> \n'
-        + '<a href="http://google.com/maps/place/The+Flying&#x27;+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121" target="_blank">google.com/maps/place/The+Flying&#x27;+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121</a> \n'
-        + '<a href="http://google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843" target="_blank">google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843</a> \n'
-        + '<a href="https://www.google.com/maps/place/Taj+Mahal+@is~&quot;Awesome&quot;/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422" target="_blank">https://www.google.com/maps/place/Taj+Mahal+@is~&quot;Awesome&quot;/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422</a> \n'
-        + '<a href="Https://www.regex101.com" target="_blank" rel="noreferrer noopener">Https://www.regex101.com</a> \n'
-        + '<a href="https://www.facebook.com/hashtag/__main/?__eep__=6" target="_blank" rel="noreferrer noopener">https://www.facebook.com/hashtag/__main/?__eep__=6</a> \n'
-        + '<a href="https://example.com/~username/foo~bar.txt" target="_blank" rel="noreferrer noopener">https://example.com/~username/foo~bar.txt</a> \n'
-        + '<a href="http://example.com/foo/*/bar/*/test.txt" target="_blank" rel="noreferrer noopener">http://example.com/foo/*/bar/*/test.txt</a>';
+    const urlTestStartString =
+        'Testing ' +
+        '<a href="http://foo.com" target="_blank">foo.com</a> \n' +
+        '<a href="http://www.foo.com" target="_blank">www.foo.com</a> \n' +
+        '<a href="http://www.foo.com" target="_blank">http://www.foo.com</a> \n' +
+        '<a href="http://foo.com/blah_blah" target="_blank">http://foo.com/blah_blah</a> \n' +
+        '<a href="http://foo.com/blah_blah/" target="_blank">http://foo.com/blah_blah/</a> \n' +
+        '<a href="http://foo.com/blah_blah_(wikipedia)" target="_blank">http://foo.com/blah_blah_(wikipedia)</a> \n' +
+        '<a href="http://www.example.com/wpstyle/?p=364" target="_blank">http://www.example.com/wpstyle/?p=364</a> \n' +
+        '<a href="https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux" target="_blank">https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux</a> \n' +
+        '<a href="http://foo.com/(something)?after=parens" target="_blank">http://foo.com/(something)?after=parens</a> \n' +
+        '<a href="http://code.google.com/events/#&amp;product=browser" target="_blank">http://code.google.com/events/#&amp;product=browser</a> \n' +
+        '<a href="http://foo.bar/?q=Test%20URL-encoded%20stuff" target="_blank">http://foo.bar/?q=Test%20URL-encoded%20stuff</a> \n' +
+        '<a href="http://www.test.com/path?param=123#123" target="_blank">http://www.test.com/path?param=123#123</a> \n' +
+        '<a href="http://1337.net" target="_blank">http://1337.net</a> \n' +
+        '<a href="http://a.b-c.de/" target="_blank">http://a.b-c.de/</a> \n' +
+        '<a href="https://sd1.sd2.docs.google.com/" target="_blank">https://sd1.sd2.docs.google.com/</a> \n' +
+        '<a href="https://expensify.cash/#/r/1234" target="_blank">https://expensify.cash/#/r/1234</a> \n' +
+        '<a href="https://github.com/Expensify/ReactNativeChat/pull/6.45" target="_blank">https://github.com/Expensify/ReactNativeChat/pull/6.45</a> \n' +
+        '<a href="https://github.com/Expensify/Expensify/issues/143,231" target="_blank">https://github.com/Expensify/Expensify/issues/143,231</a> \n' +
+        '<a href="http://testRareTLDs.beer" target="_blank">testRareTLDs.beer</a> \n' +
+        '<a href="mailto:test@expensify.com">test@expensify.com</a> \n' +
+        'test.completelyFakeTLD \n' +
+        '<a href="https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878" target="_blank">https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&amp;index=logs_expensify-008878</a>) \n' +
+        '<a href="http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled" target="_blank">http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled</a> \n' +
+        '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> \n' +
+        '<a href="https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash" target="_blank">https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash</a> \n' +
+        'mm..food \n' +
+        '<a href="http://upwork.com/jobs/~016781e062ce860b84" target="_blank">upwork.com/jobs/~016781e062ce860b84</a> \n' +
+        '<a href="https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))" target="_blank">https://bastion1.sjc/logs/app/kibana#/discover?_g=()&amp;_a=(columns:!(_source),index:&#x27;2125cbe0-28a9-11e9-a79c-3de0157ed580&#x27;,interval:auto,query:(language:lucene,query:&#x27;&#x27;),sort:!(timestamp,desc))</a> \n' +
+        '<a href="http://google.com/maps/place/The+Flying&#x27;+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121" target="_blank">google.com/maps/place/The+Flying&#x27;+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121</a> \n' +
+        '<a href="http://google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843" target="_blank">google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843</a> \n' +
+        '<a href="https://www.google.com/maps/place/Taj+Mahal+@is~&quot;Awesome&quot;/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422" target="_blank">https://www.google.com/maps/place/Taj+Mahal+@is~&quot;Awesome&quot;/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422</a> \n' +
+        '<a href="Https://www.regex101.com" target="_blank" rel="noreferrer noopener">Https://www.regex101.com</a> \n' +
+        '<a href="https://www.facebook.com/hashtag/__main/?__eep__=6" target="_blank" rel="noreferrer noopener">https://www.facebook.com/hashtag/__main/?__eep__=6</a> \n' +
+        '<a href="https://example.com/~username/foo~bar.txt" target="_blank" rel="noreferrer noopener">https://example.com/~username/foo~bar.txt</a> \n' +
+        '<a href="http://example.com/foo/*/bar/*/test.txt" target="_blank" rel="noreferrer noopener">http://example.com/foo/*/bar/*/test.txt</a>';
 
-    const urlTestReplacedString = 'Testing '
-        + '[foo.com](http://foo.com) \n'
-        + '[www.foo.com](http://www.foo.com) \n'
-        + '[http://www.foo.com](http://www.foo.com) \n'
-        + '[http://foo.com/blah_blah](http://foo.com/blah_blah) \n'
-        + '[http://foo.com/blah_blah/](http://foo.com/blah_blah/) \n'
-        + '[http://foo.com/blah_blah_(wikipedia)](http://foo.com/blah_blah_(wikipedia)) \n'
-        + '[http://www.example.com/wpstyle/?p=364](http://www.example.com/wpstyle/?p=364) \n'
-        + '[https://www.example.com/foo/?bar=baz&inga=42&quux](https://www.example.com/foo/?bar=baz&inga=42&quux) \n'
-        + '[http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens) \n'
-        + '[http://code.google.com/events/#&product=browser](http://code.google.com/events/#&product=browser) \n'
-        + '[http://foo.bar/?q=Test%20URL-encoded%20stuff](http://foo.bar/?q=Test%20URL-encoded%20stuff) \n'
-        + '[http://www.test.com/path?param=123#123](http://www.test.com/path?param=123#123) \n'
-        + '[http://1337.net](http://1337.net) \n'
-        + '[http://a.b-c.de/](http://a.b-c.de/) \n'
-        + '[https://sd1.sd2.docs.google.com/](https://sd1.sd2.docs.google.com/) \n'
-        + '[https://expensify.cash/#/r/1234](https://expensify.cash/#/r/1234) \n'
-        + '[https://github.com/Expensify/ReactNativeChat/pull/6.45](https://github.com/Expensify/ReactNativeChat/pull/6.45) \n'
-        + '[https://github.com/Expensify/Expensify/issues/143,231](https://github.com/Expensify/Expensify/issues/143,231) \n'
-        + '[testRareTLDs.beer](http://testRareTLDs.beer) \n'
-        + 'test@expensify.com \n'
-        + 'test.completelyFakeTLD \n'
-        + '[https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878](https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878)) \n'
-        + '[http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled](http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled) \n'
-        + '[https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash](https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) \n'
-        + '[https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash](https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) \n'
-        + 'mm..food \n'
-        + '[upwork.com/jobs/~016781e062ce860b84](http://upwork.com/jobs/~016781e062ce860b84) \n'
-        + '[https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:\'2125cbe0-28a9-11e9-a79c-3de0157ed580\',interval:auto,query:(language:lucene,query:\'\'),sort:!(timestamp,desc))](https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:\'2125cbe0-28a9-11e9-a79c-3de0157ed580\',interval:auto,query:(language:lucene,query:\'\'),sort:!(timestamp,desc))) \n'
-
-        + '[google.com/maps/place/The+Flying\'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121](http://google.com/maps/place/The+Flying\'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121) \n'
-
-        + '[google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843](http://google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843) \n'
-        + '[https://www.google.com/maps/place/Taj+Mahal+@is~"Awesome"/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422](https://www.google.com/maps/place/Taj+Mahal+@is~"Awesome"/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422) \n'
-        + '[Https://www.regex101.com](Https://www.regex101.com) \n'
-        + '[https://www.facebook.com/hashtag/__main/?__eep__=6](https://www.facebook.com/hashtag/__main/?__eep__=6) \n'
-        + '[https://example.com/~username/foo~bar.txt](https://example.com/~username/foo~bar.txt) \n'
-        + '[http://example.com/foo/*/bar/*/test.txt](http://example.com/foo/*/bar/*/test.txt)';
+    const urlTestReplacedString =
+        'Testing ' +
+        '[foo.com](http://foo.com) \n' +
+        '[www.foo.com](http://www.foo.com) \n' +
+        '[http://www.foo.com](http://www.foo.com) \n' +
+        '[http://foo.com/blah_blah](http://foo.com/blah_blah) \n' +
+        '[http://foo.com/blah_blah/](http://foo.com/blah_blah/) \n' +
+        '[http://foo.com/blah_blah_(wikipedia)](http://foo.com/blah_blah_(wikipedia)) \n' +
+        '[http://www.example.com/wpstyle/?p=364](http://www.example.com/wpstyle/?p=364) \n' +
+        '[https://www.example.com/foo/?bar=baz&inga=42&quux](https://www.example.com/foo/?bar=baz&inga=42&quux) \n' +
+        '[http://foo.com/(something)?after=parens](http://foo.com/(something)?after=parens) \n' +
+        '[http://code.google.com/events/#&product=browser](http://code.google.com/events/#&product=browser) \n' +
+        '[http://foo.bar/?q=Test%20URL-encoded%20stuff](http://foo.bar/?q=Test%20URL-encoded%20stuff) \n' +
+        '[http://www.test.com/path?param=123#123](http://www.test.com/path?param=123#123) \n' +
+        '[http://1337.net](http://1337.net) \n' +
+        '[http://a.b-c.de/](http://a.b-c.de/) \n' +
+        '[https://sd1.sd2.docs.google.com/](https://sd1.sd2.docs.google.com/) \n' +
+        '[https://expensify.cash/#/r/1234](https://expensify.cash/#/r/1234) \n' +
+        '[https://github.com/Expensify/ReactNativeChat/pull/6.45](https://github.com/Expensify/ReactNativeChat/pull/6.45) \n' +
+        '[https://github.com/Expensify/Expensify/issues/143,231](https://github.com/Expensify/Expensify/issues/143,231) \n' +
+        '[testRareTLDs.beer](http://testRareTLDs.beer) \n' +
+        'test@expensify.com \n' +
+        'test.completelyFakeTLD \n' +
+        '[https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878](https://www.expensify.com/_devportal/tools/logSearch/#query=request_id:(%22Ufjjim%22)+AND+timestamp:[2021-01-08T03:48:10.389Z+TO+2021-01-08T05:48:10.389Z]&index=logs_expensify-008878)) \n' +
+        '[http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled](http://necolas.github.io/react-native-web/docs/?path=/docs/components-pressable--disabled) \n' +
+        '[https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash](https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) \n' +
+        '[https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash](https://github.com/Expensify/Expensify.cash/issues/123#:~:text=Please%20work/Expensify.cash) \n' +
+        'mm..food \n' +
+        '[upwork.com/jobs/~016781e062ce860b84](http://upwork.com/jobs/~016781e062ce860b84) \n' +
+        "[https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'2125cbe0-28a9-11e9-a79c-3de0157ed580',interval:auto,query:(language:lucene,query:''),sort:!(timestamp,desc))](https://bastion1.sjc/logs/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:'2125cbe0-28a9-11e9-a79c-3de0157ed580',interval:auto,query:(language:lucene,query:''),sort:!(timestamp,desc))) \n" +
+        "[google.com/maps/place/The+Flying'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121](http://google.com/maps/place/The+Flying'+Saucer/@42.4043314,-86.2742418,15z/data=!4m5!3m4!1s0x0:0xe28f6108670216bc!8m2!3d42.4043316!4d-86.2742121) \n" +
+        '[google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843](http://google.com/maps/place/%E9%9D%92%E5%B3%B6%E9%80%A3%E7%B5%A1%E8%88%B9%E4%B9%97%E5%A0%B4/@33.7363156,132.4877213,17.78z/data=!4m5!3m4!1s0x3545615c8c65bf7f:0xb89272c1a705a33f!8m2!3d33.7366776!4d132.4878843) \n' +
+        '[https://www.google.com/maps/place/Taj+Mahal+@is~"Awesome"/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422](https://www.google.com/maps/place/Taj+Mahal+@is~"Awesome"/@27.1751496,78.0399535,17z/data=!4m12!1m6!3m5!1s0x39747121d702ff6d:0xdd2ae4803f767dde!2sTaj+Mahal!8m2!3d27.1751448!4d78.0421422!3m4!1s0x39747121d702ff6d:0xdd2ae4803f767dde!8m2!3d27.1751448!4d78.0421422) \n' +
+        '[Https://www.regex101.com](Https://www.regex101.com) \n' +
+        '[https://www.facebook.com/hashtag/__main/?__eep__=6](https://www.facebook.com/hashtag/__main/?__eep__=6) \n' +
+        '[https://example.com/~username/foo~bar.txt](https://example.com/~username/foo~bar.txt) \n' +
+        '[http://example.com/foo/*/bar/*/test.txt](http://example.com/foo/*/bar/*/test.txt)';
 
     expect(parser.htmlToMarkdown(urlTestStartString)).toBe(urlTestReplacedString);
 });
@@ -403,10 +417,11 @@ test('Test HTML string with code fence', () => {
     const resultStringForBrTag = '```\nclass Expensify extends PureComponent {\n    constructor(props) {\n        super(props);\n    }\n}\n```';
     expect(parser.htmlToMarkdown(testStringWithBrTag)).toBe(resultStringForBrTag);
 
-    const testStringWithNewLinesFromSlack = '<pre class="c-mrkdwn__pre" data-stringify-type="pre" >line1'
-    + '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;">'
-    + '</span>line3<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>'
-    + '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>line6</pre>';
+    const testStringWithNewLinesFromSlack =
+        '<pre class="c-mrkdwn__pre" data-stringify-type="pre" >line1' +
+        '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;">' +
+        '</span>line3<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>' +
+        '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>line6</pre>';
     const resultStringWithNewLinesFromSlack = '```\nline1\n\nline3\n\n\nline6\n```';
     expect(parser.htmlToMarkdown(testStringWithNewLinesFromSlack)).toBe(resultStringWithNewLinesFromSlack);
 });
@@ -504,13 +519,15 @@ test('map table to newline', () => {
 });
 
 test('map real message from app', () => {
-    const testString = '<div><div><div><div><div><div><div><div><div><div><div><div><comment><div><em>hhh</em><span> ddd</span></div><br></comment></div></div></div></div></div></div><div><div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div></div></div></div></div></div></div></div><div><div><div><div><div><div><div><div><div><div>ddd</div></div></div></div></div><div></div></div></div></div></div></div><div><div><div><div><div><div><div><div><div><div>dd</div></div></div></div></div></div></div></div></div></div></div>';
+    const testString =
+        '<div><div><div><div><div><div><div><div><div><div><div><div><comment><div><em>hhh</em><span> ddd</span></div><br></comment></div></div></div></div></div></div><div><div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div></div></div></div></div></div></div></div><div><div><div><div><div><div><div><div><div><div>ddd</div></div></div></div></div><div></div></div></div></div></div></div><div><div><div><div><div><div><div><div><div><div>dd</div></div></div></div></div></div></div></div></div></div></div>';
     const resultString = '_hhh_ ddd\nddd\ndd';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('map real message with quotes', () => {
-    const testString = '<div><div><div><div><div><div><div><div><div><div><div><div><comment><blockquote><div>hi</div></blockquote><br></comment></div></div></div></div></div></div><div><div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div></div></div></div></div></div></div></div><div><div><div><div><div><div><div><div><div><div><div><comment><blockquote><div>hi</div></blockquote><br></comment></div></div></div></div></div></div></div></div></div></div></div></div>';
+    const testString =
+        '<div><div><div><div><div><div><div><div><div><div><div><div><comment><blockquote><div>hi</div></blockquote><br></comment></div></div></div></div></div></div><div><div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div><div><div><div><svg><path/></svg></div></div></div></div></div></div></div></div></div></div><div><div><div><div><div><div><div><div><div><div><div><comment><blockquote><div>hi</div></blockquote><br></comment></div></div></div></div></div></div></div></div></div></div></div></div>';
     const resultString = '> hi\n> hi';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
@@ -553,39 +570,31 @@ test('Test html to heading1 markdown when there are other tags inside h1 tag', (
 
 test('Test html to heading1 markdown when h1 tag is in the beginning of the line', () => {
     const testString = '<h1>heading1</h1> in the beginning of the line';
-    const resultString = '# heading1\n'
-    + ' in the beginning of the line';
+    const resultString = '# heading1\n' + ' in the beginning of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test html to heading1 markdown when h1 tags are in the middle of the line', () => {
     const testString = 'this line has a <h1>heading1</h1> in the middle of the line';
-    const resultString = 'this line has a\n'
-    + '# heading1\n'
-    + ' in the middle of the line';
+    const resultString = 'this line has a\n' + '# heading1\n' + ' in the middle of the line';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test html to heading1 markdown when h1 tag is in the end of the line', () => {
     const testString = 'this line has an h1 in the end of the line<h1>heading1</h1>';
-    const resultString = 'this line has an h1 in the end of the line'
-    + '\n# heading1';
+    const resultString = 'this line has an h1 in the end of the line' + '\n# heading1';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test html to heading1 markdown when there are 2 h1 tags in the line', () => {
     const testString = 'this is the first heading1<h1>heading1</h1>this is the second heading1<h1>heading1</h1>';
-    const resultString = 'this is the first heading1'
-    + '\n# heading1'
-    + '\nthis is the second heading1'
-    + '\n# heading1';
+    const resultString = 'this is the first heading1' + '\n# heading1' + '\nthis is the second heading1' + '\n# heading1';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
 test('Test html to heading1 markdown when there are adjacent h1 tags in the line', () => {
     const testString = '<h1>heading1</h1><h1>heading2</h1>';
-    const resultString = '# heading1'
-    + '\n# heading2';
+    const resultString = '# heading1' + '\n# heading2';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });
 
@@ -617,7 +626,8 @@ test('Map html list item to newline with two prefix spaces', () => {
 });
 
 test('Test list item replacement when there is an anchor tag inside <li> tag', () => {
-    let testString = '<ul><li><a href="https://example.com">Coffee</a> -- Coffee</li><li><a href="https://example.com">Tea</a> -- Tea</li><li><a href="https://example.com">Milk</a> -- Milk</li></ul>';
+    let testString =
+        '<ul><li><a href="https://example.com">Coffee</a> -- Coffee</li><li><a href="https://example.com">Tea</a> -- Tea</li><li><a href="https://example.com">Milk</a> -- Milk</li></ul>';
     let resultString = '  [Coffee](https://example.com) -- Coffee\n  [Tea](https://example.com) -- Tea\n  [Milk](https://example.com) -- Milk';
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 
@@ -664,19 +674,28 @@ test('Test blockquote with h1 inside', () => {
 });
 
 test('Test blockquote linebreak handling with text, block and inline elements', () => {
-    const testStringQuotes = '<blockquote>one line quote a</blockquote><br /><blockquote>two line quote b<br />two line quote b</blockquote><br /><blockquote>quote c with internal line break<br /><br />quote c with internal line break</blockquote>';
-    expect(parser.htmlToMarkdown(testStringQuotes)).toBe('> one line quote a\n\n> two line quote b\n> two line quote b\n\n> quote c with internal line break\n> \n> quote c with internal line break');
+    const testStringQuotes =
+        '<blockquote>one line quote a</blockquote><br /><blockquote>two line quote b<br />two line quote b</blockquote><br /><blockquote>quote c with internal line break<br /><br />quote c with internal line break</blockquote>';
+    expect(parser.htmlToMarkdown(testStringQuotes)).toBe(
+        '> one line quote a\n\n> two line quote b\n> two line quote b\n\n> quote c with internal line break\n> \n> quote c with internal line break',
+    );
 
-    const testStringSurroundedByText = 'text a<br /><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote>text b<br /><br />text c<br /><blockquote>quote c</blockquote>text c';
+    const testStringSurroundedByText =
+        'text a<br /><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote>text b<br /><br />text c<br /><blockquote>quote c</blockquote>text c';
     expect(parser.htmlToMarkdown(testStringSurroundedByText)).toBe('text a\n> quote a\n\n> quote b\ntext b\n\ntext c\n> quote c\ntext c');
 
-    const testStringSurroundedByInlineElement = '<em>italic a</em><br /><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote><strong>bold b</strong><br /><br /><em>italic c</em><br /><blockquote>quote c</blockquote><strong>bold c</strong>';
+    const testStringSurroundedByInlineElement =
+        '<em>italic a</em><br /><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote><strong>bold b</strong><br /><br /><em>italic c</em><br /><blockquote>quote c</blockquote><strong>bold c</strong>';
     expect(parser.htmlToMarkdown(testStringSurroundedByInlineElement)).toBe('_italic a_\n> quote a\n\n> quote b\n*bold b*\n\n_italic c_\n> quote c\n*bold c*');
 
-    const testStringSurroundedByBlockElementCodeFence = '<pre>code fence a</pre><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote><pre>code fence b</pre><br /><pre>code fence c</pre><blockquote>quote c</blockquote><pre>code fence c</pre>';
-    expect(parser.htmlToMarkdown(testStringSurroundedByBlockElementCodeFence)).toBe('```\ncode fence a\n```\n> quote a\n\n> quote b\n```\ncode fence b\n```\n\n```\ncode fence c\n```\n> quote c\n```\ncode fence c\n```');
+    const testStringSurroundedByBlockElementCodeFence =
+        '<pre>code fence a</pre><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote><pre>code fence b</pre><br /><pre>code fence c</pre><blockquote>quote c</blockquote><pre>code fence c</pre>';
+    expect(parser.htmlToMarkdown(testStringSurroundedByBlockElementCodeFence)).toBe(
+        '```\ncode fence a\n```\n> quote a\n\n> quote b\n```\ncode fence b\n```\n\n```\ncode fence c\n```\n> quote c\n```\ncode fence c\n```',
+    );
 
-    const testStringSurroundedByBlockElementHeading = '<h1>h1 a</h1><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote><h1>h1 b</h1><br /><h1>h1 c</h1><blockquote>quote c</blockquote><h1>h1 c</h1>';
+    const testStringSurroundedByBlockElementHeading =
+        '<h1>h1 a</h1><blockquote>quote a</blockquote><br /><blockquote>quote b</blockquote><h1>h1 b</h1><br /><h1>h1 c</h1><blockquote>quote c</blockquote><h1>h1 c</h1>';
     expect(parser.htmlToMarkdown(testStringSurroundedByBlockElementHeading)).toBe('# h1 a\n> quote a\n\n> quote b\n# h1 b\n\n# h1 c\n> quote c\n# h1 c');
 });
 
@@ -687,7 +706,8 @@ test('Test codeFence copy from selection does not add extra new line', () => {
     testString = '<pre>code<br></pre>text';
     expect(parser.htmlToMarkdown(testString)).toBe('```\ncode\n```\ntext');
 
-    testString = '<h3>test heading</h3><div><pre class=\"notranslate\"><code class=\"notranslate\">Code snippet\n</code></pre></div><blockquote><p><a href=\"https://www.example.com\">link</a></p></blockquote>';
+    testString =
+        '<h3>test heading</h3><div><pre class="notranslate"><code class="notranslate">Code snippet\n</code></pre></div><blockquote><p><a href="https://www.example.com">link</a></p></blockquote>';
     expect(parser.htmlToMarkdown(testString)).toBe('test heading\n```\nCode snippet\n```\n> [link](https://www.example.com)');
 });
 
@@ -757,10 +777,13 @@ test('Mention user html to markdown', () => {
     expect(parser.htmlToMarkdown(testString)).toBe('@user@DOMAIN.com');
 
     const extras = {
-        "accountIdToName": {
-            "1234": "@user@domain.com"
-        }
-    }
+        accountIdToName: {
+            '1234': 'user@domain.com',
+        },
+    };
+    testString = '<mention-user accountID="1234"/>';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
+
     testString = '<mention-user accountID="1234" />';
     expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
 });
@@ -779,10 +802,13 @@ test('Mention report html to markdown', () => {
     expect(parser.htmlToMarkdown(testString)).toBe('#room-NAME');
 
     const extras = {
-        "reportIdToName": {
-            "1234": "#room-name"
-        }
-    }
+        reportIdToName: {
+            '1234': '#room-name',
+        },
+    };
+    testString = '<mention-report reportID="1234"/>';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
+
     testString = '<mention-report reportID="1234" />';
     expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
 });
@@ -813,7 +839,8 @@ describe('Image tag conversion to markdown', () => {
     });
 
     test('Alt attribute with complex/escaped content', () => {
-        const testString = '<img src="https://example.com/image.png" alt="&#x60;&#x60;&#x60;code&#x60;&#x60;&#x60;" data-raw-href="https://example.com/image.png" data-link-variant="labeled" />';
+        const testString =
+            '<img src="https://example.com/image.png" alt="&#x60;&#x60;&#x60;code&#x60;&#x60;&#x60;" data-raw-href="https://example.com/image.png" data-link-variant="labeled" />';
         const resultString = '![```code```](https://example.com/image.png)';
         expect(parser.htmlToMarkdown(testString)).toBe(resultString);
     });

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -1,10 +1,11 @@
-declare type Replacement = (...args: string[]) => string;
+declare type Replacement = (...args: string[], extras?: ExtrasObject) => string;
 declare type Name =
     | 'codeFence'
     | 'inlineCodeBlock'
     | 'email'
     | 'link'
     | 'hereMentions'
+    | 'roomMentions'
     | 'userMentions'
     | 'autoEmail'
     | 'autolink'
@@ -31,6 +32,11 @@ declare type Rule = {
     replacement: Replacement | string;
     pre?: (input: string) => string;
     post?: (input: string) => string;
+};
+
+declare type ExtrasObject = {
+    reportIdToName?: Record<string, string>;
+    accountIDToName?: Record<string, string>;
 };
 export default class ExpensiMark {
     rules: Rule[];
@@ -91,14 +97,14 @@ export default class ExpensiMark {
      * @param htmlString
      * @param extras
      */
-    htmlToMarkdown(htmlString: string, extras?: Object): string;
+    htmlToMarkdown(htmlString: string, extras?: ExtrasObject): string;
     /**
      * Convert HTML to text
      *
      * @param htmlString
      * @param extras
      */
-    htmlToText(htmlString: string, extras?: Object): string;
+    htmlToText(htmlString: string, extras?: ExtrasObject): string;
     /**
      * Modify text for Quotes replacing chevrons with html elements
      *

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -89,14 +89,16 @@ export default class ExpensiMark {
      * Replaces HTML with markdown
      *
      * @param htmlString
+     * @param extras
      */
-    htmlToMarkdown(htmlString: string): string;
+    htmlToMarkdown(htmlString: string, extras?: Object): string;
     /**
      * Convert HTML to text
      *
      * @param htmlString
+     * @param extras
      */
-    htmlToText(htmlString: string): string;
+    htmlToText(htmlString: string, extras?: Object): string;
     /**
      * Modify text for Quotes replacing chevrons with html elements
      *

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -124,7 +124,7 @@ export default class ExpensiMark {
                 name: 'image',
                 regex: MARKDOWN_IMAGE_REGEX,
                 replacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}"${g1 ? ` alt="${this.escapeAttributeContent(g1)}"` : ''} />`,
-                rawInputReplacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}"${g1 ? ` alt="${this.escapeAttributeContent(g1)}"` : ''} data-raw-href="${g2}" data-link-variant="${typeof(g1) === 'string' ? 'labeled': 'auto'}" />`
+                rawInputReplacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}"${g1 ? ` alt="${this.escapeAttributeContent(g1)}"` : ''} data-raw-href="${g2}" data-link-variant="${typeof (g1) === 'string' ? 'labeled' : 'auto'}" />`
             },
 
             /**
@@ -264,7 +264,11 @@ export default class ExpensiMark {
                         this.currentQuoteDepth++;
                     }
 
-                    const replacedText = this.replace(textToReplace, {filterRules, shouldEscapeText: false, shouldKeepRawInput});
+                    const replacedText = this.replace(textToReplace, {
+                        filterRules,
+                        shouldEscapeText: false,
+                        shouldKeepRawInput
+                    });
                     this.currentQuoteDepth = 0;
                     return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
@@ -453,6 +457,16 @@ export default class ExpensiMark {
 
                     return `!(${g2})`;
                 }
+            },
+            {
+                name: 'roomMention',
+                regex: /<mention-report reportID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+            },
+            {
+                name: 'userMention',
+                regex: /<mention-user accountID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.accountIdToName[g1]
             }
         ];
 
@@ -498,10 +512,20 @@ export default class ExpensiMark {
                 replacement: '[Attachment]',
             },
             {
+                name: 'roomMention',
+                regex: /<mention-report reportID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+            },
+            {
+                name: 'userMention',
+                regex: /<mention-user accountID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.accountIdToName[g1]
+            },
+            {
                 name: 'stripTag',
                 regex: /(<([^>]+)>)/gi,
                 replacement: '',
-            },
+            }
         ];
 
         /**
@@ -768,10 +792,11 @@ export default class ExpensiMark {
      * Replaces HTML with markdown
      *
      * @param {String} htmlString
+     * @param {Object} extras
      *
      * @returns {String}
      */
-    htmlToMarkdown(htmlString) {
+    htmlToMarkdown(htmlString, extras = {}) {
         let generatedMarkdown = htmlString;
         const body = /<(body)(?:"[^"]*"|'[^']*'|[^'"><])*>(?:\n|\r\n)?([\s\S]*?)(?:\n|\r\n)?<\/\1>(?![^<]*(<\/pre>|<\/code>))/im;
         const parseBodyTag = generatedMarkdown.match(body);
@@ -786,7 +811,7 @@ export default class ExpensiMark {
             if (rule.pre) {
                 generatedMarkdown = rule.pre(generatedMarkdown);
             }
-            generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
+            generatedMarkdown = generatedMarkdown.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
         });
         return Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
     }
@@ -795,13 +820,15 @@ export default class ExpensiMark {
      * Convert HTML to text
      *
      * @param {String} htmlString
+     * @param {Object} extras
+     *
      * @returns {String}
      */
-    htmlToText(htmlString) {
+    htmlToText(htmlString, extras) {
         let replacedText = htmlString;
 
         this.htmlToTextRules.forEach((rule) => {
-            replacedText = replacedText.replace(rule.regex, rule.replacement);
+            replacedText = replacedText.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
         });
 
         // Unescaping because the text is escaped in 'replace' function

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -460,14 +460,28 @@ export default class ExpensiMark {
             },
             {
                 name: 'roomMention',
-                regex: /<mention-report reportID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+                regex: /<mention-report reportID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const reportToNameMap = extras.reportIdToName;
+                    if (!reportToNameMap || !reportToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return reportToNameMap[g1];
+                },
             },
             {
                 name: 'userMention',
-                regex: /<mention-user accountID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.accountIdToName[g1]
-            }
+                regex: /<mention-user accountID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const accountToNameMap = extras.accountIdToName;
+                    if (!accountToNameMap || !accountToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return `@${extras.accountIdToName[g1]}`;
+                },
+            },
         ];
 
         /**
@@ -513,13 +527,27 @@ export default class ExpensiMark {
             },
             {
                 name: 'roomMention',
-                regex: /<mention-report reportID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+                regex: /<mention-report reportID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const reportToNameMap = extras.reportIdToName;
+                    if (!reportToNameMap || !reportToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return reportToNameMap[g1];
+                },
             },
             {
                 name: 'userMention',
-                regex: /<mention-user accountID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.accountIdToName[g1]
+                regex: /<mention-user accountID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const accountToNameMap = extras.accountIdToName;
+                    if (!accountToNameMap || !accountToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return `@${extras.accountIdToName[g1]}`;
+                },
             },
             {
                 name: 'stripTag',
@@ -811,7 +839,10 @@ export default class ExpensiMark {
             if (rule.pre) {
                 generatedMarkdown = rule.pre(generatedMarkdown);
             }
-            generatedMarkdown = generatedMarkdown.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
+
+            // if replacement is a function, we want to pass optional extras to it
+            const replacementFunction = typeof rule.replacement === 'function' ? (...args) => rule.replacement(...args, extras) : rule.replacement;
+            generatedMarkdown = generatedMarkdown.replace(rule.regex, replacementFunction);
         });
         return Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
     }
@@ -828,7 +859,8 @@ export default class ExpensiMark {
         let replacedText = htmlString;
 
         this.htmlToTextRules.forEach((rule) => {
-            replacedText = replacedText.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
+            const replacementFunction = typeof rule.replacement === 'function' ? (...args) => rule.replacement(...args, extras) : rule.replacement;
+            replacedText = replacedText.replace(rule.regex, replacementFunction);
         });
 
         // Unescaping because the text is escaped in 'replace' function


### PR DESCRIPTION
After recent changes room and user mentions will be based on accountID, due to that inside the html tags we would not have any information about user name. This would lead to not parsing such a mentions.
In order to tackle this problem we are introducing additional, optional,  argument for parsing function: `extras` which would be able to contain the map of room IDs to room names. This is used inside replacement function to properly retrieve report/user name

### Fixed Issues
$ GH_LINK

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
