### PR TITLE
Pass extra data (fe. accountIDs) to HTMLToMarkdown method & add possibility to disable certain rules

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2030,6 +2030,13 @@ describe('room mentions', () => {
         expect(parser.replace(testString)).toBe(resultString);
     });
 
+    test('room mention shouldn\'t be parsed when rule is disabled', () => {
+        const testString = '*hello* @user@mail.com in #room!';
+        const resultString = '<strong>hello</strong> <mention-user>@user@mail.com</mention-user> in #room!';
+        const disabledRules = ['reportMentions'];
+        expect(parser.replace(testString, {disabledRules})).toBe(resultString);
+    });
+
     test('room mention with italic, bold and strikethrough styles', () => {
         const testString = '#room'
         + ' _#room_'

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -133,7 +133,7 @@ test('Test remove style tag', () => {
     expect(parser.htmlToText(testString)).toBe('a text');
 });
 
-test('Mention html to text', () => {
+test('Mention user html to text', () => {
     let testString = '<mention-user>@user@domain.com</mention-user>';
     expect(parser.htmlToText(testString)).toBe('@user@domain.com');
 
@@ -145,6 +145,36 @@ test('Mention html to text', () => {
 
     testString = '<mention-user>@user@DOMAIN.com</mention-user>';
     expect(parser.htmlToText(testString)).toBe('@user@DOMAIN.com');
+
+    const extras = {
+        "accountIdToName": {
+            "1234": "@user@domain.com"
+        }
+    }
+    testString = '<mention-user accountID="1234" />';
+    expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
+});
+
+test('Mention report html to text', () => {
+    let testString = '<mention-report>#room-name</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#room-name');
+
+    testString = '<mention-report>#ROOM-NAME</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#ROOM-NAME');
+
+    testString = '<mention-report>#ROOM-name</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#ROOM-name');
+
+    testString = '<mention-report>#room-NAME</mention-report>';
+    expect(parser.htmlToText(testString)).toBe('#room-NAME');
+
+    const extras = {
+        "reportIdToName": {
+            "1234": "#room-name"
+        }
+    }
+    testString = '<mention-report reportID="1234" />';
+    expect(parser.htmlToText(testString, extras)).toBe('#room-name');
 });
 
 test('Test replacement for <img> tags', () => {

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -147,10 +147,13 @@ test('Mention user html to text', () => {
     expect(parser.htmlToText(testString)).toBe('@user@DOMAIN.com');
 
     const extras = {
-        "accountIdToName": {
-            "1234": "@user@domain.com"
-        }
-    }
+        accountIdToName: {
+            '1234': 'user@domain.com',
+        },
+    };
+    testString = '<mention-user accountID="1234"/>';
+    expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
+
     testString = '<mention-user accountID="1234" />';
     expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
 });
@@ -169,10 +172,13 @@ test('Mention report html to text', () => {
     expect(parser.htmlToText(testString)).toBe('#room-NAME');
 
     const extras = {
-        "reportIdToName": {
-            "1234": "#room-name"
-        }
-    }
+        reportIdToName: {
+            '1234': '#room-name',
+        },
+    };
+    testString = '<mention-report reportID="1234"/>';
+    expect(parser.htmlToText(testString, extras)).toBe('#room-name');
+
     testString = '<mention-report reportID="1234" />';
     expect(parser.htmlToText(testString, extras)).toBe('#room-name');
 });

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -743,7 +743,7 @@ test('Linebreak should be remained for text between code block', () => {
     });
 });
 
-test('Mention html to markdown', () => {
+test('Mention user html to markdown', () => {
     let testString = '<mention-user>@user@domain.com</mention-user>';
     expect(parser.htmlToMarkdown(testString)).toBe('@user@domain.com');
 
@@ -755,6 +755,36 @@ test('Mention html to markdown', () => {
 
     testString = '<mention-user>@user@DOMAIN.com</mention-user>';
     expect(parser.htmlToMarkdown(testString)).toBe('@user@DOMAIN.com');
+
+    const extras = {
+        "accountIdToName": {
+            "1234": "@user@domain.com"
+        }
+    }
+    testString = '<mention-user accountID="1234" />';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
+});
+
+test('Mention report html to markdown', () => {
+    let testString = '<mention-report>#room-name</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#room-name');
+
+    testString = '<mention-report>#ROOM-NAME</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#ROOM-NAME');
+
+    testString = '<mention-report>#ROOM-name</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#ROOM-name');
+
+    testString = '<mention-report>#room-NAME</mention-report>';
+    expect(parser.htmlToMarkdown(testString)).toBe('#room-NAME');
+
+    const extras = {
+        "reportIdToName": {
+            "1234": "#room-name"
+        }
+    }
+    testString = '<mention-report reportID="1234" />';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
 });
 
 describe('Image tag conversion to markdown', () => {

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -757,10 +757,13 @@ test('Mention user html to markdown', () => {
     expect(parser.htmlToMarkdown(testString)).toBe('@user@DOMAIN.com');
 
     const extras = {
-        "accountIdToName": {
-            "1234": "@user@domain.com"
-        }
-    }
+        accountIdToName: {
+            '1234': 'user@domain.com',
+        },
+    };
+    testString = '<mention-user accountID="1234"/>';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
+
     testString = '<mention-user accountID="1234" />';
     expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
 });
@@ -779,10 +782,13 @@ test('Mention report html to markdown', () => {
     expect(parser.htmlToMarkdown(testString)).toBe('#room-NAME');
 
     const extras = {
-        "reportIdToName": {
-            "1234": "#room-name"
-        }
-    }
+        reportIdToName: {
+            '1234': '#room-name',
+        },
+    };
+    testString = '<mention-report reportID="1234"/>';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
+
     testString = '<mention-report reportID="1234" />';
     expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
 });

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -1,10 +1,11 @@
-declare type Replacement = (...args: string[]) => string;
+declare type Replacement = (...args: string[], extras?: ExtrasObject) => string;
 declare type Name =
     | 'codeFence'
     | 'inlineCodeBlock'
     | 'email'
     | 'link'
     | 'hereMentions'
+    | 'roomMentions'
     | 'userMentions'
     | 'autoEmail'
     | 'autolink'
@@ -31,6 +32,11 @@ declare type Rule = {
     replacement: Replacement | string;
     pre?: (input: string) => string;
     post?: (input: string) => string;
+};
+
+declare type ExtrasObject = {
+    reportIdToName?: Record<string, string>;
+    accountIDToName?: Record<string, string>;
 };
 export default class ExpensiMark {
     rules: Rule[];
@@ -91,14 +97,14 @@ export default class ExpensiMark {
      * @param htmlString
      * @param extras
      */
-    htmlToMarkdown(htmlString: string, extras?: Object): string;
+    htmlToMarkdown(htmlString: string, extras?: ExtrasObject): string;
     /**
      * Convert HTML to text
      *
      * @param htmlString
      * @param extras
      */
-    htmlToText(htmlString: string, extras?: Object): string;
+    htmlToText(htmlString: string, extras?: ExtrasObject): string;
     /**
      * Modify text for Quotes replacing chevrons with html elements
      *

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -7,6 +7,7 @@ declare type Name =
     | 'hereMentions'
     | 'roomMentions'
     | 'userMentions'
+    | 'reportMentions'
     | 'autoEmail'
     | 'autolink'
     | 'quote'
@@ -49,7 +50,9 @@ export default class ExpensiMark {
      * @param text - Text to parse as markdown
      * @param options - Options to customize the markdown parser
      * @param options.filterRules=[] - An array of name of rules as defined in this class.
-     * If not provided, all available rules will be applied.
+     * If not provided, all available rules will be applied. If provided, only the rules in the array will be applied.
+     * @param options.disabledRules=[] - An array of name of rules as defined in this class.
+     * If not provided, all available rules will be applied. If provided, the rules in the array will be skipped.
      * @param options.shouldEscapeText=true - Whether or not the text should be escaped
      * @param options.shouldKeepRawInput=false - Whether or not the raw input should be kept and returned
      */
@@ -60,7 +63,8 @@ export default class ExpensiMark {
             shouldEscapeText,
             shouldKeepRawInput,
         }?: {
-            filterRules?: string[];
+            filterRules?: Name[];
+            disabledRules?: Name[];
             shouldEscapeText?: boolean;
             shouldKeepRawInput?: boolean;
         },

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -5,7 +5,6 @@ declare type Name =
     | 'email'
     | 'link'
     | 'hereMentions'
-    | 'roomMentions'
     | 'userMentions'
     | 'reportMentions'
     | 'autoEmail'

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -89,14 +89,16 @@ export default class ExpensiMark {
      * Replaces HTML with markdown
      *
      * @param htmlString
+     * @param extras
      */
-    htmlToMarkdown(htmlString: string): string;
+    htmlToMarkdown(htmlString: string, extras?: Object): string;
     /**
      * Convert HTML to text
      *
      * @param htmlString
+     * @param extras
      */
-    htmlToText(htmlString: string): string;
+    htmlToText(htmlString: string, extras?: Object): string;
     /**
      * Modify text for Quotes replacing chevrons with html elements
      *

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -124,7 +124,7 @@ export default class ExpensiMark {
                 name: 'image',
                 regex: MARKDOWN_IMAGE_REGEX,
                 replacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}"${g1 ? ` alt="${this.escapeAttributeContent(g1)}"` : ''} />`,
-                rawInputReplacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}"${g1 ? ` alt="${this.escapeAttributeContent(g1)}"` : ''} data-raw-href="${g2}" data-link-variant="${typeof(g1) === 'string' ? 'labeled': 'auto'}" />`
+                rawInputReplacement: (match, g1, g2) => `<img src="${Str.sanitizeURL(g2)}"${g1 ? ` alt="${this.escapeAttributeContent(g1)}"` : ''} data-raw-href="${g2}" data-link-variant="${typeof (g1) === 'string' ? 'labeled' : 'auto'}" />`
             },
 
             /**
@@ -264,7 +264,11 @@ export default class ExpensiMark {
                         this.currentQuoteDepth++;
                     }
 
-                    const replacedText = this.replace(textToReplace, {filterRules, shouldEscapeText: false, shouldKeepRawInput});
+                    const replacedText = this.replace(textToReplace, {
+                        filterRules,
+                        shouldEscapeText: false,
+                        shouldKeepRawInput
+                    });
                     this.currentQuoteDepth = 0;
                     return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
@@ -453,6 +457,16 @@ export default class ExpensiMark {
 
                     return `!(${g2})`;
                 }
+            },
+            {
+                name: 'roomMention',
+                regex: /<mention-report reportID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+            },
+            {
+                name: 'userMention',
+                regex: /<mention-user accountID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.accountIdToName[g1]
             }
         ];
 
@@ -498,10 +512,20 @@ export default class ExpensiMark {
                 replacement: '[Attachment]',
             },
             {
+                name: 'roomMention',
+                regex: /<mention-report reportID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+            },
+            {
+                name: 'userMention',
+                regex: /<mention-user accountID="(\d+)" \/>/gi,
+                replacement: (match, g1, extras) => extras.accountIdToName[g1]
+            },
+            {
                 name: 'stripTag',
                 regex: /(<([^>]+)>)/gi,
                 replacement: '',
-            },
+            }
         ];
 
         /**
@@ -768,10 +792,11 @@ export default class ExpensiMark {
      * Replaces HTML with markdown
      *
      * @param {String} htmlString
+     * @param {Object} extras
      *
      * @returns {String}
      */
-    htmlToMarkdown(htmlString) {
+    htmlToMarkdown(htmlString, extras = {}) {
         let generatedMarkdown = htmlString;
         const body = /<(body)(?:"[^"]*"|'[^']*'|[^'"><])*>(?:\n|\r\n)?([\s\S]*?)(?:\n|\r\n)?<\/\1>(?![^<]*(<\/pre>|<\/code>))/im;
         const parseBodyTag = generatedMarkdown.match(body);
@@ -786,7 +811,7 @@ export default class ExpensiMark {
             if (rule.pre) {
                 generatedMarkdown = rule.pre(generatedMarkdown);
             }
-            generatedMarkdown = generatedMarkdown.replace(rule.regex, rule.replacement);
+            generatedMarkdown = generatedMarkdown.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
         });
         return Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
     }
@@ -795,13 +820,15 @@ export default class ExpensiMark {
      * Convert HTML to text
      *
      * @param {String} htmlString
+     * @param {Object} extras
+     *
      * @returns {String}
      */
-    htmlToText(htmlString) {
+    htmlToText(htmlString, extras) {
         let replacedText = htmlString;
 
         this.htmlToTextRules.forEach((rule) => {
-            replacedText = replacedText.replace(rule.regex, rule.replacement);
+            replacedText = replacedText.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
         });
 
         // Unescaping because the text is escaped in 'replace' function

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -174,7 +174,7 @@ export default class ExpensiMark {
              * combination of letters and hyphens
              */
             {
-                name: 'roomMentions',
+                name: 'reportMentions',
 
                 regex: /(?<![^ \n*~_])(#[\p{Ll}0-9-]{1,80})/gmiu,
                 replacement: '<mention-report>$1</mention-report>',
@@ -581,6 +581,20 @@ export default class ExpensiMark {
         this.currentQuoteDepth = 0;
     }
 
+    getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput) {
+        let rules = this.rules;
+        if(shouldKeepRawInput) {
+            rules = this.shouldKeepWhitespaceRules;
+        }
+        if (!_.isEmpty(filterRules)) {
+            rules = _.filter(this.rules, (rule) => _.contains(filterRules, rule.name));
+        }
+        if (!_.isEmpty(disabledRules)) {
+            rules = _.filter(rules, (rule) => !_.contains(disabledRules, rule.name));
+        }
+        return rules;
+    }
+
     /**
      * Replaces markdown with html elements
      *
@@ -589,14 +603,16 @@ export default class ExpensiMark {
      * @param {String[]} [options.filterRules=[]] - An array of name of rules as defined in this class.
      * If not provided, all available rules will be applied.
      * @param {Boolean} [options.shouldEscapeText=true] - Whether or not the text should be escaped
+     * @param {String[]} [options.disabledRules=[]] - An array of name of rules as defined in this class.
+     * If not provided, all available rules will be applied. If provided, the rules in the array will be skipped.
      *
      * @returns {String}
      */
-    replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false} = {}) {
+    replace(text, {filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false, disabledRules = []} = {}) {
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? _.escape(text) : text;
-        const enabledRules = shouldKeepRawInput ? this.shouldKeepWhitespaceRules : this.rules;
-        const rules = _.isEmpty(filterRules) ? enabledRules : _.filter(this.rules, (rule) => _.contains(filterRules, rule.name));
+        const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
+
         try {
             rules.forEach((rule) => {
                 // Pre-process text before applying regex

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -459,7 +459,7 @@ export default class ExpensiMark {
                 }
             },
             {
-                name: 'roomMention',
+                name: 'reportMentions',
                 regex: /<mention-report reportID="(\d+)" *\/>/gi,
                 replacement: (match, g1, offset, string, extras) => {
                     const reportToNameMap = extras.reportIdToName;
@@ -526,7 +526,7 @@ export default class ExpensiMark {
                 replacement: '[Attachment]',
             },
             {
-                name: 'roomMention',
+                name: 'reportMentions',
                 regex: /<mention-report reportID="(\d+)" *\/>/gi,
                 replacement: (match, g1, offset, string, extras) => {
                     const reportToNameMap = extras.reportIdToName;
@@ -875,6 +875,8 @@ export default class ExpensiMark {
         let replacedText = htmlString;
 
         this.htmlToTextRules.forEach((rule) => {
+
+            // if replacement is a function, we want to pass optional extras to it
             const replacementFunction = typeof rule.replacement === 'function' ? (...args) => rule.replacement(...args, extras) : rule.replacement;
             replacedText = replacedText.replace(rule.regex, replacementFunction);
         });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -460,14 +460,28 @@ export default class ExpensiMark {
             },
             {
                 name: 'roomMention',
-                regex: /<mention-report reportID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+                regex: /<mention-report reportID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const reportToNameMap = extras.reportIdToName;
+                    if (!reportToNameMap || !reportToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return reportToNameMap[g1];
+                },
             },
             {
                 name: 'userMention',
-                regex: /<mention-user accountID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.accountIdToName[g1]
-            }
+                regex: /<mention-user accountID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const accountToNameMap = extras.accountIdToName;
+                    if (!accountToNameMap || !accountToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return `@${extras.accountIdToName[g1]}`;
+                },
+            },
         ];
 
         /**
@@ -513,13 +527,27 @@ export default class ExpensiMark {
             },
             {
                 name: 'roomMention',
-                regex: /<mention-report reportID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.reportIdToName[g1]
+                regex: /<mention-report reportID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const reportToNameMap = extras.reportIdToName;
+                    if (!reportToNameMap || !reportToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return reportToNameMap[g1];
+                },
             },
             {
                 name: 'userMention',
-                regex: /<mention-user accountID="(\d+)" \/>/gi,
-                replacement: (match, g1, extras) => extras.accountIdToName[g1]
+                regex: /<mention-user accountID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const accountToNameMap = extras.accountIdToName;
+                    if (!accountToNameMap || !accountToNameMap[g1]) {
+                        return '';
+                    }
+
+                    return `@${extras.accountIdToName[g1]}`;
+                },
             },
             {
                 name: 'stripTag',
@@ -811,7 +839,10 @@ export default class ExpensiMark {
             if (rule.pre) {
                 generatedMarkdown = rule.pre(generatedMarkdown);
             }
-            generatedMarkdown = generatedMarkdown.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
+
+            // if replacement is a function, we want to pass optional extras to it
+            const replacementFunction = typeof rule.replacement === 'function' ? (...args) => rule.replacement(...args, extras) : rule.replacement;
+            generatedMarkdown = generatedMarkdown.replace(rule.regex, replacementFunction);
         });
         return Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
     }
@@ -828,7 +859,8 @@ export default class ExpensiMark {
         let replacedText = htmlString;
 
         this.htmlToTextRules.forEach((rule) => {
-            replacedText = replacedText.replace(rule.regex, typeof rule.replacement === "function" && extras ? (match, g1) => rule.replacement(match, g1, extras) : rule.replacement);
+            const replacementFunction = typeof rule.replacement === 'function' ? (...args) => rule.replacement(...args, extras) : rule.replacement;
+            replacedText = replacedText.replace(rule.regex, replacementFunction);
         });
 
         // Unescaping because the text is escaped in 'replace' function


### PR DESCRIPTION
This PR consists of two different changes
1.  `htmlToMarkdown` method now has additional, optional argument `extras` this argument adds the possibility to pass extra data which can be used in replacement function. For now is used to pass accountID to name and reportID to name maps
2. `replace` method has additional object key `disabledRules`. Every rule name from this array will be skipped in parsing.

### Fixed Issues
$ https://github.com/Expensify/App/issues/40480
https://github.com/Expensify/App/issues/39550


# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
The changes, which this PR introduces, allows to more precisely interact with parser. To be precise, now we will be able to pass application state to the parser itself. We wrote couple of unit tests which mocks passing `extras` object with account ID and reportID maps to ensure that parsing shortened room and user mentions tags works as intended.

1. What tests did you perform that validates your changed worked?
We also tested our changes inside E/App. It's not yet supported on main branch, but all changes worked as intended

# QA
1. What does QA need to do to validate your changes?
These changes cannot be tested on E/App yet. Only follow-up PR will be using these changes
1. What areas to they need to test for regressions?
As we were touching methods responsible for both HTML –> markdown and markdown -> HTML we should look for regressions in every rule and parsing.
