### PR TITLE
Create explicit `rawInputReplacement` function for userMentions

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1813,6 +1813,12 @@ describe('when should keep raw input flag is enabled', () => {
             const resultString = '<a href="mailto:mail@mail.com" data-raw-href="mailto:mail@mail.com" data-link-variant="labeled"><strong>mail</strong></a>';
             expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
         });
+
+        test('user mention from phone number', () => {
+            const testString = '@+1234567890';
+            const resultString = '<mention-user>@+1234567890</mention-user>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
     });
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -199,6 +199,12 @@ export default class ExpensiMark {
                     const phoneRegex = new RegExp(`^@${Constants.CONST.REG_EXP.PHONE_PART}$`);
                     return `${g1}<mention-user>${g2}${phoneRegex.test(g2) ? `@${Constants.CONST.SMS.DOMAIN}` : ''}</mention-user>`;
                 },
+                rawInputReplacement: (match, g1, g2) => {
+                    if (!Str.isValidMention(match)) {
+                        return match;
+                    }
+                    return `${g1}<mention-user>${g2}</mention-user>`;
+                },
             },
 
             {


### PR DESCRIPTION
Extends the implementation of `userMentions` to include explicit `rawInputReplacement` function.  With this change we ensure that input string is not changed when `shouldKeepRawInput` flag is raised

### Fixed Issues
$ https://github.com/Expensify/App/issues/40414

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
I"ve added unit test to catch the situation when input string contains phone number mention and `shouldKeepRawInput` flag is raised.

1. What tests did you perform that validates your changed worked?
I've tested it inside `react-native-live-markdown` example library - with this change we no longer experience console.error described in linked issue.

# QA
1. What does QA need to do to validate your changes?
Updating `expensify-common` version inside parser directory of `react-native-live-markdown` and testing it inside it's example application
1. What areas to they need to test for regressions?
As we are only introducing separate `rawInputReplacement` there should be no regressions outside of `react-native-live-markdown` and Composer component inside `E/App`