### PR TITLE
Improve markdown italicizing when following tags

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -57,6 +57,16 @@ test('Test italic markdown replacement', () => {
     expect(parser.replace(italicTestStartString)).toBe(italicTestReplacedString);
 });
 
+test('Test italic markdown replacement', () => {
+    const italicTestStartString = 'Note that _this is correctly italicized_\n'
+        + 'Note that `_this is correctly not italicized_` and _following inline contents are italicized_'
+        
+    const italicTestReplacedString = 'Note that <em>this is correctly italicized</em><br />'
+        + 'Note that <code>_this is correctly not italicized_</code> and <em>following inline contents are italicized</em>'
+        
+    expect(parser.replace(italicTestStartString)).toBe(italicTestReplacedString);
+});
+
 // Multi-line text wrapped in _ is successfully replaced with <em></em>
 test('Test multi-line italic markdown replacement', () => {
     const testString = '_Here is a multi-line\ncomment that should\nbe italic_ \n_\n_test\n_';

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -282,6 +282,11 @@ export default class ExpensiMark {
                     return `<blockquote>${isStartingWithSpace ? ' ' : ''}${replacedText}</blockquote>`;
                 },
             },
+            /**
+             * Use \b in this case because it will match on words, letters,
+             * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
+             * Use [\s\S]* instead of .* to match newline
+             */
             {
                 name: 'italic',
                 regex: /(<(pre|code|a|mention-user)[^>]*>(.*?)<\/\2>)|((\b_+|\b)_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(?![^\W_])(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>)))/g,

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -177,7 +177,7 @@ export default class ExpensiMark {
             {
                 name: 'reportMentions',
 
-                regex: /(?<![^ \n*~_])(#[\p{Ll}0-9-]{1,80})/gmiu,
+                regex: /(?<![^ \n*~_])(#[\p{Ll}0-9-]{1,80})/gimu,
                 replacement: '<mention-report>$1</mention-report>',
             },
 
@@ -283,23 +283,19 @@ export default class ExpensiMark {
                 },
             },
             {
-                /**
-                 * Use \b in this case because it will match on words, letters,
-                 * and _: https://www.rexegg.com/regex-boundaries.html#wordboundary
-                 * The !_blank is to prevent the `target="_blank">` section of the
-                 * link replacement from being captured Additionally, something like
-                 * `\b\_([^<>]*?)\_\b` doesn't work because it won't replace
-                 * `_https://www.test.com_`
-                 * Use [\s\S]* instead of .* to match newline
-                 */
                 name: 'italic',
-                regex: /(?<!<[^>]*)(\b_+|\b)(?!_blank")_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(?![^\W_])(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|_blank))/g,
+                regex: /(<(pre|code|a|mention-user)[^>]*>(.*?)<\/\2>)|((\b_+|\b)_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(?![^\W_])(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>)))/g,
+                replacement: (match, html, tag, content, text, extraLeadingUnderscores, textWithinUnderscores) => {
+                    // Skip any <pre>, <code>, <a>, <mention-user> tag contents
+                    if (html) {
+                        return html;
+                    }
 
-                // We want to add extraLeadingUnderscores back before the <em> tag unless textWithinUnderscores starts with valid email
-                replacement: (match, extraLeadingUnderscores, textWithinUnderscores) => {
+                    // If any tags are included inside underscores, ignore it. ie. _abc <pre>pre tag</pre> abc_
                     if (textWithinUnderscores.includes('</pre>') || this.containsNonPairTag(textWithinUnderscores)) {
                         return match;
                     }
+
                     if (String(textWithinUnderscores).match(`^${Constants.CONST.REG_EXP.MARKDOWN_EMAIL}`)) {
                         return `<em>${extraLeadingUnderscores}${textWithinUnderscores}</em>`;
                     }


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/41110
This PR is to fix italicizing the context which are following `<code>,<pre>,<a>` tags in one line.

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Passed all existing test cases and Added one more test case for this purpose.
1. What tests did you perform that validates your changed worked?
bump expensify-common version in E/App and `react-native-live-markdown` to this PR and tested locally
![330365055-4134416a-eb49-42fc-8884-697b7f265cee](https://github.com/Expensify/expensify-common/assets/25519849/3694017a-5f3c-4198-afcc-2f1201dd318c)

# QA
1. What does QA need to do to validate your changes?
bump expensify-common version in E/App and use chat normally - sent messages should be parsed with the new rule
1. What areas do they need to test for regressions?
Italic markdown following `<code>,<pre>,<a>,<mention-user>` tags in one line