### PR TITLE
Allow empty blockquotes

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1040,15 +1040,15 @@ test('Test quotes markdown replacement and removing <br/> from <br/><pre> and </
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test quotes markdown replacement skipping blank quotes', () => {
+test('Test quotes markdown replacement including blank quotes', () => {
     const testString = '> \n>';
-    const resultString = '&gt; <br />&gt;';
+    const resultString = '<blockquote></blockquote>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test quotes markdown replacement with text starts with blank quote', () => {
     const testString = '> \ntest';
-    const resultString = '&gt; <br />test';
+    const resultString = '<blockquote></blockquote>test';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -1078,7 +1078,7 @@ test('Test quotes markdown replacement with quotes includes multiple middle blan
 
 test('Test quotes markdown replacement with text includes blank quotes', () => {
     const testString = '> \n> quote1 line a\n> quote1 line b\ntest\n> \ntest\n> quote2 line a\n> \n> \n> quote2 line b with an empty line above';
-    const resultString = '<blockquote>quote1 line a<br />quote1 line b</blockquote>test<br />&gt; <br />test<br /><blockquote>quote2 line a<br /><br /><br />quote2 line b with an empty line above</blockquote>';
+    const resultString = '<blockquote>quote1 line a<br />quote1 line b</blockquote>test<br /><blockquote></blockquote>test<br /><blockquote>quote2 line a<br /><br /><br />quote2 line b with an empty line above</blockquote>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1040,15 +1040,15 @@ test('Test quotes markdown replacement and removing <br/> from <br/><pre> and </
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test quotes markdown replacement including blank quotes', () => {
+test('Test quotes markdown replacement skipping blank quotes', () => {
     const testString = '> \n>';
-    const resultString = '<blockquote></blockquote>';
+    const resultString = '&gt; <br />&gt;';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
 test('Test quotes markdown replacement with text starts with blank quote', () => {
     const testString = '> \ntest';
-    const resultString = '<blockquote></blockquote>test';
+    const resultString = '&gt; <br />test';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -1078,7 +1078,7 @@ test('Test quotes markdown replacement with quotes includes multiple middle blan
 
 test('Test quotes markdown replacement with text includes blank quotes', () => {
     const testString = '> \n> quote1 line a\n> quote1 line b\ntest\n> \ntest\n> quote2 line a\n> \n> \n> quote2 line b with an empty line above';
-    const resultString = '<blockquote>quote1 line a<br />quote1 line b</blockquote>test<br /><blockquote></blockquote>test<br /><blockquote>quote2 line a<br /><br /><br />quote2 line b with an empty line above</blockquote>';
+    const resultString = '<blockquote>quote1 line a<br />quote1 line b</blockquote>test<br />&gt; <br />test<br /><blockquote>quote2 line a<br /><br /><br />quote2 line b with an empty line above</blockquote>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -239,7 +239,7 @@ export default class ExpensiMark {
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
                 process: (textToProcess, replacement, shouldKeepRawInput = false) => {
-                    const regex = /^(?:&gt;)+ +(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm;
+                    const regex = /^(?:&gt;)+ +(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]*)/gm;
                     const replaceFunction = (g1) => replacement(g1, shouldKeepRawInput);
                     if (shouldKeepRawInput) {
                         return textToProcess.replace(regex, replaceFunction);

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -239,10 +239,11 @@ export default class ExpensiMark {
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
                 process: (textToProcess, replacement, shouldKeepRawInput = false) => {
-                    const regex = /^(?:&gt;)+ +(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]*)/gm;
+                    const regex = /^(?:&gt;)+ +(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]+)/gm;
                     const replaceFunction = (g1) => replacement(g1, shouldKeepRawInput);
                     if (shouldKeepRawInput) {
-                        return textToProcess.replace(regex, replaceFunction);
+                        const rawInputRegex = /^(?:&gt;)+ +(?! )(?![^<]*(?:<\/pre>|<\/code>))([^\v\n\r]*)/gm;
+                        return textToProcess.replace(rawInputRegex, replaceFunction);
                     }
                     return this.modifyTextForQuote(regex, textToProcess, replacement);
                 },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR changes the way we parse blockquotes in shouldKeepRawInput mode - empty blockquotes will not be excluded by the regex.

<img width="426" alt="image" src="https://github.com/Expensify/expensify-common/assets/45288762/c3b28f4e-8449-42c8-aa7e-9e006f7ed5f5">
 
### Fixed Issues
$ https://github.com/Expensify/App/issues/41107

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
There are no tests verifying the shouldKeepRawInput flag paths, but all the existing tests are passing as expected (the logic is supposed to change only for the react-native-live-markdown).

2. What tests did you perform that validates your changed worked?
I verified how it works by applying a proper patch including a modified regex in react-native-live-markdown.

# QA
1. What does QA need to do to validate your changes?
bump expensify-common version in E/App and use chat normally - sent messages should be parsed with the new rule

2. What areas to they need to test for regressions?
All quotes usage scenarios are vulnerable to regressions