### PR TITLE
Modify mention user and mention report extras field names in ExpensiMark htmlToText and htmlToMarkdown rules

### DIFF
--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -151,7 +151,7 @@ test('Mention user html to text', () => {
     expect(parser.htmlToText(testString)).toBe('@Hidden');
 
     const extras = {
-        accountIdToName: {
+        accountIDToName: {
             '1234': 'user@domain.com',
         },
     };
@@ -180,7 +180,7 @@ test('Mention report html to text', () => {
     expect(parser.htmlToText(testString)).toBe('#Hidden');
 
     const extras = {
-        reportIdToName: {
+        reportIDToName: {
             '1234': '#room-name',
         },
     };

--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -765,7 +765,7 @@ test('Mention user html to markdown', () => {
     expect(parser.htmlToMarkdown(testString)).toBe('@Hidden');
 
     const extras = {
-        accountIdToName: {
+        accountIDToName: {
             '1234': 'user@domain.com',
         },
     };
@@ -794,7 +794,7 @@ test('Mention report html to markdown', () => {
     expect(parser.htmlToText(testString)).toBe('#Hidden');
 
     const extras = {
-        reportIdToName: {
+        reportIDToName: {
             '1234': '#room-name',
         },
     };

--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -35,7 +35,7 @@ declare type Rule = {
 };
 
 declare type ExtrasObject = {
-    reportIdToName?: Record<string, string>;
+    reportIDToName?: Record<string, string>;
     accountIDToName?: Record<string, string>;
 };
 export default class ExpensiMark {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -464,7 +464,7 @@ export default class ExpensiMark {
                 name: 'reportMentions',
                 regex: /<mention-report reportID="(\d+)" *\/>/gi,
                 replacement: (match, g1, offset, string, extras) => {
-                    const reportToNameMap = extras.reportIdToName;
+                    const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
                         Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
                         return '#Hidden';
@@ -478,13 +478,13 @@ export default class ExpensiMark {
                 regex: /(?:<mention-user accountID="(\d+)" *\/>)|(?:<mention-user>(.*?)<\/mention-user>)/gi,
                 replacement: (match, g1, g2, offset, string, extras) => {
                     if (g1) {
-                        const accountToNameMap = extras.accountIdToName;
+                        const accountToNameMap = extras.accountIDToName;
                         if (!accountToNameMap || !accountToNameMap[g1]) {
                             Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
                             return '@Hidden';
                         }
     
-                        return `@${extras.accountIdToName[g1]}`;
+                        return `@${accountToNameMap[g1]}`;
                     }
                     return Str.removeSMSDomain(g2)
                 },
@@ -536,7 +536,7 @@ export default class ExpensiMark {
                 name: 'reportMentions',
                 regex: /<mention-report reportID="(\d+)" *\/>/gi,
                 replacement: (match, g1, offset, string, extras) => {
-                    const reportToNameMap = extras.reportIdToName;
+                    const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
                         Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
                         return '#Hidden';
@@ -547,15 +547,18 @@ export default class ExpensiMark {
             },
             {
                 name: 'userMention',
-                regex: /<mention-user accountID="(\d+)" *\/>/gi,
-                replacement: (match, g1, offset, string, extras) => {
-                    const accountToNameMap = extras.accountIdToName;
-                    if (!accountToNameMap || !accountToNameMap[g1]) {
-                        Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
-                        return '@Hidden';
-                    }
+                regex: /(?:<mention-user accountID="(\d+)" *\/>)|(?:<mention-user>(.*?)<\/mention-user>)/gi,
+                replacement: (match, g1, g2, offset, string, extras) => {
+                    if (g1) {
+                        const accountToNameMap = extras.accountIDToName;
+                        if (!accountToNameMap || !accountToNameMap[g1]) {
+                            Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
+                            return '@Hidden';
+                        }
 
-                    return `@${extras.accountIdToName[g1]}`;
+                        return `@${accountToNameMap[g1]}`;
+                    }
+                    return Str.removeSMSDomain(g2)
                 },
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -483,10 +483,10 @@ export default class ExpensiMark {
                             Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
                             return '@Hidden';
                         }
-    
+
                         return `@${accountToNameMap[g1]}`;
                     }
-                    return Str.removeSMSDomain(g2)
+                    return Str.removeSMSDomain(g2);
                 },
             },
         ];
@@ -558,7 +558,7 @@ export default class ExpensiMark {
 
                         return `@${accountToNameMap[g1]}`;
                     }
-                    return Str.removeSMSDomain(g2)
+                    return Str.removeSMSDomain(g2);
                 },
             },
             {

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -484,7 +484,7 @@ export default class ExpensiMark {
                             return '@Hidden';
                         }
 
-                        return `@${accountToNameMap[g1]}`;
+                        return `@${extras.accountIDToName[g1]}`;
                     }
                     return Str.removeSMSDomain(g2);
                 },
@@ -547,18 +547,14 @@ export default class ExpensiMark {
             },
             {
                 name: 'userMention',
-                regex: /(?:<mention-user accountID="(\d+)" *\/>)|(?:<mention-user>(.*?)<\/mention-user>)/gi,
-                replacement: (match, g1, g2, offset, string, extras) => {
-                    if (g1) {
-                        const accountToNameMap = extras.accountIDToName;
-                        if (!accountToNameMap || !accountToNameMap[g1]) {
-                            Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
-                            return '@Hidden';
-                        }
-
-                        return `@${accountToNameMap[g1]}`;
+                regex: /<mention-user accountID="(\d+)" *\/>/gi,
+                replacement: (match, g1, offset, string, extras) => {
+                    const accountToNameMap = extras.accountIDToName;
+                    if (!accountToNameMap || !accountToNameMap[g1]) {
+                        Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
+                        return '@Hidden';
                     }
-                    return Str.removeSMSDomain(g2);
+                    return `@${extras.accountIDToName[g1]}`;
                 },
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR changes field name of extras in ExpensiMark to fix type check fails.
Modify mention user and mention report extras field names in ExpensiMark htmlToText and htmlToMarkdown rules

### Fixed Issues
$ https://github.com/Expensify/App/issues/40928

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
typecheck on expensify/App should run successfully

1. What tests did you perform that validates your changed worked?
I have tested it on my other PR, thread report from report action that contains mention room and mention user should display report name properly in header report and in LHN.

# QA
1. What does QA need to do to validate your changes?
N/A

1. What areas to they need to test for regressions?
N/A