### PR TITLE
Use new logic to check bold text

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -23,6 +23,18 @@ test('Test multi-line bold HTML replacement', () => {
     expect(parser.htmlToMarkdown(testString)).toBe(replacedString);
 });
 
+test('Converts <b> tags with font-weight 700 inline style in between to markdown bold', () => {
+    const input = '<b><span style="font-weight:400;">This is a text with </span><span style="font-weight:700;">nested bold</span><span style="font-weight:400;"> content</span></b>';
+    const expected = 'This is a text with *nested bold* content';
+    expect(parser.htmlToMarkdown(input)).toBe(expected);
+});
+
+test('Does not convert <b> tags with font-weight normal inline style to markdown bold', () => {
+    const input = '<b><span style="font-weight:400;">This is a text with </span><span style="font-weight:normal;">no bold</span><span style="font-weight:400;"> content</span></b>';
+    const expected = 'This is a text with no bold content';
+    expect(parser.htmlToMarkdown(input)).toBe(expected);
+});
+
 test('Test italic HTML replacement', () => {
     const italicTestStartString = 'This is a <em>sentence,</em> and it has some <em>punctuation, words, and spaces</em>. <em>test</em> _ testing_ test_test_test. _ test _ _test _ '
         + 'This is a <i>sentence,</i> and it has some <i>punctuation, words, and spaces</i>. <i>test</i> _ testing_ test_test_test. _ test _ _test _';


### PR DESCRIPTION
Use new logic to check bold text: https://github.com/Expensify/App/issues/41109#issuecomment-2095057640

### Fixed Issues
$ https://github.com/Expensify/App/issues/41109

Tests and QA steps:

1. Type anything on a Google document.
2. Copy it.
3. Paste it in Expensify.
4. Check if the font is still normal (it shouldn't be bold).
5. Now, type something in bold text on a Google document.
6. Copy/paste to Expensify.
7. It should show in bold.


https://github.com/Expensify/expensify-common/assets/35566748/86e457a4-919a-46af-b261-8d9565763be8


https://github.com/Expensify/expensify-common/assets/35566748/3c22cbc6-c51e-42b3-b318-f918907035aa


