### PR TITLE
Remove `Log.alert` usages

### DIFF
--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -493,7 +493,8 @@ export default class ExpensiMark {
                 replacement: (match, g1, offset, string, extras) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
-                        Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
+                        // eslint-disable-next-line no-console
+                        console.warn('[ExpensiMark] Missing report name', {reportID: g1});
                         return '#Hidden';
                     }
 
@@ -507,7 +508,8 @@ export default class ExpensiMark {
                     if (g1) {
                         const accountToNameMap = extras.accountIDToName;
                         if (!accountToNameMap || !accountToNameMap[g1]) {
-                            Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
+                            // eslint-disable-next-line no-console
+                            console.warn('[ExpensiMark] Missing account name', {accountID: g1});
                             return '@Hidden';
                         }
 
@@ -565,7 +567,8 @@ export default class ExpensiMark {
                 replacement: (match, g1, offset, string, extras) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
-                        Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
+                        // eslint-disable-next-line no-console
+                        console.warn('[ExpensiMark] Missing report name', {reportID: g1});
                         return '#Hidden';
                     }
 
@@ -578,7 +581,8 @@ export default class ExpensiMark {
                 replacement: (match, g1, offset, string, extras) => {
                     const accountToNameMap = extras.accountIDToName;
                     if (!accountToNameMap || !accountToNameMap[g1]) {
-                        Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
+                        // eslint-disable-next-line no-console
+                        console.warn('[ExpensiMark] Missing account name', {accountID: g1});
                         return '@Hidden';
                     }
                     return `@${extras.accountIDToName[g1]}`;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -2,7 +2,6 @@ import * as _ from 'underscore';
 import Str from './str';
 import * as Constants from './CONST';
 import * as UrlPatterns from './Url';
-import Log from './Log';
 
 const MARKDOWN_LINK_REGEX = new RegExp(`\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
 const MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/42161

Quick-fix PR removing `Log.alert` usages since it makes mobile apps fail. jQuery can't be used on mobile devices

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
