### PR TITLE
Add static logger to ExpensiMark

### DIFF
--- a/lib/ExpensiMark.d.ts
+++ b/lib/ExpensiMark.d.ts
@@ -1,3 +1,5 @@
+import type Logger from './Logger';
+
 declare type Replacement = (...args: string[], extras?: ExtrasObject) => string;
 declare type Name =
     | 'codeFence'
@@ -39,6 +41,9 @@ declare type ExtrasObject = {
     accountIDToName?: Record<string, string>;
 };
 export default class ExpensiMark {
+    static Log: Logger;
+    static setLogger(logger: Logger): void;
+
     rules: Rule[];
     htmlToMarkdownRules: Rule[];
     htmlToTextRules: Rule[];

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -1,8 +1,8 @@
+/* eslint-disable no-console */
 import * as _ from 'underscore';
 import Str from './str';
 import * as Constants from './CONST';
 import * as UrlPatterns from './Url';
-import Log from './Log';
 
 const MARKDOWN_LINK_REGEX = new RegExp(`\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
 const MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
@@ -10,6 +10,22 @@ const MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
 export default class ExpensiMark {
+    static Log = {
+        info: console.log,
+        alert: console.warn,
+        warn: console.warn,
+        hmmm: console.log,
+        client: console.log,
+    };
+
+    /**
+     * Set the logger to use for logging inside of the ExpensiMark class
+     * @param {Object} logger - The logger object to use
+     */
+    static setLogger(logger) {
+        ExpensiMark.Log = logger;
+    }
+
     constructor() {
         /**
          * The list of regex replacements to do on a comment. Check the link regex is first so links are processed
@@ -494,7 +510,7 @@ export default class ExpensiMark {
                 replacement: (match, g1, offset, string, extras) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
-                        Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
+                        ExpensiMark.Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
                         return '#Hidden';
                     }
 
@@ -508,7 +524,7 @@ export default class ExpensiMark {
                     if (g1) {
                         const accountToNameMap = extras.accountIDToName;
                         if (!accountToNameMap || !accountToNameMap[g1]) {
-                            Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
+                            ExpensiMark.Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
                             return '@Hidden';
                         }
 
@@ -566,7 +582,7 @@ export default class ExpensiMark {
                 replacement: (match, g1, offset, string, extras) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
-                        Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
+                        ExpensiMark.Log.alert('[ExpensiMark] Missing report name', {reportID: g1});
                         return '#Hidden';
                     }
 
@@ -579,7 +595,7 @@ export default class ExpensiMark {
                 replacement: (match, g1, offset, string, extras) => {
                     const accountToNameMap = extras.accountIDToName;
                     if (!accountToNameMap || !accountToNameMap[g1]) {
-                        Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
+                        ExpensiMark.Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
                         return '@Hidden';
                     }
                     return `@${extras.accountIDToName[g1]}`;

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -1,8 +1,8 @@
-/* eslint-disable no-console */
 import * as _ from 'underscore';
 import Str from './str';
 import * as Constants from './CONST';
 import * as UrlPatterns from './Url';
+import Logger from './Logger';
 
 const MARKDOWN_LINK_REGEX = new RegExp(`\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)]\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
 const MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
@@ -10,13 +10,11 @@ const MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
 export default class ExpensiMark {
-    static Log = {
-        info: console.log,
-        alert: console.warn,
-        warn: console.warn,
-        hmmm: console.log,
-        client: console.log,
-    };
+    static Log = new Logger({
+        serverLoggingCallback: _.noop,
+        clientLoggingCallback: (message) => console.warn(message),
+        isDebug: true,
+    });
 
     /**
      * Set the logger to use for logging inside of the ExpensiMark class

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -12,6 +12,7 @@ const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type=
 export default class ExpensiMark {
     static Log = new Logger({
         serverLoggingCallback: _.noop,
+        // eslint-disable-next-line no-console
         clientLoggingCallback: (message) => console.warn(message),
         isDebug: true,
     });


### PR DESCRIPTION
Currently using `Log.alert` in `ExpensiMark` [causes E/App to crash](https://github.com/Expensify/App/issues/42161#issuecomment-2145151574), to avoid this we want to add possibility to set your own logger in `ExpensiMark` and provide errorless default logger that just `console.warns`. 

### Fixed Issues
$ https://github.com/Expensify/App/issues/42161

