### PR TITLE
fix mention preview with invalid phone number

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1844,9 +1844,15 @@ describe('when should keep raw input flag is enabled', () => {
             expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
         });
 
-        test('user mention from phone number', () => {
+        test('user mention from invalid phone number', () => {
             const testString = '@+1234567890';
-            const resultString = '<mention-user>@+1234567890</mention-user>';
+            const resultString = '@+1234567890';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+
+        test('user mention from valid phone number', () => {
+            const testString = '@+15005550006';
+            const resultString = '<mention-user>@+15005550006</mention-user>';
             expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
         });
     });

--- a/lib/ExpensiMark.js
+++ b/lib/ExpensiMark.js
@@ -214,7 +214,10 @@ export default class ExpensiMark {
                     return `${g1}<mention-user>${g2}${phoneRegex.test(g2) ? `@${Constants.CONST.SMS.DOMAIN}` : ''}</mention-user>`;
                 },
                 rawInputReplacement: (match, g1, g2) => {
-                    if (!Str.isValidMention(match)) {
+                    const phoneNumberRegex = new RegExp(`^${Constants.CONST.REG_EXP.PHONE_PART}$`);
+                    const mention = g2.slice(1);
+                    const mentionWithoutSMSDomain = Str.removeSMSDomain(mention);
+                    if (!Str.isValidMention(match) || (phoneNumberRegex.test(mentionWithoutSMSDomain) && !Str.isValidPhoneNumber(mentionWithoutSMSDomain))) {
                         return match;
                     }
                     return `${g1}<mention-user>${g2}</mention-user>`;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

Update `rawInputReplacement` of `userMetion` rule to not display as `mention` for the invalid phone number in the live preview.

### Fixed Issues
$ https://github.com/Expensify/App/issues/41078

# Tests
The auto test is updated and added.
# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
