### PR TITLE
Update packages to fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13012,9 +13012,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
The main dependency `jest-environment-jsdom` does not have any updates so I updated the package with `npm update ws`

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/407146

# Tests
It's a dev dependency for tests so as long as tests are still passing, we should be good.

# QA
N/A
