### PR TITLE
update htmlToMarkdownRules userMention and reportMention

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -786,6 +786,9 @@ test('Mention user html to markdown', () => {
 
     testString = '<mention-user accountID="1234" />';
     expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
+
+    testString = '<mention-user accountID="1234"></mention-user>';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('@user@domain.com');
 });
 
 test('Mention report html to markdown', () => {
@@ -814,6 +817,9 @@ test('Mention report html to markdown', () => {
     expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
 
     testString = '<mention-report reportID="1234" />';
+    expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
+
+    testString = '<mention-report reportID="1234"></mention-report>';
     expect(parser.htmlToMarkdown(testString, extras)).toBe('#room-name');
 });
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -647,7 +647,7 @@ export default class ExpensiMark {
 
             {
                 name: 'reportMentions',
-                regex: /<mention-report reportID="(\d+)" *\/>/gi,
+                regex: /<mention-report reportID="(\d+)"(?: *\/>|><\/mention-report>)/gi,
                 replacement: (extras, _match, g1, _offset, _string) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
@@ -660,7 +660,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'userMention',
-                regex: /(?:<mention-user accountID="(\d+)" *\/>)|(?:<mention-user>(.*?)<\/mention-user>)/gi,
+                regex: /(?:<mention-user accountID="(\d+)"(?: *\/>|><\/mention-user>))|(?:<mention-user>(.*?)<\/mention-user>)/gi,
                 replacement: (extras, _match, g1, g2, _offset, _string) => {
                     if (g1) {
                         const accountToNameMap = extras.accountIDToName;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
CC @marcaaron @lakchote @eh2077 

When We copy `<mention-user accountID="1234" />` as `text/html` to clipboard on the web [here](https://github.com/Expensify/App/blob/571a79d3d43f68ace68406a2e4bcb17604289103/src/libs/Clipboard/index.ts#L119-L123). The paste value [here](https://github.com/Expensify/App/blob/d0513b9513a091cb49f79fbc429b73d2a987cfce/src/hooks/useHtmlPaste/index.ts#L109) paste with different format `<meta charset='utf-8'><html><head></head><body><mention-user accountid="1234"></mention-user></body></html>`

(`<openTag></closeTag>` not `<closedTag />`), and this format not match rule `reportMention` in `ExpensiMark`

This issue will update htmlToMarkdownRules `userMention` and `reportMention` regex to work for both self closing and non self closing tags.

### Fixed Issues
$ https://github.com/Expensify/App/issues/40477
$ https://github.com/Expensify/App/issues/40403

# Tests
1. pull this branch
2. run `npm install & npm run build`
3. copy `dist` folder to E/App to `node_modules/expensify-common/dist`
4. run E/App and open any report
5. mention a user in message and send it
6. right click > copy to clipboard and paste it in a composer and Verify that message is pasted correctly
7. mention a report in message and send it
8. right click > copy to clipboard and paste it in a composer and Verify that message is pasted correctly

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/Expensify/expensify-common/assets/41129870/1b5d617e-a637-4e2b-81e1-f241a2b49bc1



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/Expensify/expensify-common/assets/41129870/727e45f3-502e-4b24-8822-abed72c76bd4



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/Expensify/expensify-common/assets/41129870/d2be1322-e597-4049-b72c-d1a8df474e65



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/Expensify/expensify-common/assets/41129870/b58a0e9c-c6fd-44af-b7dd-b1f171790cf8



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/Expensify/expensify-common/assets/41129870/8c68d435-11f7-4afe-854c-37434a400d62



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/expensify-common/assets/41129870/5025f48e-fc4d-414c-996e-71a8367940f1



</details>

