### PR TITLE
Rename `escape`/`unescape` to `escapeText`/`unescapeText`

### DIFF
--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -25,7 +25,7 @@ test('Test with regex Maximum regex stack depth reached error', () => {
         throw new Error('Maximum regex stack depth reached');
     });
     expensiMarkParser.modifyTextForUrlLinks = modifyTextForUrlLinksMock;
-    expect(expensiMarkParser.replace(testString)).toBe(Utils.escape(testString));
+    expect(expensiMarkParser.replace(testString)).toBe(Utils.escapeText(testString));
     expect(modifyTextForUrlLinksMock).toHaveBeenCalledTimes(1);
 
     // Mock method extractLinksInMarkdownComment to let it return undefined to test try/catch of method ExpensiMark.extractLinksInMarkdownComment

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -812,7 +812,7 @@ export default class ExpensiMark {
      */
     replace(text: string, {filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false, disabledRules = [], extras = EXTRAS_DEFAULT}: ReplaceOptions = {}): string {
         // This ensures that any html the user puts into the comment field shows as raw html
-        let replacedText = shouldEscapeText ? Utils.escape(text) : text;
+        let replacedText = shouldEscapeText ? Utils.escapeText(text) : text;
         const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
 
         const processRule = (rule: Rule) => {
@@ -838,7 +838,7 @@ export default class ExpensiMark {
             ExpensiMark.Log.alert('Error replacing text with html in ExpensiMark.replace', {error: e});
 
             // We want to return text without applying rules if exception occurs during replacing
-            return shouldEscapeText ? Utils.escape(text) : text;
+            return shouldEscapeText ? Utils.escapeText(text) : text;
         }
 
         return replacedText;
@@ -1230,7 +1230,7 @@ export default class ExpensiMark {
         // When the attribute contains HTML and is converted back to MD we need to re-escape it to avoid
         // illegal attribute value characters like `," or ' which might break the HTML
         originalContent = Str.replaceAll(originalContent, '\n', '');
-        return Utils.escape(originalContent);
+        return Utils.escapeText(originalContent);
     }
 
     /**

--- a/lib/components/form/element/combobox.js
+++ b/lib/components/form/element/combobox.js
@@ -937,7 +937,7 @@ class Combobox extends React.Component {
                     aria-label="..."
                     onChange={this.performSearch}
                     onKeyDown={this.closeDropdownOnTabOut}
-                    value={this.props.propertyToDisplay === 'value' ? Utils.unescape(this.state.currentValue) : Utils.unescape(this.state.currentText.replace(/&nbsp;/g, ''))}
+                    value={this.props.propertyToDisplay === 'value' ? Utils.unescapeText(this.state.currentValue) : Utils.unescapeText(this.state.currentText.replace(/&nbsp;/g, ''))}
                     onFocus={this.openDropdown}
                     autoComplete="off"
                     placeholder={this.props.placeholder}

--- a/lib/str.ts
+++ b/lib/str.ts
@@ -107,7 +107,7 @@ const Str = {
      * @returns The escaped string
      */
     safeEscape(s: string) {
-        return Utils.escape(Utils.unescape(s));
+        return Utils.escapeText(Utils.unescapeText(s));
     },
 
     /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,7 +24,7 @@ const reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
  * corresponding HTML entities.
  * Source: https://github.com/lodash/lodash/blob/main/src/escape.ts
  */
-function escape(string: string): string {
+function escapeText(string: string): string {
     return string && reHasUnescapedHtml.test(string) ? string.replace(reUnescapedHtml, (chr) => htmlEscapes[chr as keyof typeof htmlEscapes]) : string || '';
 }
 
@@ -47,7 +47,7 @@ const reHasEscapedHtml = RegExp(reEscapedHtml.source);
  * their corresponding characters.
  * Source: https://github.com/lodash/lodash/blob/main/src/unescape.ts
  * */
-function unescape(string: string): string {
+function unescapeText(string: string): string {
     return string && reHasEscapedHtml.test(string) ? string.replace(reEscapedHtml, (entity) => htmlUnescapes[entity as keyof typeof htmlUnescapes] || "'") : string || '';
 }
 
@@ -70,4 +70,4 @@ function isObject(obj: unknown): boolean {
     return type === 'function' || (!!obj && type === 'object');
 }
 
-export {isWindowAvailable, isNavigatorAvailable, escape, unescape, isFunction, isObject};
+export {isWindowAvailable, isNavigatorAvailable, escapeText, unescapeText, isFunction, isObject};


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This PR renames `escape` and `unescape` functions in `Utils` module to `escapeText` and `unescapeText`, accordingly.

The reason for this change is that, although deprecated, both `escape` and `unescape` are built-in JavaScript functions:
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape

Hence, these names might be confusing for other third-party libraries that rely on this rule, e.g. Reanimated Babel plugin.

These changes are needed for `ExpensiMark` to work properly in worklets in `react-native-live-markdown`:
* https://github.com/Expensify/react-native-live-markdown/issues/317

### Fixed Issues
$ GH_LINK

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
