### PR TITLE
Allow emoji as link text

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -295,7 +295,7 @@ test('Test markdown replacement for invalid emails', () => {
 
 test('Test markdown replacement for emojis with emails', () => {
     const testString =
-        'Do not replace the emoji with link ' +
+        'Replace the emoji with link ' +
         '[😄](abc@gmail.com) ' +
         '[😄]( abc@gmail.com) ' +
         '[😄] abc@gmail.com ' +
@@ -303,7 +303,7 @@ test('Test markdown replacement for emojis with emails', () => {
         '[😄abc@gmail.com](abc@gmail.com) ' +
         '[😄 abc@gmail.com ](abc@gmail.com) ';
     const result =
-        'Do not replace the emoji with link ' +
+        'Replace the emoji with link ' +
         '<a href=\"mailto:abc@gmail.com\"><emoji>😄</emoji></a> ' +
         '[<emoji>😄</emoji>]( <a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
         '[<emoji>😄</emoji>] <a href="mailto:abc@gmail.com">abc@gmail.com</a> ' +
@@ -1198,6 +1198,7 @@ test('Test for link with no content', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+// Replace the emoji with email link
 test('Test for link with emoji', () => {
     const testString = '[😀](www.link.com)';
     const resultString = '<a href="https://www.link.com" target="_blank" rel="noreferrer noopener"><emoji>😀</emoji></a>';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -304,12 +304,12 @@ test('Test markdown replacement for emojis with emails', () => {
         '[😄 abc@gmail.com ](abc@gmail.com) ';
     const result =
         'Do not replace the emoji with link ' +
-        '[<emoji>😄</emoji>](<a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
+        '<a href=\"mailto:abc@gmail.com\"><emoji>😄</emoji></a> ' +
         '[<emoji>😄</emoji>]( <a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
         '[<emoji>😄</emoji>] <a href="mailto:abc@gmail.com">abc@gmail.com</a> ' +
         '[<emoji>😄</emoji>]((<a href="mailto:abc@gmail.com">abc@gmail.com</a>)) ' +
-        '[<emoji>😄</emoji><a href="mailto:abc@gmail.com">abc@gmail.com</a>](<a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
-        '[<emoji>😄</emoji> <a href="mailto:abc@gmail.com">abc@gmail.com</a> ](<a href="mailto:abc@gmail.com">abc@gmail.com</a>) ';
+        '<a href="mailto:abc@gmail.com"><emoji>😄</emoji>abc@gmail.com</a> ' +
+        '<a href="mailto:abc@gmail.com"><emoji>😄</emoji> abc@gmail.com</a> ';
     expect(parser.replace(testString)).toBe(result);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1200,7 +1200,7 @@ test('Test for link with no content', () => {
 
 test('Test for link with emoji', () => {
     const testString = '[😀](www.link.com)';
-    const resultString = '[<emoji>😀</emoji>](<a href="https://www.link.com" target="_blank" rel="noreferrer noopener">www.link.com</a>)';
+    const resultString = '<a href="https://www.link.com" target="_blank" rel="noreferrer noopener"><emoji>😀</emoji></a>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/CONST.ts
+++ b/lib/CONST.ts
@@ -357,14 +357,6 @@ const CONST = {
         MARKDOWN_EMAIL: EMAIL_BASE_REGEX,
 
         /**
-         * Regex matching an text containing an Emoji
-         *
-         * @type RegExp
-         */
-        // eslint-disable-next-line no-misleading-character-class
-        EMOJIS: /[\p{Extended_Pictographic}\u200d\u{1f1e6}-\u{1f1ff}\u{1f3fb}-\u{1f3ff}\u{e0020}-\u{e007f}\u20E3\uFE0F]|[#*0-9]\uFE0F?\u20E3/gu,
-
-        /**
          * Regex matching an text containing an Emoji that can be a single emoji or made up by some different emojis
          *
          * @type RegExp

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -249,13 +249,13 @@ export default class ExpensiMark {
                 name: 'link',
                 process: (textToProcess, replacement) => this.modifyTextForUrlLinks(MARKDOWN_LINK_REGEX, textToProcess, replacement as ReplacementFn),
                 replacement: (_extras, match, g1, g2) => {
-                    if (g1.match(Constants.CONST.REG_EXP.EMOJIS) || !g1.trim()) {
+                    if (!g1.trim()) {
                         return match;
                     }
                     return `<a href="${Str.sanitizeURL(g2)}" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;
                 },
                 rawInputReplacement: (_extras, match, g1, g2) => {
-                    if (g1.match(Constants.CONST.REG_EXP.EMOJIS) || !g1.trim()) {
+                    if (!g1.trim()) {
                         return match;
                     }
                     return `<a href="${Str.sanitizeURL(g2)}" data-raw-href="${g2}" data-link-variant="labeled" target="_blank" rel="noreferrer noopener">${g1.trim()}</a>`;

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -173,7 +173,7 @@ export default class ExpensiMark {
                     return this.modifyTextForEmailLinks(regex, textToProcess, replacement as ReplacementFn, shouldKeepRawInput);
                 },
                 replacement: (_extras, match, g1, g2) => {
-                    if (g1.match(Constants.CONST.REG_EXP.EMOJIS) || !g1.trim()) {
+                    if (!g1.trim()) {
                         return match;
                     }
                     const label = g1.trim();
@@ -182,7 +182,7 @@ export default class ExpensiMark {
                     return `<a href="${href}">${formattedLabel}</a>`;
                 },
                 rawInputReplacement: (_extras, match, g1, g2, g3) => {
-                    if (g1.match(Constants.CONST.REG_EXP.EMOJIS) || !g1.trim()) {
+                    if (!g1.trim()) {
                         return match;
                     }
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/44835

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Updated unit test.

1. What tests did you perform that validates your changed worked?
a. Send a link with emoji as text (`[😄 link](google.com)`) to any user
b. Verify `😄 link` is rendered as a link

Web
<img width="352" alt="Screenshot 2024-07-11 at 12 07 30" src="https://github.com/Expensify/expensify-common/assets/50919443/0ce0c281-43ee-46ef-9fc8-cdbf81a7fd9c">

Desktop
<img width="298" alt="image" src="https://github.com/Expensify/expensify-common/assets/50919443/4a925ef9-6f71-47f9-8d50-96862757426a">

iOS mWeb
<img width="439" alt="image" src="https://github.com/Expensify/expensify-common/assets/50919443/f2d7b6a6-0ee3-4857-987b-205fd6b6bd33">

iOS
<img width="419" alt="image" src="https://github.com/Expensify/expensify-common/assets/50919443/9b7c357f-6dfb-42f8-98d3-a1139db21742">

Android mWeb
<img width="416" alt="image" src="https://github.com/Expensify/expensify-common/assets/50919443/3088cb21-8d40-4eec-97cd-1cb82dd0eff8">

Android
<img width="417" alt="image" src="https://github.com/Expensify/expensify-common/assets/50919443/6fc74f43-67f5-416a-9d15-2aae87b9f0db">

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
Same as Test step above