### PR TITLE
fix parsing markdown for multiline email hyperlink

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -191,6 +191,24 @@ test('Test markdown replacement for emails wrapped in bold/strikethrough/italic 
     expect(parser.replace(testInput)).toBe(result);
 });
 
+test('Test markdown replacement for multiline email hyperlinks', () => {
+    let testInput = '[test\ntest](test@test.com)';
+    let result = '<a href="mailto:test@test.com">test<br />test</a>';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '[test\n\n\n](test@test.com)';
+    result = '<a href="mailto:test@test.com">test</a>';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = '[test\ntest](test.com)';
+    result = '<a href="https://test.com" target="_blank" rel="noreferrer noopener">test<br />test</a>';
+    expect(parser.replace(testInput)).toBe(result);
+
+    testInput = 'test@gmail.com';
+    result = '<a href="mailto:test@gmail.com">test@gmail.com</a>';
+    expect(parser.replace(testInput)).toBe(result);
+});
+
 // Check emails within other markdown
 test('Test emails within other markdown', () => {
     const testString =

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -996,6 +996,10 @@ export default class ExpensiMark {
             replacedText = replacedText.concat(replacedMatch);
             startIndex = match.index + match[0].length;
 
+            // Line breaks (`\n`) followed by empty contents are already removed
+            // but line breaks inside contents should be parsed to <br/> to skip `autoEmail` rule
+            replacedText = this.replace(replacedText, {filterRules: ['newline'], shouldEscapeText: false});
+
             // Now we move to the next match that the js regex found in the text
             match = regex.exec(textToCheck);
         }


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/43386
This PR is to fix parsing markdown for multiline email hyperlinks

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Passed all existing test cases and Added one more test case for this purpose.
1. What tests did you perform that validates your changed worked?
bump expensify-common version in E/App and `react-native-live-markdown` to this PR and tested locally

# QA
1. What does QA need to do to validate your changes?
bump expensify-common version in E/App and try to input multiline email hyperlinks ( i.e. [test\ntest](test@test.com) ) and see if there's any errors or wrong parsing.



