### PR TITLE
Fix underscore ahead of asterisk not get bolded

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -26,9 +26,21 @@ test('Test bold within code blocks is skipped', () => {
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
+test('Test special character plus _ ahead asterisk still result in bold', () => {
+    const testString = 'This is a !_*bold*';
+    const replacedString = 'This is a !_<strong>bold</strong>';
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
+test('Test a word plus _ ahead asterisk not result in bold', () => {
+    const testString = 'This is not a_*bold*';
+    const replacedString = 'This is not a_*bold*';
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 test('Test _ ahead asterisk still result in bold', () => {
-    const testString = 'bold\n```\n*not a bold*\n```\nThis is _*bold*';
-    const replacedString = 'bold<br /><pre>*not&#32;a&#32;bold*<br /></pre>This is _<strong>bold</strong>';
+    const testString = 'This is a ~_*bold*';
+    const replacedString = 'This is a ~_<strong>bold</strong>';
     expect(parser.replace(testString)).toBe(replacedString);
 });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -26,12 +26,6 @@ test('Test bold within code blocks is skipped', () => {
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
-test('Test _ ahead asterisk still result in bold', () => {
-    const testString = 'bold\n```\n*not a bold*\n```\nThis is _*bold*';
-    const replacedString = 'bold<br /><pre>*not&#32;a&#32;bold*<br /></pre>This is _<strong>bold</strong>';
-    expect(parser.replace(testString)).toBe(replacedString);
-});
-
 test('Test heading markdown replacement', () => {
     let testString = '# Heading should not have new line after it.\n';
     expect(parser.replace(testString)).toBe('<h1>Heading should not have new line after it.</h1>');

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -26,6 +26,12 @@ test('Test bold within code blocks is skipped', () => {
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
+test('Test _ ahead asterisk still result in bold', () => {
+    const testString = 'bold\n```\n*not a bold*\n```\nThis is _*bold*';
+    const replacedString = 'bold<br /><pre>*not&#32;a&#32;bold*<br /></pre>This is _<strong>bold</strong>';
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 test('Test heading markdown replacement', () => {
     let testString = '# Heading should not have new line after it.\n';
     expect(parser.replace(testString)).toBe('<h1>Heading should not have new line after it.</h1>');

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -461,14 +461,8 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /(?<!<[^>]*)(\b_|\B)\*(?![^<]*(?:<\/pre>|<\/code>|<\/a>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (_extras, match, g1, g2) => {
-                    if (g1.includes('_')) {
-                        return `${g1}<strong>${g2}</strong>`;
-                    }
-
-                    return g2.includes('</pre>') || this.containsNonPairTag(g2) ? match : `<strong>${g2}</strong>`;
-                },
+                regex: /(?<!<[^>]*)\B\*(?![^<]*(?:<\/pre>|<\/code>|<\/a>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: (_extras, match, g1) => (g1.includes('</pre>') || this.containsNonPairTag(g1) ? match : `<strong>${g1}</strong>`),
             },
             {
                 name: 'strikethrough',

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -461,8 +461,14 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /(?<!<[^>]*)\B\*(?![^<]*(?:<\/pre>|<\/code>|<\/a>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
-                replacement: (_extras, match, g1) => (g1.includes('</pre>') || this.containsNonPairTag(g1) ? match : `<strong>${g1}</strong>`),
+                regex: /(?<!<[^>]*)(\b_|\B)\*(?![^<]*(?:<\/pre>|<\/code>|<\/a>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>))/g,
+                replacement: (_extras, match, g1, g2) => {
+                    if (g1.includes('_')) {
+                        return `${g1}<strong>${g2}</strong>`;
+                    }
+
+                    return g2.includes('</pre>') || this.containsNonPairTag(g2) ? match : `<strong>${g2}</strong>`;
+                },
             },
             {
                 name: 'strikethrough',


### PR DESCRIPTION
Fix if underscore ahead of `*` not result in a bold style

### Fixed Issues
https://github.com/Expensify/App/issues/44032

# Tests
1. What unit/integration tests cover your change? 
A unit test is added in this PR.
1. What tests did you perform that validates your changed worked?
Apply this change to expensify/App to test.
# QA
1. What does QA need to do to validate your changes?
typing _*any words* should result in a bold 
1. What areas to they need to test for regressions?
NA

I have read the CLA Document and I hereby sign the CLA