### PR TITLE
Fix `<emoji>` is mistaken as `<em>`

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -891,3 +891,23 @@ describe('Video tag conversion to markdown', () => {
         expect(cacheVideoAttributes).toHaveBeenCalledWith("https://example.com/video.mp4", ' data-expensify-width="100" data-expensify-height="500" data-expensify-thumbnail-url="https://image.com/img.jpg"')
     })
 })
+
+describe('Tag names starting with common charaters', () => {
+    test('Italic and emoji', () => {
+        const testString = '<emoji>😄</emoji> <em>italic</em>';
+        const resultString = '😄 _italic_';
+        expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+    });
+
+    test('Blockquote and bold', () => {
+        const testString = '<blockquote> quote <b>bold</b></blockquote>';
+        const resultString = '> quote *bold*';
+        expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+    });
+
+    test('Line break and bold', () => {
+        const testString = '<br/><b>bold</b>';
+        const resultString = '\n*bold*';
+        expect(parser.htmlToMarkdown(testString)).toBe(resultString);
+    });
+});

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -554,12 +554,12 @@ export default class ExpensiMark {
             // Use [\s\S]* instead of .* to match newline
             {
                 name: 'italic',
-                regex: /<(em|i)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(em|i)\b(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: '_$2_',
             },
             {
                 name: 'bold',
-                regex: /<(b|strong)(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
+                regex: /<(b|strong)\b(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/\1>(?![^<]*(<\/pre>|<\/code>))/gi,
                 replacement: (extras, match, tagName, innerContent) => {
                     // To check if style attribute contains bold font-weight
                     const isBoldFromStyle = (style: string | null) => {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/45635
$ PROPOSAL: https://github.com/Expensify/App/issues/45635#issuecomment-2235052840

### Tests

1. Send this message:

```
~👿~ _abc_
```

2. Edit the message
3. Verify the message in edit composer matches the original message in step 1
4. Open workspace room
5. Change room description to the message in step 1 and save
6. Open room description page again
7. Verify the room description matches the original description in step 1

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

![Screenshot_1721871271](https://github.com/user-attachments/assets/436c8768-a624-4f02-8681-d37e92700fd4)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

![Screenshot_1721871353](https://github.com/user-attachments/assets/6475eefb-1db4-41eb-81ff-539b934b0279)


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
![simulator_screenshot_BD4A70AE-D1FA-43FA-BA23-BD5044CA7E90](https://github.com/user-attachments/assets/d5c23bab-c5d0-457e-a2ae-c989d0aa3d0a)


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
![Screenshot 2024-07-25 at 08 32 54](https://github.com/user-attachments/assets/efcc80ea-d873-474b-9261-9c46f7f83b35)

![Screenshot 2024-07-25 at 08 42 30](https://github.com/user-attachments/assets/8ccc8cd4-da67-41dd-9b30-e724b918c1a3)

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

![Screenshot 2024-07-25 at 08 37 08](https://github.com/user-attachments/assets/9acf650c-1bf6-4ec1-80c6-e3a6487133f2)


</details>
