### PR TITLE
Make it possible to use ExpensiMark in worklets

### DIFF
--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -1,3 +1,5 @@
+'worklet';
+
 import Str from './str';
 import * as Constants from './CONST';
 import * as UrlPatterns from './Url';

--- a/lib/str.ts
+++ b/lib/str.ts
@@ -1,3 +1,5 @@
+'worklet';
+
 /* eslint-disable no-control-regex */
 import {parsePhoneNumber} from 'awesome-phonenumber';
 import * as HtmlEntities from 'html-entities';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,5 @@
+'worklet';
+
 /** Checks if the `window` global object is available. */
 function isWindowAvailable(): boolean {
     return typeof window !== 'undefined';


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This PR adds `'worklet';` directive in file `ExpensiMark.ts` (as well as some of its dependencies, namely `str.ts` and `utils.ts`) so that class `ExpensiMark` can be used instantiated and used in [worklets](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/).

When `'worklet';` directive is located at the top of the file, all functions, classes and object methods in the top-level scope of within this file are workletized.

Worklets are short-running JS functions that can be run on the UI thread. We need to run ExpensiMark on the UI thread synchronously as the user types inside `MarkdownTextInput` so we can format its contents synchronously.

### Fixed Issues
$ https://github.com/Expensify/react-native-live-markdown/issues/317

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
