### PR TITLE
Add missing semicolon in `htmlUnescapes`

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,7 +37,7 @@ const htmlUnescapes = {
     '&quot;': '"',
     '&#x27;': "'",
     '&#x60;': '`',
-    '&#32': ' ',
+    '&#32;': ' ',
 };
 
 const reEscapedHtml = /&(?:amp|lt|gt|quot|#(x27|x60|32));/g;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This PR changes `&#32` to `&#32;` in `htmlUnescapes` map in `utils.ts`.

Without this change, `unescapeText('\nHello&#32;world\n')` returns `Hello'world` (with an apostrophe) instead of `Hello world` (with space).

This breaks Markdown parsing in react-native-live-markdown (see failing tests here: https://github.com/Expensify/react-native-live-markdown/actions/runs/10217116965/job/28270172280?pr=439)

cc @roryabraham 

### Fixed Issues
$ GH_LINK

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
