### PR TITLE
Fix bold tag isn't rendered as markdown when it has a style

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -7,10 +7,12 @@ test('Test bold HTML replacement', () => {
     const boldTestStartString = 'This is a <strong>sentence,</strong> and it has some <strong>punctuation, words, and spaces</strong>. '
         + '<strong>test</strong> * testing* test*test*test. * testing * *testing * '
         + 'This is a <b>sentence,</b> and it has some <b>punctuation, words, and spaces</b>. '
+        + 'This is a <b style="font-size: 20px;">bold sentence with style</b> '
         + '<b>test</b> * testing* test*test*test. * testing * *testing *';
     const boldTestReplacedString = 'This is a *sentence,* and it has some *punctuation, words, and spaces*. '
         + '*test* * testing* test*test*test. * testing * *testing * '
         + 'This is a *sentence,* and it has some *punctuation, words, and spaces*. '
+        + 'This is a *bold sentence with style* '
         + '*test* * testing* test*test*test. * testing * *testing *';
 
     expect(parser.htmlToMarkdown(boldTestStartString)).toBe(boldTestReplacedString);

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -576,13 +576,14 @@ export default class ExpensiMark {
                     };
 
                     // Determine if the outer tag is bold
-                    const styleAttributeMatch = match.match(/style="(.*?)"/);
+                    const fontWeightRegex = /style="([^"]*?\bfont-weight:\s*(\d+|bold|normal)[^"]*?)"/
+                    const styleAttributeMatch = match.match(fontWeightRegex);
                     const isFontWeightBold = isBoldFromStyle(styleAttributeMatch ? styleAttributeMatch[1] : null);
                     const isBold = styleAttributeMatch ? isFontWeightBold : tagName === 'b' || tagName === 'strong';
 
                     // Process nested spans with potential bold style
                     const processedInnerContent = innerContent.replace(/<span(?:"[^"]*"|'[^']*'|[^'">])*>([\s\S]*?)<\/span>/gi, (nestedMatch, nestedContent) => {
-                        const nestedStyleMatch = nestedMatch.match(/style="(.*?)"/);
+                        const nestedStyleMatch = nestedMatch.match(fontWeightRegex);
                         const isNestedBold = isBoldFromStyle(nestedStyleMatch ? nestedStyleMatch[1] : null);
                         return updateSpacesAndWrapWithAsterisksIfBold(nestedContent, isNestedBold);
                     });

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -576,7 +576,7 @@ export default class ExpensiMark {
                     };
 
                     // Determine if the outer tag is bold
-                    const fontWeightRegex = /style="([^"]*?\bfont-weight:\s*(\d+|bold|normal)[^"]*?)"/
+                    const fontWeightRegex = /style="([^"]*?\bfont-weight:\s*(\d+|bold|normal)[^"]*?)"/;
                     const styleAttributeMatch = match.match(fontWeightRegex);
                     const isFontWeightBold = isBoldFromStyle(styleAttributeMatch ? styleAttributeMatch[1] : null);
                     const isBold = styleAttributeMatch ? isFontWeightBold : tagName === 'b' || tagName === 'strong';


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/46891

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Updated unit test to cover bold tag with style.
1. What tests did you perform that validates your changed worked?
- Open a chat app that supports Markdown (Example: Slack)
- Send a message containing a bold markdown
- Copy the text with markdown and open NewDot
- Open any chat and paste the copied text into the compose box
- Verify the bold markdown is pasted instead of a plain text (only on Web/Desktop/iOS mWeb)

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/f08d5df4-d814-4ba5-9a99-79dfb11ded0d



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/37a7d42a-92bc-46a2-9e35-6b7929d11a12



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/dbdb44e5-0b46-4903-96c0-01ec6aaf14e6



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/53446f7e-11a4-4eb5-9cdb-9b29fdf86abf



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/754910e0-d32c-487a-9617-cb3d7aa5c80a


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/7512ba45-6ca9-438b-8918-295b43404e4d


</details>

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
Same as Tests