### PR TITLE
Fix inline code regex mismatch when there is an escaped backtick character inside the backtick

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1219,6 +1219,24 @@ test('Test for backticks with suffix', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+test('Test for backticks with an escaped backtick character inside it', () => {
+    const testString = 'a `;` abc `:` a';
+    const resultString = 'a <code>;</code> abc <code>:</code> a';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test for backticks with an escaped backtick character inside it without prefix and suffix', () => {
+    const testString = '`#` abc `:`';
+    const resultString = '<code>#</code> abc <code>:</code>';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test for backticks with complete escaped backtick characters inside it', () => {
+    const testString = 'a `&` b `#` c `x` d `6` e `0` f `;` g `test` h';
+    const resultString = 'a <code>&amp;</code> b <code>#</code> c <code>x</code> d <code>6</code> e <code>0</code> f <code>;</code> g <code>test</code> h';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
 // Backticks with no content are not replaced with <code>
 test('Test for backticks with no content', () => {
     const testString = '`   `';

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -190,8 +190,8 @@ export default class ExpensiMark {
                 // Use the url escaped version of a backtick (`) symbol. Mobile platforms do not support lookbehinds,
                 // so capture the first and third group and place them in the replacement.
                 // but we should not replace backtick symbols if they include <pre> tags between them.
-                regex: /(\B|_|)&#x60;(.*?(?![&#x60;])\S.*?)&#x60;(\B|_|)(?!&#x60;|[^<]*<\/pre>|[^<]*<\/video>)/gm,
-                replacement: '$1<code>$2</code>$3',
+                regex: /(\B|_|)&#x60;((?:&#x60;)*)(?!&#x60;)(.*?\S+?.*?)(?<!&#x60;)((?:&#x60;)*)(&#x60;)(\B|_|)(?!&#x60;|[^<]*<\/pre>|[^<]*<\/video>)/gm,
+                replacement: '$1<code>$2$3$4</code>$6',
             },
 
             /**


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/46917

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
I have add unit tests for this issue.

1. What tests did you perform that validates your changed worked?
Update the related regex in the expensify-common in node module and send the test messages from composer of the App.
Verify the displayed message is displayed correctly.

# QA
1. What does QA need to do to validate your changes?
Same as test above

1. What areas to they need to test for regressions?
Inline code and code fence related tests. 