### PR TITLE
Allow codefence regex to accept any characters after first three backticks

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -454,6 +454,12 @@ test('Test code fencing with spaces and new lines', () => {
     codeFenceExample = '```\r\n# test\r\n```';
     expect(parser.replace(codeFenceExample)).toBe('<pre>#&#32;test<br /></pre>');
 
+    codeFenceExample = '```   \r\n# test\r\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>#&#32;test<br /></pre>');
+
+    codeFenceExample = '```test\r\n# test\r\n```';
+    expect(parser.replace(codeFenceExample)).toBe('<pre>#&#32;test<br /></pre>');
+
     codeFenceExample = '```\r\n\r\n# test\r\n\r\n```';
     expect(parser.replace(codeFenceExample)).toBe('<pre><br />#&#32;test<br /><br /></pre>');
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -138,7 +138,7 @@ export default class ExpensiMark {
                 name: 'codeFence',
 
                 // &#x60; is a backtick symbol we are matching on three of them before then after a new line character
-                regex: /(&#x60;&#x60;&#x60;(\r\n|\n))((?:\s*?(?!(?:\r\n|\n)?&#x60;&#x60;&#x60;(?!&#x60;))[\S])+\s*?(?:\r\n|\n))(&#x60;&#x60;&#x60;)/g,
+                regex: /(&#x60;&#x60;&#x60;.*?(\r\n|\n))((?:\s*?(?!(?:\r\n|\n)?&#x60;&#x60;&#x60;(?!&#x60;))[\S])+\s*?(?:\r\n|\n))(&#x60;&#x60;&#x60;)/g,
 
                 // We're using a function here to perform an additional replace on the content
                 // inside the backticks because Android is not able to use <pre> tags and does


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/45088

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
I have add unit tests for this issue.
1. What tests did you perform that validates your changed worked?
Update the related regex in the expensify-common in node module and send the test messages from composer of the App.
Test example:
````
```   
test
```
````

````
```  abc 
test
```
````

The code fence/ code block must be displayed properly.

Verify the displayed message is displayed correctly.

# QA
1. What does QA need to do to validate your changes?
Same as test above
1. What areas to they need to test for regressions?
Code fence related regression tests.