### PR TITLE
Fix - Remove sms domain in htmlToText

### DIFF
--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -160,6 +160,11 @@ test('Mention user html to text', () => {
 
     testString = '<mention-user accountID="1234" />';
     expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
+
+    extras.accountIDToName['1234'] = '+251924892738@expensify.sms';  
+    testString = '<mention-user accountID="1234"/>';
+    expect(parser.htmlToText(testString, extras)).toBe('@+251924892738');
+
 });
 
 test('Mention report html to text', () => {

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -164,7 +164,6 @@ test('Mention user html to text', () => {
     extras.accountIDToName['1234'] = '+251924892738@expensify.sms';  
     testString = '<mention-user accountID="1234"/>';
     expect(parser.htmlToText(testString, extras)).toBe('@+251924892738');
-
 });
 
 test('Mention report html to text', () => {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -780,7 +780,7 @@ export default class ExpensiMark {
                         ExpensiMark.Log.alert('[ExpensiMark] Missing account name', {accountID: g1});
                         return '@Hidden';
                     }
-                    return `@${extras.accountIDToName?.[g1]}`;
+                    return `@${Str.removeSMSDomain(extras.accountIDToName?.[g1] ?? '')}`;
                 },
             },
             {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/47484

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?
Test: 

1. Make the same update on `userMention` rule as in the current pr in node-modules
2. Now Open Expensify App
3. Tap on a report
4. Enter any phone mention
5. Send the message
6. Long press the message and copy to clipboard
7. Tap plus icon -- assign task
8. Paste it in title field
9. Verify sms domain doesn't exist in the text pasted

# QA
1. What does QA need to do to validate your changes? 
same as above
1. What areas to they need to test for regressions?
same as above