### PR TITLE
fix report mentions characters limit

### DIFF
--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -298,7 +298,7 @@ export default class ExpensiMark {
             {
                 name: 'reportMentions',
 
-                regex: /(?<![^ \n*~_])(#[\p{Ll}0-9-]{1,80})(?![^<]*(?:<\/pre>|<\/code>|<\/a>))/gimu,
+                regex: /(?<![^ \n*~_])(#[\p{Ll}0-9-]{1,99})(?![^<]*(?:<\/pre>|<\/code>|<\/a>))/gimu,
                 replacement: '<mention-report>$1</mention-report>',
             },
 


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/App/issues/48168

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
2. What tests did you perform that validates your changed worked?
3. Open Expensify App
4. Tap fab - start chat -- room
5. Create 2 room with name more than 80 characters long (max 99)
6. Mention any room with name more than 80 characters
7. Verify that the room mention is shown in whisper
# QA
1. What does QA need to do to validate your changes?
2. What areas to they need to test for regressions?
3. Same as above