### PR TITLE
Fix single backtick code block is rendered within a triple backtick code block when followed by an emoji

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -560,6 +560,9 @@ test('Test code fencing with additional backticks inside', () => {
     expect(parser.replace(nestedBackticks)).toBe(
         '<pre>&#x60;This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)&#x60;<br /></pre>',
     );
+
+    nestedBackticks = '```\n`test`👋\n```';
+    expect(parser.replace(nestedBackticks)).toBe('<pre>&#x60;test&#x60;<emoji>👋</emoji><br /></pre>');
 });
 
 test('Test combination replacements', () => {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -192,7 +192,7 @@ export default class ExpensiMark {
                 // but we should not replace backtick symbols if they include <pre> tags between them.
                 // At least one non-whitespace character or a specific whitespace character (" " and "\u00A0")
                 // must be present inside the backticks.
-                regex: /(\B|_|)&#x60;((?:&#x60;)*(?!&#x60;).*?[\S| |\u00A0]+?.*?(?<!&#x60;)(?:&#x60;)*)&#x60;(\B|_|)(?!&#x60;|[^<]*<\/pre>|[^<]*<\/video>)/gm,
+                regex: /(\B|_|)&#x60;((?:&#x60;)*(?!&#x60;).*?[\S| |\u00A0]+?.*?(?<!&#x60;)(?:&#x60;)*)&#x60;(\B|_|)(?!&#x60;|(?!<pre>)[^<]*(?:<(?!pre>)[^<]*)*<\/pre>|[^<]*<\/video>)/gm,
                 replacement: (_extras, _match, g1, g2, g3) => {
                     const g2Value = g2.trim() === '' ? g2.replaceAll(' ', '&nbsp;') : g2;
                     return `${g1}<code>${g2Value}</code>${g3}`;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/49276

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Updated the unit test to cover an inline code block followed by an emoji within a triple backtick code block.
1. What tests did you perform that validates your changed worked?

Update the related regex in the node_modules/expensify-common/dist/ExpensiMark.js and send this in the Expensify composer.

\`\`\`
\`diamond\` 💍
\`\`\`

Verify that the single backtick code block is not rendered within the triple backtick code block.
```
`diamond` 💍
```

# QA
1. What does QA need to do to validate your changes?
Same as test above
1. What areas to they need to test for regressions?
Tests related to inline code inside code fences.
