### PR TITLE
Add resetSMSDeliveryFailureStatus command

### DIFF
--- a/lib/API.jsx
+++ b/lib/API.jsx
@@ -433,6 +433,20 @@ export default function API(network, args) {
         },
 
         /**
+         * Resets the status of SMS delivery of a phone number
+         * @param {Object} parameters
+         * @param {String} parameters.email
+         * @returns {ExpensifyAPIDeferred}
+         */
+        resetSMSDeliveryFailureStatus(parameters) {
+            const commandName = 'ResetSMSDeliveryFailureStatus';
+            requireParameters(['email'], parameters, commandName);
+
+            const newParameters = {...parameters, api_setCookie: false};
+            return performPOSTRequest(commandName, newParameters);
+        },
+
+        /**
          * Sets the password for an account
          *
          * @param {Object} parameters


### PR DESCRIPTION
Just a missing command so the already deployed code for resetting SMS delivery failure status in Web-E can work as expected :)

### Fixed Issues
https://github.com/Expensify/Expensify/issues/335408

# Tests
Same as https://github.com/Expensify/Web-Expensify/pull/44736

QA
Same as https://github.com/Expensify/Web-Expensify/pull/44736