### PR TITLE
Fix double backticks

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -472,14 +472,14 @@ test('Test inline code blocks', () => {
     expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is <code>JavaScript</code>. How about you?');
 });
 
-test('Test inline code blocks with double backticks', () => {
-    const inlineCodeStartString = 'My favorite language is ``JavaScript``. How about you?';
-    expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is <code>&#x60;JavaScript&#x60;</code>. How about you?');
+test('Test double backticks', () => {
+    const testString = 'My favorite language is ``JavaScript``. How about you?';
+    expect(parser.replace(testString)).toBe('My favorite language is &#x60;&#x60;JavaScript&#x60;&#x60;. How about you?');
 });
 
 test('Test inline code blocks with triple backticks', () => {
     const inlineCodeStartString = 'My favorite language is ```JavaScript```. How about you?';
-    expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is <code>&#x60;&#x60;JavaScript&#x60;&#x60;</code>. How about you?');
+    expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is &#x60;&#x60;<code>JavaScript</code>&#x60;&#x60;. How about you?');
 });
 
 test('Test multiple inline codes in one line', () => {
@@ -487,14 +487,14 @@ test('Test multiple inline codes in one line', () => {
     expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is <code>JavaScript</code>. How about you? I also like <code>Python</code>.');
 });
 
-test('Test inline code with one backtick as content', () => {
-    const inlineCodeStartString = '```';
-    expect(parser.replace(inlineCodeStartString)).toBe('&#x60;&#x60;&#x60;');
+test('Test triple backticks', () => {
+    const testString = '```';
+    expect(parser.replace(testString)).toBe('&#x60;&#x60;&#x60;');
 });
 
-test('Test inline code with multiple backtick symbols as content', () => {
-    const inlineCodeStartString = '``````';
-    expect(parser.replace(inlineCodeStartString)).toBe('&#x60;&#x60;&#x60;&#x60;&#x60;&#x60;');
+test('Test multiple backtick symbols', () => {
+    const testString = '``````';
+    expect(parser.replace(testString)).toBe('&#x60;&#x60;&#x60;&#x60;&#x60;&#x60;');
 });
 
 test('Test inline code blocks with ExpensiMark syntax inside', () => {
@@ -508,9 +508,9 @@ test('Test inline code blocks inside ExpensiMark', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-test('Test inline code blocks with two backticks', () => {
+test('Test words enclosed in double backticks', () => {
     const testString = '``JavaScript``';
-    expect(parser.replace(testString)).toBe('<code>&#x60;JavaScript&#x60;</code>');
+    expect(parser.replace(testString)).toBe('&#x60;&#x60;JavaScript&#x60;&#x60;');
 });
 
 test('Test code fencing with ExpensiMark syntax inside', () => {
@@ -1240,10 +1240,9 @@ test('Test for backticks with complete escaped backtick characters inside it', (
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-// Backticks with only tab characters inside it are not replaced with <code>
-test('Test for backticks only tab characters inside it', () => {
+test('Test for inline code blocks with only tab characters as content', () => {
     const testString = '`\u0009`';
-    const resultString = '&#x60;\u0009&#x60;';
+    const resultString = '<code>	</code>';
     expect(parser.replace(testString)).toBe(resultString);
 });
 
@@ -1254,10 +1253,15 @@ test('Test for backticks with only space characters as content', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
-// Code-fence with spaces as content
 test('Test for inline code block with triple backtick with spaces as content', () => {
     const testString = '```   ```';
-    const resultString = '<code>&#x60;&#x60;   &#x60;&#x60;</code>';
+    const resultString = '&#x60;&#x60;<code>&nbsp;&nbsp;&nbsp;</code>&#x60;&#x60;';
+    expect(parser.replace(testString)).toBe(resultString);
+});
+
+test('Test for a normal code block, an empty code block, followed by a word and a backtick', () => {
+    const testString = '`hello` `` hi`';
+    const resultString = '<code>hello</code> &#x60;&#x60; hi&#x60;';
     expect(parser.replace(testString)).toBe(resultString);
 });
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -227,9 +227,12 @@ export default class ExpensiMark {
                 // but we should not replace backtick symbols if they include <pre> tags between them.
                 // At least one non-whitespace character or a specific whitespace character (" " and "\u00A0")
                 // must be present inside the backticks.
-                regex: /(\B|_|)&#x60;((?:&#x60;)*(?!&#x60;).*?[\S| |\u00A0]+?.*?(?<!&#x60;)(?:&#x60;)*)&#x60;(\B|_|)(?!&#x60;|(?!<pre>)[^<]*(?:<(?!pre>)[^<]*)*<\/pre>|[^<]*<\/video>)/gm,
+                regex: /(\B|_|)&#x60;(.*?)&#x60;(\B|_|)(?!(?!<pre>)[^<]*(?:<(?!pre>)[^<]*)*<\/pre>|[^<]*<\/video>)/gm,
                 replacement: (_extras, _match, g1, g2, g3) => {
                     const g2Value = g2.trim() === '' ? g2.replaceAll(' ', '&nbsp;') : g2;
+                    if (!g2Value) {
+                        return _match;
+                    }
                     return `${g1}<code>${g2Value}</code>${g3}`;
                 },
             },


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR fixes the issue that the inline code block regex doesn't match two backticks with no content between them.

For example, in 

     `hello` `` hi`

the two backticks in the middle are not regarded as a pair, which causes the word _hi_ after them to be part of the code block. However, the user expects the word _hi_ not to be part of the code block.

### Fixed Issues
$ https://github.com/Expensify/App/issues/53573

A similar issue is also mentioned in [this comment](https://github.com/Expensify/App/pull/52780#issuecomment-2535937359).

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?

#### New test case added

    Test string: "`hello` `` hi`"
    Expected result: "<code>hello</code> &#x60;&#x60; hi&#x60;"

#### Existing test cases updated

##### Test inline code blocks with double backticks

    Expected result before: "My favorite language is <code>&#x60;JavaScript&#x60;</code>. How about you?"
    Expected result after: "My favorite language is &#x60;&#x60;JavaScript&#x60;&#x60;. How about you?"

##### Test inline code blocks with triple backticks

    Expected result before: "My favorite language is <code>&#x60;&#x60;JavaScript&#x60;&#x60;</code>. How about you?"
    Expected result after: "My favorite language is &#x60;&#x60;<code>JavaScript</code>&#x60;&#x60;. How about you?"

##### Test inline code blocks with two backticks

    Expected result before: "<code>&#x60;JavaScript&#x60;</code>"
    Expected result after: "&#x60;&#x60;JavaScript&#x60;&#x60;"

##### Test for backticks only tab characters inside it

    Expected result before: "&#x60;	&#x60;"
    Expected result after: "<code>	</code>"

##### Test for inline code block with triple backtick with spaces as content

    Expected result before: "<code>&#x60;&#x60;   &#x60;&#x60;</code>"
    Expected result after: "&#x60;&#x60;<code>&nbsp;&nbsp;&nbsp;</code>&#x60;&#x60;"

2. What tests did you perform that validates your changed worked?

- Send the below message in Expensify.

    `hello` `` hi`

- Verify that the word _hi_ is not rendered as part of a code block.

# QA
1. What does QA need to do to validate your changes?

- Send the below message in Expensify.

    `hello` `` hi`

- Verify that the word _hi_ is not rendered as part of a code block.

2. What areas to they need to test for regressions?

- Test with inline code blocks. Be aware of the changed expected behaviors described in Tests section.