### PR TITLE
Remove &nbsp; from inline code block in raw input mode

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1978,6 +1978,34 @@ describe('when should keep raw input flag is enabled', () => {
             expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
         });
     });
+
+    describe('inline code blocks', () => {
+        test('empty content', () => {
+            const testString = '``';
+            const resultString = '&#x60;&#x60;';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+        test('single whitespace as a content', () => {
+            const testString = '` `';
+            const resultString = '<code> </code>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+        test('multiple whitespaces as a content', () => {
+            const testString = '`     `';
+            const resultString = '<code>     </code>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+        test('text content', () => {
+            const testString = 'hello `world`';
+            const resultString = 'hello <code>world</code>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+        test('text and whitespaces as a content', () => {
+            const testString = '` hello   world `';
+            const resultString = '<code> hello   world </code>';
+            expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
+        });
+    });
 });
 
 test('Test code fence within inline code', () => {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -228,14 +228,14 @@ export default class ExpensiMark {
                 // At least one non-whitespace character or a specific whitespace character (" " and "\u00A0")
                 // must be present inside the backticks.
                 regex: /(\B|_|)&#x60;(.*?)&#x60;(\B|_|)(?!(?!<pre>)[^<]*(?:<(?!pre>)[^<]*)*<\/pre>|[^<]*<\/video>)/gm,
-                replacement: (_extras, _match, g1, g2, g3) => {
+                replacement: (_extras, match, g1, g2, g3) => {
                     const g2Value = g2.trim() === '' ? g2.replaceAll(' ', '&nbsp;') : g2;
                     if (!g2Value) {
-                        return _match;
+                        return match;
                     }
                     return `${g1}<code>${g2Value}</code>${g3}`;
                 },
-                rawInputReplacement: (_extras, _match, g1, g2, g3) => `${g1}<code>${g2}</code>${g3}`,
+                rawInputReplacement: (_extras, match, g1, g2, g3) => (g2 ? `${g1}<code>${g2}</code>${g3}` : match),
             },
 
             /**

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -232,6 +232,7 @@ export default class ExpensiMark {
                     const g2Value = g2.trim() === '' ? g2.replaceAll(' ', '&nbsp;') : g2;
                     return `${g1}<code>${g2Value}</code>${g3}`;
                 },
+                rawInputReplacement: (_extras, _match, g1, g2, g3) => `${g1}<code>${g2}</code>${g3}`,
             },
 
             /**


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR removes replacing whitespaces with &nbsp; in raw input mode, so the Live Markdown Input can render markdown styles when there are only spaces between backticks ` `


### Fixed Issues
https://github.com/Expensify/App/issues/53457

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?
1. Set the `shouldKeepRawInput` prop to `true`
2. Verify if the output for `' '` (replace ' with `) is the same and the input
# QA
1. What does QA need to do to validate your changes?
1. What areas do they need to test for regressions?
