### PR TITLE
fix: mentions are not shown in invite user or remove user report

### DIFF
--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -152,7 +152,7 @@ test('Mention user html to text', () => {
 
     const extras = {
         accountIDToName: {
-            '1234': 'user@domain.com',
+            1234: 'user@domain.com',
         },
     };
     testString = '<mention-user accountID="1234"/>';
@@ -167,7 +167,7 @@ test('Mention user html to text', () => {
     testString = '<mention-user accountID=1234 />';
     expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
 
-    extras.accountIDToName['1234'] = '+251924892738@expensify.sms';  
+    extras.accountIDToName['1234'] = '+251924892738@expensify.sms';
     testString = '<mention-user accountID="1234"/>';
     expect(parser.htmlToText(testString, extras)).toBe('@+251924892738');
 });
@@ -191,7 +191,7 @@ test('Mention report html to text', () => {
 
     const extras = {
         reportIDToName: {
-            '1234': '#room-name',
+            1234: '#room-name',
         },
     };
     testString = '<mention-report reportID="1234"/>';
@@ -202,11 +202,18 @@ test('Mention report html to text', () => {
 
     testString = '<mention-report reportID=1234/>';
     expect(parser.htmlToText(testString, extras)).toBe('#room-name');
+
+    testString = '<mention-report reportID=1234></mention-report>';
+    expect(parser.htmlToText(testString, extras)).toBe('#room-name');
+
+    testString = '<mention-report reportID="1234"></mention-report>';
+    expect(parser.htmlToText(testString, extras)).toBe('#room-name');
 });
 
 test('Test replacement for attachment tags', () => {
     const testString = '<img src="https://example.com/image.png" alt="Image description" />';
-    const testString2 = '<video data-expensify-source="https://www.expensify.com/chat-attachments/123/test.mp4" data-expensify-width=720 data-expensify-height=1640 data-expensify-duration=20>test.mp4</video>';
+    const testString2 =
+        '<video data-expensify-source="https://www.expensify.com/chat-attachments/123/test.mp4" data-expensify-width=720 data-expensify-height=1640 data-expensify-duration=20>test.mp4</video>';
     const testString3 = '<a href="https://www.expensify.com/chat-attachments/123/test.csv" data-expensify-source="https://www.expensify.com/chat-attachments/123/test.csv">test.csv</a>';
     expect(parser.htmlToText(testString)).toBe('[Attachment]');
     expect(parser.htmlToText(testString2)).toBe('[Attachment]');

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -161,6 +161,12 @@ test('Mention user html to text', () => {
     testString = '<mention-user accountID="1234" />';
     expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
 
+    testString = '<mention-user accountID=1234></mention-user>';
+    expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
+
+    testString = '<mention-user accountID=1234 />';
+    expect(parser.htmlToText(testString, extras)).toBe('@user@domain.com');
+
     extras.accountIDToName['1234'] = '+251924892738@expensify.sms';  
     testString = '<mention-user accountID="1234"/>';
     expect(parser.htmlToText(testString, extras)).toBe('@+251924892738');
@@ -192,6 +198,9 @@ test('Mention report html to text', () => {
     expect(parser.htmlToText(testString, extras)).toBe('#room-name');
 
     testString = '<mention-report reportID="1234" />';
+    expect(parser.htmlToText(testString, extras)).toBe('#room-name');
+
+    testString = '<mention-report reportID=1234/>';
     expect(parser.htmlToText(testString, extras)).toBe('#room-name');
 });
 

--- a/__tests__/ExpensiMark-HTMLToText-test.js
+++ b/__tests__/ExpensiMark-HTMLToText-test.js
@@ -152,7 +152,7 @@ test('Mention user html to text', () => {
 
     const extras = {
         accountIDToName: {
-            1234: 'user@domain.com',
+            '1234': 'user@domain.com',
         },
     };
     testString = '<mention-user accountID="1234"/>';
@@ -191,7 +191,7 @@ test('Mention report html to text', () => {
 
     const extras = {
         reportIDToName: {
-            1234: '#room-name',
+            '1234': '#room-name',
         },
     };
     testString = '<mention-report reportID="1234"/>';
@@ -212,8 +212,7 @@ test('Mention report html to text', () => {
 
 test('Test replacement for attachment tags', () => {
     const testString = '<img src="https://example.com/image.png" alt="Image description" />';
-    const testString2 =
-        '<video data-expensify-source="https://www.expensify.com/chat-attachments/123/test.mp4" data-expensify-width=720 data-expensify-height=1640 data-expensify-duration=20>test.mp4</video>';
+    const testString2 = '<video data-expensify-source="https://www.expensify.com/chat-attachments/123/test.mp4" data-expensify-width=720 data-expensify-height=1640 data-expensify-duration=20>test.mp4</video>';
     const testString3 = '<a href="https://www.expensify.com/chat-attachments/123/test.csv" data-expensify-source="https://www.expensify.com/chat-attachments/123/test.csv">test.csv</a>';
     expect(parser.htmlToText(testString)).toBe('[Attachment]');
     expect(parser.htmlToText(testString2)).toBe('[Attachment]');

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -817,7 +817,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'reportMentions',
-                regex: /<mention-report reportID="?(\d+)"? *\/>/gi,
+                regex: /<mention-report reportID="?(\d+)"?(?: *\/>|><\/mention-report>)/gi,
                 replacement: (extras, _match, g1, _offset, _string) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
@@ -1217,27 +1217,17 @@ export default class ExpensiMark {
     /**
      * Convert HTML to text
      */
-    htmlToText(htmlString: string, extras: Extras = EXTRAS_DEFAULT, log = false): string {
+    htmlToText(htmlString: string, extras: Extras = EXTRAS_DEFAULT): string {
         let replacedText = htmlString;
         const processRule = (rule: RuleWithRegex) => {
             replacedText = this.replaceTextWithExtras(replacedText, rule.regex, extras, rule.replacement);
-            if (log) {
-                console.log('htmlToText', rule.name, replacedText);
-            }
         };
 
         this.htmlToTextRules.forEach(processRule);
 
-        if (log) {
-            console.log('htmlToText', replacedText);
-        }
-
         // Unescaping because the text is escaped in 'replace' function
         // We use 'htmlDecode' instead of 'unescape' to replace entities like '&#32;'
         replacedText = Str.htmlDecode(replacedText);
-        if (log) {
-            console.log('htmlToText', 'unescape', replacedText);
-        }
         return replacedText;
     }
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -736,7 +736,7 @@ export default class ExpensiMark {
 
             {
                 name: 'reportMentions',
-                regex: /<mention-report reportID="(\d+)"(?: *\/>|><\/mention-report>)/gi,
+                regex: /<mention-report reportID="?(\d+)"?(?: *\/>|><\/mention-report>)/gi,
                 replacement: (extras, _match, g1, _offset, _string) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
@@ -749,7 +749,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'userMention',
-                regex: /(?:<mention-user accountID="(\d+)"(?: *\/>|><\/mention-user>))|(?:<mention-user>(.*?)<\/mention-user>)/gi,
+                regex: /(?:<mention-user accountID="?(\d+)"?(?: *\/>|><\/mention-user>))|(?:<mention-user>(.*?)<\/mention-user>)/gi,
                 replacement: (extras, _match, g1, g2, _offset, _string) => {
                     if (g1) {
                         const accountToNameMap = extras.accountIDToName;
@@ -817,7 +817,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'reportMentions',
-                regex: /<mention-report reportID="(\d+)" *\/>/gi,
+                regex: /<mention-report reportID="?(\d+)"? *\/>/gi,
                 replacement: (extras, _match, g1, _offset, _string) => {
                     const reportToNameMap = extras.reportIDToName;
                     if (!reportToNameMap || !reportToNameMap[g1]) {
@@ -830,7 +830,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'userMention',
-                regex: /<mention-user accountID="(\d+)" *\/>/gi,
+                regex: /(?:<mention-user accountID="?(\d+)"?(?: *\/>|><\/mention-user>))|(?:<mention-user>(.*?)<\/mention-user>)/gi,
                 replacement: (extras, _match, g1, _offset, _string) => {
                     const accountToNameMap = extras.accountIDToName;
                     if (!accountToNameMap || !accountToNameMap[g1]) {


### PR DESCRIPTION
This PR fixes the issue that the mention report and mention user sometimes has no quotation marks

Update `htmlToTextRules` userMention and reportMention regex to work for both `<selfClosedTag />` and non self closing tags `<openTag></closeTag>` to be like htmlToMarkdownRules

Example:

![image](https://github.com/user-attachments/assets/e497c477-a137-474a-8f17-87760cdc1a4b)



## Fixed Issues
$ https://github.com/Expensify/App/issues/54630


# Tests

1. What unit/integration tests cover your change? What autoQA tests cover your change?

### New test case added

```
// mention-user
Test string: "<mention-user accountID=1234></mention-user>"
Expected result: "@user@domain.com"

Test string: "<mention-user accountID=1234 />"
Expected result: "@user@domain.com"

// mention-report
Test string: "<mention-report reportID=1234/>"
Expected result: "#room-name"
```

2. What tests did you perform that validates your changed worked?

- Create a workspace
- Mention an user that is not invited to the workspace
- Click "Invite" on the whisper
- Long press the "Invited ..." message and reply in thread
- Verify that mention is shown in the thread header


QA
1. What does QA need to do to validate your changes?
2. What areas to they need to test for regressions?
Same as tests

