### PR TITLE
fix: update mention room regex

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -340,7 +340,7 @@ test('Test markdown replacement for emojis with emails', () => {
         '[😄 abc@gmail.com ](abc@gmail.com) ';
     const result =
         'Replace the emoji with link ' +
-        '<a href=\"mailto:abc@gmail.com\"><emoji>😄</emoji></a> ' +
+        '<a href="mailto:abc@gmail.com"><emoji>😄</emoji></a> ' +
         '[<emoji>😄</emoji>]( <a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
         '[<emoji>😄</emoji>] <a href="mailto:abc@gmail.com">abc@gmail.com</a> ' +
         '[<emoji>😄</emoji>]((<a href="mailto:abc@gmail.com">abc@gmail.com</a>)) ' +
@@ -1051,7 +1051,7 @@ test('Test markdown and url links with inconsistent starting and closing parens'
 
 test('Test link: Keep spaces at both end for shouldKeepRawInput=true', () => {
     const testString = '[ link ](https://www.expensify.com)';
-    const resultString = '<a href=\"https://www.expensify.com\" data-raw-href=\"https://www.expensify.com\" data-link-variant=\"labeled\" target=\"_blank\" rel=\"noreferrer noopener\"> link </a>';
+    const resultString = '<a href="https://www.expensify.com" data-raw-href="https://www.expensify.com" data-link-variant="labeled" target="_blank" rel="noreferrer noopener"> link </a>';
     expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
 });
 
@@ -2136,7 +2136,8 @@ describe('Video markdown conversion to html tag', () => {
 
     test('Text containing videos', () => {
         const testString = 'A video of a banana: ![banana](https://example.com/banana.mp4) a video without name: !(https://example.com/developer.mp4)';
-        const resultString = 'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
+        const resultString =
+            'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2144,35 +2145,40 @@ describe('Video markdown conversion to html tag', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-raw-href="https://example.com/video.mp4" data-link-variant="labeled" >test</video>';
         expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
-    })
+    });
 
     test('Single video with extra cached attributes with videoAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(parser.replace(testString, {
-            extras: {
-                videoAttributeCache: {
-                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    videoAttributeCache: {
+                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 
     test('Single video with extra cached attributes with mediaAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(parser.replace(testString, {
-            extras: {
-                mediaAttributeCache: {
-                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    mediaAttributeCache: {
+                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 
     test('Text containing image and video', () => {
         const testString = 'An image of a banana: ![banana](https://example.com/banana.png) and a video of a banana: ![banana](https://example.com/banana.mp4)';
-        const resultString = 'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
+        const resultString =
+            'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2193,9 +2199,7 @@ describe('Video markdown conversion to html tag', () => {
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" >&#x60;&#x60;&#x60;test&#x60;&#x60;&#x60;</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
-
-
-})
+});
 
 describe('Image markdown conversion to html tag', () => {
     test('Single image with alt text', () => {
@@ -2285,27 +2289,30 @@ describe('Image markdown conversion to html tag', () => {
     test('Single image with extra cached attributes using mediaAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(parser.replace(testString, {
-            extras: {
-                mediaAttributeCache: {
-                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    mediaAttributeCache: {
+                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 
     test('Single image with extra cached attributes using videAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(parser.replace(testString, {
-            extras: {
-                videoAttributeCache: {
-                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
-
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    videoAttributeCache: {
+                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 });
 
 describe('room mentions', () => {
@@ -2320,10 +2327,15 @@ describe('room mentions', () => {
         const resultString = 'hi all <mention-report>#room</mention-report>';
         expect(parser.replace(testString)).toBe(resultString);
     });
+    test('room mention with any leading character', () => {
+        const testString = 'a#room 1#room :#room';
+        const resultString = 'a<mention-report>#room</mention-report> 1<mention-report>#room</mention-report> :<mention-report>#room</mention-report>';
+        expect(parser.replace(testString)).toBe(resultString);
+    });
 
     test('room mention with leading word and no space', () => {
         const testString = 'hi all#room';
-        const resultString = 'hi all#room';
+        const resultString = 'hi all<mention-report>#room</mention-report>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -340,7 +340,7 @@ test('Test markdown replacement for emojis with emails', () => {
         '[😄 abc@gmail.com ](abc@gmail.com) ';
     const result =
         'Replace the emoji with link ' +
-        '<a href="mailto:abc@gmail.com"><emoji>😄</emoji></a> ' +
+        '<a href=\"mailto:abc@gmail.com\"><emoji>😄</emoji></a> ' +
         '[<emoji>😄</emoji>]( <a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
         '[<emoji>😄</emoji>] <a href="mailto:abc@gmail.com">abc@gmail.com</a> ' +
         '[<emoji>😄</emoji>]((<a href="mailto:abc@gmail.com">abc@gmail.com</a>)) ' +
@@ -1051,7 +1051,7 @@ test('Test markdown and url links with inconsistent starting and closing parens'
 
 test('Test link: Keep spaces at both end for shouldKeepRawInput=true', () => {
     const testString = '[ link ](https://www.expensify.com)';
-    const resultString = '<a href="https://www.expensify.com" data-raw-href="https://www.expensify.com" data-link-variant="labeled" target="_blank" rel="noreferrer noopener"> link </a>';
+    const resultString = '<a href=\"https://www.expensify.com\" data-raw-href=\"https://www.expensify.com\" data-link-variant=\"labeled\" target=\"_blank\" rel=\"noreferrer noopener\"> link </a>';
     expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
 });
 
@@ -2136,8 +2136,7 @@ describe('Video markdown conversion to html tag', () => {
 
     test('Text containing videos', () => {
         const testString = 'A video of a banana: ![banana](https://example.com/banana.mp4) a video without name: !(https://example.com/developer.mp4)';
-        const resultString =
-            'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
+        const resultString = 'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2145,40 +2144,35 @@ describe('Video markdown conversion to html tag', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-raw-href="https://example.com/video.mp4" data-link-variant="labeled" >test</video>';
         expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
-    });
+    })
 
     test('Single video with extra cached attributes with videoAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    videoAttributeCache: {
-                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                videoAttributeCache: {
+                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
 
     test('Single video with extra cached attributes with mediaAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    mediaAttributeCache: {
-                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                mediaAttributeCache: {
+                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
 
     test('Text containing image and video', () => {
         const testString = 'An image of a banana: ![banana](https://example.com/banana.png) and a video of a banana: ![banana](https://example.com/banana.mp4)';
-        const resultString =
-            'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
+        const resultString = 'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2199,7 +2193,9 @@ describe('Video markdown conversion to html tag', () => {
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" >&#x60;&#x60;&#x60;test&#x60;&#x60;&#x60;</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
-});
+
+
+})
 
 describe('Image markdown conversion to html tag', () => {
     test('Single image with alt text', () => {
@@ -2303,16 +2299,15 @@ describe('Image markdown conversion to html tag', () => {
     test('Single image with extra cached attributes using videAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    videoAttributeCache: {
-                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                videoAttributeCache: {
+                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
+
 });
 
 describe('room mentions', () => {
@@ -2335,7 +2330,7 @@ describe('room mentions', () => {
 
     test('room mention with leading word and no space', () => {
         const testString = 'hi all#room';
-        const resultString = 'hi all<mention-report>#room</mention-report>';
+        const resultString = 'hi all#room';
         expect(parser.replace(testString)).toBe(resultString);
     });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -340,7 +340,7 @@ test('Test markdown replacement for emojis with emails', () => {
         '[😄 abc@gmail.com ](abc@gmail.com) ';
     const result =
         'Replace the emoji with link ' +
-        '<a href="mailto:abc@gmail.com"><emoji>😄</emoji></a> ' +
+        '<a href=\"mailto:abc@gmail.com\"><emoji>😄</emoji></a> ' +
         '[<emoji>😄</emoji>]( <a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
         '[<emoji>😄</emoji>] <a href="mailto:abc@gmail.com">abc@gmail.com</a> ' +
         '[<emoji>😄</emoji>]((<a href="mailto:abc@gmail.com">abc@gmail.com</a>)) ' +
@@ -1051,7 +1051,7 @@ test('Test markdown and url links with inconsistent starting and closing parens'
 
 test('Test link: Keep spaces at both end for shouldKeepRawInput=true', () => {
     const testString = '[ link ](https://www.expensify.com)';
-    const resultString = '<a href="https://www.expensify.com" data-raw-href="https://www.expensify.com" data-link-variant="labeled" target="_blank" rel="noreferrer noopener"> link </a>';
+    const resultString = '<a href=\"https://www.expensify.com\" data-raw-href=\"https://www.expensify.com\" data-link-variant=\"labeled\" target=\"_blank\" rel=\"noreferrer noopener\"> link </a>';
     expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
 });
 
@@ -2136,8 +2136,7 @@ describe('Video markdown conversion to html tag', () => {
 
     test('Text containing videos', () => {
         const testString = 'A video of a banana: ![banana](https://example.com/banana.mp4) a video without name: !(https://example.com/developer.mp4)';
-        const resultString =
-            'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
+        const resultString = 'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2145,40 +2144,35 @@ describe('Video markdown conversion to html tag', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-raw-href="https://example.com/video.mp4" data-link-variant="labeled" >test</video>';
         expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
-    });
+    })
 
     test('Single video with extra cached attributes with videoAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    videoAttributeCache: {
-                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                videoAttributeCache: {
+                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
 
     test('Single video with extra cached attributes with mediaAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    mediaAttributeCache: {
-                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                mediaAttributeCache: {
+                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
 
     test('Text containing image and video', () => {
         const testString = 'An image of a banana: ![banana](https://example.com/banana.png) and a video of a banana: ![banana](https://example.com/banana.mp4)';
-        const resultString =
-            'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
+        const resultString = 'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2199,7 +2193,9 @@ describe('Video markdown conversion to html tag', () => {
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" >&#x60;&#x60;&#x60;test&#x60;&#x60;&#x60;</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
-});
+
+
+})
 
 describe('Image markdown conversion to html tag', () => {
     test('Single image with alt text', () => {
@@ -2289,30 +2285,27 @@ describe('Image markdown conversion to html tag', () => {
     test('Single image with extra cached attributes using mediaAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    mediaAttributeCache: {
-                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                mediaAttributeCache: {
+                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
 
     test('Single image with extra cached attributes using videAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    videoAttributeCache: {
-                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                videoAttributeCache: {
+                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
+
 });
 
 describe('room mentions', () => {

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2285,16 +2285,14 @@ describe('Image markdown conversion to html tag', () => {
     test('Single image with extra cached attributes using mediaAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(
-            parser.replace(testString, {
-                extras: {
-                    mediaAttributeCache: {
-                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
-                    },
-                },
-            }),
-        ).toBe(resultString);
-    });
+        expect(parser.replace(testString, {
+            extras: {
+                mediaAttributeCache: {
+                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
+                }
+            }
+        })).toBe(resultString);
+    })
 
     test('Single image with extra cached attributes using videAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -340,7 +340,7 @@ test('Test markdown replacement for emojis with emails', () => {
         '[😄 abc@gmail.com ](abc@gmail.com) ';
     const result =
         'Replace the emoji with link ' +
-        '<a href=\"mailto:abc@gmail.com\"><emoji>😄</emoji></a> ' +
+        '<a href="mailto:abc@gmail.com"><emoji>😄</emoji></a> ' +
         '[<emoji>😄</emoji>]( <a href="mailto:abc@gmail.com">abc@gmail.com</a>) ' +
         '[<emoji>😄</emoji>] <a href="mailto:abc@gmail.com">abc@gmail.com</a> ' +
         '[<emoji>😄</emoji>]((<a href="mailto:abc@gmail.com">abc@gmail.com</a>)) ' +
@@ -1051,7 +1051,7 @@ test('Test markdown and url links with inconsistent starting and closing parens'
 
 test('Test link: Keep spaces at both end for shouldKeepRawInput=true', () => {
     const testString = '[ link ](https://www.expensify.com)';
-    const resultString = '<a href=\"https://www.expensify.com\" data-raw-href=\"https://www.expensify.com\" data-link-variant=\"labeled\" target=\"_blank\" rel=\"noreferrer noopener\"> link </a>';
+    const resultString = '<a href="https://www.expensify.com" data-raw-href="https://www.expensify.com" data-link-variant="labeled" target="_blank" rel="noreferrer noopener"> link </a>';
     expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
 });
 
@@ -2136,7 +2136,8 @@ describe('Video markdown conversion to html tag', () => {
 
     test('Text containing videos', () => {
         const testString = 'A video of a banana: ![banana](https://example.com/banana.mp4) a video without name: !(https://example.com/developer.mp4)';
-        const resultString = 'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
+        const resultString =
+            'A video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video> a video without name: <video data-expensify-source="https://example.com/developer.mp4" ></video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2144,35 +2145,40 @@ describe('Video markdown conversion to html tag', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-raw-href="https://example.com/video.mp4" data-link-variant="labeled" >test</video>';
         expect(parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString);
-    })
+    });
 
     test('Single video with extra cached attributes with videoAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(parser.replace(testString, {
-            extras: {
-                videoAttributeCache: {
-                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    videoAttributeCache: {
+                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 
     test('Single video with extra cached attributes with mediaAttributeCache', () => {
         const testString = '![test](https://example.com/video.mp4)';
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" data-expensify-height="100" data-expensify-width="100">test</video>';
-        expect(parser.replace(testString, {
-            extras: {
-                mediaAttributeCache: {
-                    'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    mediaAttributeCache: {
+                        'https://example.com/video.mp4': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 
     test('Text containing image and video', () => {
         const testString = 'An image of a banana: ![banana](https://example.com/banana.png) and a video of a banana: ![banana](https://example.com/banana.mp4)';
-        const resultString = 'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
+        const resultString =
+            'An image of a banana: <img src="https://example.com/banana.png" alt="banana" /> and a video of a banana: <video data-expensify-source="https://example.com/banana.mp4" >banana</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
@@ -2193,9 +2199,7 @@ describe('Video markdown conversion to html tag', () => {
         const resultString = '<video data-expensify-source="https://example.com/video.mp4" >&#x60;&#x60;&#x60;test&#x60;&#x60;&#x60;</video>';
         expect(parser.replace(testString)).toBe(resultString);
     });
-
-
-})
+});
 
 describe('Image markdown conversion to html tag', () => {
     test('Single image with alt text', () => {
@@ -2285,27 +2289,30 @@ describe('Image markdown conversion to html tag', () => {
     test('Single image with extra cached attributes using mediaAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(parser.replace(testString, {
-            extras: {
-                mediaAttributeCache: {
-                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    mediaAttributeCache: {
+                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 
     test('Single image with extra cached attributes using videAttributeCache', () => {
         const testString = '![test](https://example.com/image.jpg)';
         const resultString = '<img src="https://example.com/image.jpg" alt="test" data-expensify-height="100" data-expensify-width="100"/>';
-        expect(parser.replace(testString, {
-            extras: {
-                videoAttributeCache: {
-                    'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"'
-                }
-            }
-        })).toBe(resultString);
-    })
-
+        expect(
+            parser.replace(testString, {
+                extras: {
+                    videoAttributeCache: {
+                        'https://example.com/image.jpg': 'data-expensify-height="100" data-expensify-width="100"',
+                    },
+                },
+            }),
+        ).toBe(resultString);
+    });
 });
 
 describe('room mentions', () => {
@@ -2320,15 +2327,15 @@ describe('room mentions', () => {
         const resultString = 'hi all <mention-report>#room</mention-report>';
         expect(parser.replace(testString)).toBe(resultString);
     });
-    test('room mention with any leading character', () => {
-        const testString = 'a#room 1#room :#room';
-        const resultString = 'a<mention-report>#room</mention-report> 1<mention-report>#room</mention-report> :<mention-report>#room</mention-report>';
+    test('room mention with : as leading character', () => {
+        const testString = ':#room';
+        const resultString = ':<mention-report>#room</mention-report>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 
     test('room mention with leading word and no space', () => {
         const testString = 'hi all#room';
-        const resultString = 'hi all<mention-report>#room</mention-report>';
+        const resultString = 'hi all#room';
         expect(parser.replace(testString)).toBe(resultString);
     });
 

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2328,7 +2328,7 @@ describe('room mentions', () => {
 
     test('room mention with leading word and no space', () => {
         const testString = 'hi all#room';
-        const resultString = 'hi all#room';
+        const resultString = 'hi all<mention-report>#room</mention-report>';
         expect(parser.replace(testString)).toBe(resultString);
     });
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -350,7 +350,7 @@ export default class ExpensiMark {
             {
                 name: 'reportMentions',
 
-                regex: /(?<=^[*~_]?|[ \n][*~_]?)(#[\p{Ll}0-9-]{1,99})(?![^<]*(?:<\/pre>|<\/code>|<\/a>))/gimu,
+                regex: /(?<=^|[*~_]?|[ \n][*~_]?)(#[\p{Ll}0-9-]{1,99})(?![^<]*(?:<\/pre>|<\/code>|<\/a>))/gimu,
                 replacement: '<mention-report>$1</mention-report>',
             },
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -350,7 +350,7 @@ export default class ExpensiMark {
             {
                 name: 'reportMentions',
 
-                regex: /(?<=^|[*~_]?|[ \n][*~_]?)(#[\p{Ll}0-9-]{1,99})(?![^<]*(?:<\/pre>|<\/code>|<\/a>))/gimu,
+                regex: /(?<=^[*~_:]?|[ \n][*~_:]?|[:#])(#[\p{Ll}0-9-]{1,99})(?![^<]*(?:<\/pre>|<\/code>|<\/a>))/gimu,
                 replacement: '<mention-report>$1</mention-report>',
             },
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This PR fixes an issue where the regex for room mentions (`#room-name`) was not matching case when the `#` symbol was preceded by `:` character


### Fixed Issues
https://github.com/Expensify/App/issues/57195

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
- Verify the `#test-room` string matches the room name if the string is:
`:#test-room`


2. What tests did you perform that validates your changed worked?

Test steps:

```
1. Create a room named `test-room-name`
2. Open the admin room of the workspace in step 1
3. Send `:#test-room-name` message
4. Verify the `#test-room-name` is highlighted
```


https://github.com/user-attachments/assets/d6392dac-fbad-427b-a244-54698115e7d2



# QA
1. What does QA need to do to validate your changes?

2. What areas to they need to test for regressions?





