### PR TITLE
fix: multiple bolds with </em> in between are not rendered correctly

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2069,6 +2069,10 @@ test('Test italic/bold/strikethrough markdown to keep consistency', () => {
     testString = '~This~is~strikethrough~test~~~~';
     resultString = '<del>This~is~strikethrough~test</del>~~~';
     expect(parser.replace(testString)).toBe(resultString);
+
+    testString = '_**bold**_*bold*';
+    resultString = '<em>*<strong>bold</strong>*</em><strong>bold</strong>';
+    expect(parser.replace(testString)).toBe(resultString);
 });
 
 describe('multi-level blockquote', () => {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -525,7 +525,7 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /(?<!<[^>]*)(\b_|\B)\*(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
+                regex: /(?<!<[^>]*)(\b_|\B)\*(?!(?:<\/em))(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
                 replacement: (_extras, match, g1, g2) => {
                     if (g1.includes('_')) {
                         return `${g1}<strong>${g2}</strong>`;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/58215
$ PROPOSAL: https://github.com/Expensify/App/issues/58215#issuecomment-2714963469

# Tests

1. Paste this message into the composer in App:

```
~_**Zoom**_~
*Test*
```

2. Verify `*Zoom*` is formatted with bold, italic and strikethrough
3. Verify `Test` is formatted with bold
4. Send the message
5. Verify `*Zoom*` and `Test` are formatted with bold

# QA

1. Paste this message into the composer in App:

```
~_**Zoom**_~
*Test*
```

2. Verify `*Zoom*` is formatted with bold, italic and strikethrough
3. Verify `Test` is formatted with bold
4. Send the message
5. Verify `*Zoom*` and `Test` are formatted with bold

# Screenshots

<img width="1195" alt="Screenshot 2025-03-24 at 12 32 21" src="https://github.com/user-attachments/assets/7db6616b-e5b3-41f2-9402-bf0c9952e782" />

<img width="1195" alt="Screenshot 2025-03-24 at 12 32 24" src="https://github.com/user-attachments/assets/ac6bdee6-c2c6-4591-93b4-27b01cff4279" />
