### PR TITLE
add Unicode Private Use Area to emoji regex for custom emojis implementation

### DIFF
--- a/lib/CONST.ts
+++ b/lib/CONST.ts
@@ -418,7 +418,7 @@ const CONST = {
          * @type RegExp
          */
         EMOJI_RULE:
-            /[\p{Extended_Pictographic}](\u200D[\p{Extended_Pictographic}]|[\u{1F3FB}-\u{1F3FF}]|[\u{E0020}-\u{E007F}]|\uFE0F|\u20E3)*|[\u{1F1E6}-\u{1F1FF}]{2}|[#*0-9]\uFE0F?\u20E3/gu,
+            /[\p{Extended_Pictographic}\uE000-\uF8FF\u{F0000}-\u{FFFFD}\u{100000}-\u{10FFFD}](\u200D[\p{Extended_Pictographic}]|[\u{1F3FB}-\u{1F3FF}]|[\u{E0020}-\u{E007F}]|\uFE0F|\u20E3)*|[\u{1F1E6}-\u{1F1FF}]{2}|[#*0-9]\uFE0F?\u20E3/gu,
 
         /**
          * Regex to match a piece of text or @here, needed for both shortMention and userMention


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/54643

This implements part of this issue of adding custom emojis with adding a font containing Unicode Private User Area.

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

1. Start typing :global_create: in the composer. As you type this, verify that the emoji suggestions show the green plus icon emoji.
2. Click on the emoji.
(The composer presently shows an unrecognized glyph and this needs change in native react-native-live-markdown.)
3. Send the message.
4. Verify that the message is shown as the global create emoji.
5. Go to LHN.
6. Verify that the LHN shows the global create emoji for this chat in LHN.

# QA
1. What does QA need to do to validate your changes?
Same as above specified for "What tests did you perform that validates your changed worked?"
1. What areas to they need to test for regressions?
