### PR TITLE
Add new method to merge report actions by reportActionID

### DIFF
--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -204,7 +204,7 @@ export default class ReportHistoryStore {
 
     /**
      * Merges history items using the reportActionID into the cache and creates it if it doesn't yet exist.
-     * We then sorts them by timestamp and action name to ensure a consistent order if two report actions have the same timestamp
+     * We then sorts them by timestamp and then reprotActionID to ensure a consistent order if two report actions have the same timestamp
      *
      * @param {Number} reportID
      * @param {Object[]} newHistory
@@ -227,7 +227,7 @@ export default class ReportHistoryStore {
                 return b.reportActionTimestamp - a.reportActionTimestamp;
             }
 
-            return a.actionName.localeCompare(b.actionName);
+            return a.reportActionID.localeCompare(b.reportActionID);
         });
     }
 

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -159,16 +159,6 @@ export default class ReportHistoryStore {
     }
 
     /**
-     * Updates the cache with new history containing all of the report's actions
-     *
-     * @param {Number} reportID
-     * @param {Object[]} newHistory
-     */
-    updateCache(reportID, newHistory) {
-        this.cache[reportID] = newHistory;
-    }
-
-    /**
      * Merges history items into the cache and creates it if it doesn't yet exist.
      *
      * @param {Number} reportID
@@ -213,6 +203,28 @@ export default class ReportHistoryStore {
     }
 
     /**
+     * Merges history items by reportActionID into the cache and creates it if it doesn't yet exist.
+     *
+     * @param {Number} reportID
+     * @param {Object[]} newHistory
+     */
+    mergeHistoryByReportActionID(reportID, newHistory) {
+        if (newHistory.length === 0) {
+            return;
+        }
+
+        const newCache = newHistory.reverse().reduce((prev, curr) => {
+            if (!prev.some((item) => item.reportActionID === curr.reportActionID)) {
+                prev.unshift(curr);
+            }
+            return prev;
+        }, this.cache[reportID] || []);
+
+        // Sort items in case they have become out of sync
+        this.cache[reportID] = newCache.sort((a, b) => b.reportActionTimestamp - a.reportActionTimestamp);
+    }
+
+    /**
      * Gets the history.
      *
      * @param {Number} reportID
@@ -238,13 +250,8 @@ export default class ReportHistoryStore {
             offset: firstHistoryItem.sequenceNumber || 0,
         })
             .done((recentHistory) => {
-                if (firstHistoryItem.sequenceNumber > 0) {
-                    // Update history with new items fetched
-                    this.mergeItems(reportID, recentHistory);
-                } else {
-                    // If offset is 0, don't do any merging as we've fetched all of the actions
-                    this.updateCache(reportID, recentHistory);
-                }
+                // Update history with new items fetched
+                this.mergeItems(reportID, recentHistory);
 
                 // Return history for this report
                 promise.resolve(this.cache[reportID]);
@@ -273,8 +280,9 @@ export default class ReportHistoryStore {
         this.API.Report_GetHistory({
             reportID,
         })
-            .done((newHistory) => {
-                this.updateCache(reportID, newHistory);
+            .done((recentHistory) => {
+                // Update history with new items fetched
+                this.mergeHistoryByReportActionID(reportID, recentHistory);
 
                 // Return history for this report
                 promise.resolve(this.cache[reportID]);

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -277,7 +277,6 @@ export default class ReportHistoryStore {
      * @returns {Deferred}
      */
     getFlatHistory(reportID, ignoreCache) {
-        console.log("flat");
         const promise = new Deferred();
 
         // Remove the cache entry if we're ignoring the cache, since we'll be replacing it later.


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

When fetching all of the report's action to refresh them, we don't need to do any merging but simply update the cache.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/489667

# Tests
I used [localJS](https://stackoverflowteams.com/c/expensify/questions/29) and supportalled into events@culturalcare.com / report  https://www.expensify.com/report?param=%7B%22pageReportID%22:%22877821327596826%22,%22keepCollection%22:true%7D  and made sure the report action `FORWARDED` is showing  in report page.

Before:
<img width="994" alt="Screenshot 2025-04-11 at 02 23 57" src="https://github.com/user-attachments/assets/156ffe77-7078-4b2f-b352-a01519a0cb7d" />

After:
<img width="986" alt="Screenshot 2025-04-11 at 02 24 03" src="https://github.com/user-attachments/assets/405808fe-1f3d-4820-a1d2-b5cf079c70b1" />


# QA
1. Supportal into events@culturalcare.com, go to report https://www.expensify.com/report?param=%7B%22pageReportID%22:%22877821327596826%22,%22keepCollection%22:true%7D and verify actions show up as in the "After" screenshot above.
