### PR TITLE
italic with multiple underscores in the middle

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2437,4 +2437,10 @@ describe('room mentions', () => {
         const resultString = '<mention-report>#room-name123</mention-report>';
         expect(parser.replace(testString)).toBe(resultString);
     });
+
+    test('italic with multiple underscores in the middle', () => {
+        const testString = '_test1__test2_';
+        const resultString = '<em>test1__test2</em>';
+        expect(parser.replace(testString)).toBe(resultString);
+    });
 });

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -454,8 +454,8 @@ export default class ExpensiMark {
              */
             {
                 name: 'italic',
-                regex: /(<(pre|code|a|mention-user|video)[^>]*>(.*?)<\/\2>)|((\b_+|\b)_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(?![^\W_])(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|<\/video>)))/g,
-                replacement: (_extras, match, html, tag, content, text, extraLeadingUnderscores, textWithinUnderscores) => {
+                regex: /(<(pre|code|a|mention-user|video)[^>]*>(.*?)<\/\2>)|((\b_+|\b)_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(_*)(?![^\W_])(\b_+|\b)(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|<\/video>)))/g,
+                replacement: (_extras, match, html, tag, content, text, extraLeadingUnderscores, textWithinUnderscores, extraLeadingUnderscoresEnd) => {
                     // Skip any <pre>, <code>, <a>, <mention-user>, <video> tag contents
                     if (html) {
                         return html;
@@ -467,9 +467,9 @@ export default class ExpensiMark {
                     }
 
                     if (String(textWithinUnderscores).match(`^${Constants.CONST.REG_EXP.MARKDOWN_EMAIL}`)) {
-                        return `<em>${extraLeadingUnderscores}${textWithinUnderscores}</em>`;
+                        return `<em>${extraLeadingUnderscores}${textWithinUnderscores}</em>${extraLeadingUnderscoresEnd}`;
                     }
-                    return `${extraLeadingUnderscores}<em>${textWithinUnderscores}</em>`;
+                    return `${extraLeadingUnderscores}<em>${textWithinUnderscores}</em>${extraLeadingUnderscoresEnd}`;
                 },
             },
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

This issue is to fix the case `_italic1__italic2_` doesn't work for `_italic2_`. Currently we just applied word boundary at the beginning and we need to do the same at the end

### Fixed Issues
$ https://github.com/Expensify/App/issues/59790

# Tests
1. Go to any chat
2. Enter `_italic1__italic2_`
3. Verify the whole text is italicized

# QA
1. Go to any chat
2. Enter `_italic1__italic2_`
3. Verify the whole text is italicized

# Screenshot
<img width="501" alt="Screenshot 2025-04-14 at 22 52 12" src="https://github.com/user-attachments/assets/99b18573-05ac-4b76-bb11-0b1753f876be" />

