### PR TITLE
Bring back underscore to fix broken templates from Web-E

### DIFF
--- a/lib/Templates.jsx
+++ b/lib/Templates.jsx
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import createTemplate from 'lodash/template';
+import _ from 'underscore';
 import * as Utils from './utils';
 
 /**
@@ -37,7 +37,7 @@ export default (function () {
          */
         get(data = {}) {
             if (!this.compiled) {
-                this.compiled = createTemplate(this.templateValue);
+                this.compiled = _.template(this.templateValue);
                 this.templateValue = '';
             }
             return this.compiled(data);
@@ -71,7 +71,7 @@ export default (function () {
             // eslint-disable-next-line no-undef
             dataToCompile.nestedTemplate = Templates.get;
             if (!this.compiled) {
-                this.compiled = createTemplate($(`#${this.id}`).html());
+                this.compiled = _.template($(`#${this.id}`).html());
             }
             return this.compiled(dataToCompile);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-dom": "16.12.0",
         "semver": "^7.6.3",
         "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-        "ua-parser-js": "^1.0.38"
+        "ua-parser-js": "^1.0.38",
+        "underscore": "^1.13.7"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",
@@ -12240,10 +12241,10 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
-      "dev": true
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
     },
     "node_modules/underscore.string": {
       "version": "3.3.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-dom": "16.12.0",
     "semver": "^7.6.3",
     "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-    "ua-parser-js": "^1.0.38"
+    "ua-parser-js": "^1.0.38",
+    "underscore": "^1.13.7"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

We're bringing back underscore to be used in the templates file only because there's way too many changes needed in Web-E to make it work, we'll be doing that separately. For now we need to fix a customer issue ASAP.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/489667

# Tests
1. Make sure various pages load fine in Web-E.

# QA
N/A will be tested in Web-E
