### PR TITLE
Fix quoted multiline links

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1751,6 +1751,19 @@ test('Test link with header before the alias multiline text part', () => {
     expect(parser.replace(testString)).toBe(resultString);
 });
 
+
+test('Test markdown replacement for quoted multiline links', () => {
+    let testString = `> [exa\nmple.com](https://example.com)`;
+    let resultString = `<blockquote>[exa</blockquote><a href="https://mple.com" target="_blank" rel="noreferrer noopener">mple.com</a>](<a href="https://example.com" target="_blank" rel="noreferrer noopener">https://example.com</a>)`
+    expect(parser.replace(testString)).toBe(resultString);
+
+    testString = `> [exa\nmple.com](https://example.com)`;
+    resultString = `<blockquote> [exa</blockquote>\n<a href="https://mple.com" data-raw-href="mple.com" data-link-variant="auto" target="_blank" rel="noreferrer noopener">mple.com</a>](<a href="https://example.com" data-raw-href="https://example.com" data-link-variant="auto" target="_blank" rel="noreferrer noopener">https://example.com</a>)`
+    expect( parser.replace(testString, {shouldKeepRawInput: true})).toBe(resultString)
+});
+
+
+
 test('Test strikethrough with multiple tilde characters', () => {
     let testString = '~~~hello~~~';
     expect(parser.replace(testString)).toBe('~~<del>hello</del>~~');


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
This PR fixes an issues with parsing quoted multiline link which causes errors in the Live Markdown Input.


Now it looks like this:
![Screenshot 2025-04-22 at 15 29 47](https://github.com/user-attachments/assets/f505f239-4b5d-4c47-b6b1-5fe76b6b7086)

### Fixed Issues

$ GH_LINK

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
