### PR TITLE
handle back-to-back underscore/italic in markdown

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -98,6 +98,12 @@ test('Test italic markdown replacement with word boundary and undercores', () =>
     expect(parser.replace(testString)).toBe(replacedString);
 });
 
+test('Test italic markdown replacement with consecutive italicized strings with no space', () => {
+    const testString =  '_hello_world_ ' + '_hello__world_ ' + '_hello_';
+    const replacedString =  '<em>hello_world</em> ' + '<em>hello</em><em>world</em> ' + '<em>hello</em>';
+    expect(parser.replace(testString)).toBe(replacedString);
+});
+
 test('Test quote markdown combined multi-line italic/bold/strikethrough markdown replacement', () => {
     let testString = '_test\n> test_';
     let replacedString = '_test<br /><blockquote>test_</blockquote>';

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -454,7 +454,7 @@ export default class ExpensiMark {
              */
             {
                 name: 'italic',
-                regex: /(<(pre|code|a|mention-user|video)[^>]*>(.*?)<\/\2>)|((\b_+|\b)_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(?![^\W_])(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|<\/video>)))/g,
+                regex: /(<(pre|code|a|mention-user|video)[^>]*>(.*?)<\/\2>)|((\b_+|\b|(?<=_)(?<!\b[^\W_]*_))_((?![\s_])[\s\S]*?[^\s_](?<!\s))_(?![^\W_])(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/mention-user>|<\/video>)))/g,
                 replacement: (_extras, match, html, tag, content, text, extraLeadingUnderscores, textWithinUnderscores) => {
                     // Skip any <pre>, <code>, <a>, <mention-user>, <video> tag contents
                     if (html) {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->
Fix the regular expression that processes underscores in markdown to correctly handle two back-to-back words, for example:
```
_test__test_
```
There are two changes to the (already pretty complicated) regex that's matching the "_":
1. To fix the current issue, add a positive lookbehind to allow "_": `(?<=_)`
2. To not break the existing test case of hello__world (which should not get italicized), add a negative lookbehind to not match an underscore in the middle of a word: `(?<!\b[^\W_]*_)`


### Fixed Issues
$ https://github.com/Expensify/App/issues/59790

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Added test named "Test italic markdown replacement with consecutive italicized strings with no space" in `ExpensiMark-HTML-jest.js`

2. What tests did you perform that validates your changed worked?
Tested manually with a variety of inputs using  regex101.com

# QA
1. What does QA need to do to validate your changes?
Test entering the following into a chat and sending it:
```
_test__test_
```
Both words should display in italics.

2. What areas to they need to test for regressions?
Test splitting italics across multiple lines:
```
_this should all
be in italics_
```

Test underscores in the middle of a word:
```
this_should_not_be_italics
```
