### PR TITLE
chore: use globalThis when checking for window and navigator

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,12 +2,12 @@
 
 /** Checks if the `window` global object is available. */
 function isWindowAvailable(): boolean {
-    return typeof window !== 'undefined';
+    return typeof globalThis.window !== 'undefined';
 }
 
 /** Checks if the `navigator` global object is available. */
 function isNavigatorAvailable(): boolean {
-    return typeof navigator !== 'undefined';
+    return typeof globalThis.navigator !== 'undefined';
 }
 
 const htmlEscapes = {


### PR DESCRIPTION
When I was trying to use `react-native-worklets` with `react-native-live-markdown` https://github.com/tjzel/react-native-live-markdown/pull/1 I noticed that not explicitly using `globalThis` in these helper functions makes them fail - the `navigator` object is copied from the RN Runtime to the UI Runtime, instead of checking if it's available on the caller runtime. This change should have no other effect.
