### PR TITLE
Fix fastMerge worklet

### DIFF
--- a/lib/fastMerge.ts
+++ b/lib/fastMerge.ts
@@ -13,21 +13,28 @@ function isMergeableObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Merges the source object into the target object.
- * @param target - The target object.
- * @param source - The source object.
- * @param shouldRemoveNestedNulls - If true, null object values will be removed.
- * @returns - The merged object.
+ * Merges two objects and removes null values if "shouldRemoveNullObjectValues" is set to true
+ *
+ * We generally want to remove null values from objects written to disk and cache, because it decreases the amount of data stored in memory and on disk.
+ * On native, when merging an existing value with new changes, SQLite will use JSON_PATCH, which removes top-level nullish values.
+ * To be consistent with the behaviour for merge, we'll also want to remove null values for "set" operations.
  */
-function mergeObject<TObject extends Record<string, unknown>>(target: TObject, source: TObject, shouldRemoveNullObjectValues = true): TObject {
-    const destination: Record<string, unknown> = {};
+function fastMerge<TObject extends Record<string, unknown>>(target: TObject, source: TObject, shouldRemoveNullObjectValues = true): TObject {
+    // We have to ignore arrays and nullish values here,
+    // otherwise "mergeObject" will throw an error,
+    // because it expects an object as "source"
+    if (Array.isArray(source) || source === null || source === undefined) {
+        return source;
+    }
 
+    //  Merges the source object into the target object.
+    const destination: Record<string, unknown> = {};
     if (isMergeableObject(target)) {
         // lodash adds a small overhead so we don't use it here
         const targetKeys = Object.keys(target);
         for (let i = 0; i < targetKeys.length; ++i) {
             const key = targetKeys[i];
-            const sourceValue = source?.[key];
+            const sourceValue = source?.[key] as unknown;
             const targetValue = target?.[key];
 
             // If shouldRemoveNullObjectValues is true, we want to remove null values from the merged object
@@ -68,23 +75,6 @@ function mergeObject<TObject extends Record<string, unknown>>(target: TObject, s
     }
 
     return destination as TObject;
-}
-
-/**
- * Merges two objects and removes null values if "shouldRemoveNullObjectValues" is set to true
- *
- * We generally want to remove null values from objects written to disk and cache, because it decreases the amount of data stored in memory and on disk.
- * On native, when merging an existing value with new changes, SQLite will use JSON_PATCH, which removes top-level nullish values.
- * To be consistent with the behaviour for merge, we'll also want to remove null values for "set" operations.
- */
-function fastMerge<TObject>(target: TObject, source: TObject, shouldRemoveNullObjectValues = true): TObject {
-    // We have to ignore arrays and nullish values here,
-    // otherwise "mergeObject" will throw an error,
-    // because it expects an object as "source"
-    if (Array.isArray(source) || source === null || source === undefined) {
-        return source;
-    }
-    return mergeObject(target as Record<string, unknown>, source as Record<string, unknown>, shouldRemoveNullObjectValues) as TObject;
 }
 
 export default fastMerge;


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

We've tried updating `expensify-common` to the latest version (2.0.144) in the `react-native-live-markdown` repo, but encountered crashes due to invalid fastMerge file workletization caused by https://github.com/Expensify/expensify-common/pull/855. Because in this file we can find double-function recursion and worklets aren't hoisted, it results in a crash with an error: `Cannot access 'fastMerge' before initialization`.

In this PR, I'm breaking double function recursion and moving the `mergeObject` code inside the `fastMerge` function. It shouldn't affect anything since `mergeObject` isn't exported, only `fastMerge` was using it.

### Fixed Issues
$ https://github.com/Expensify/App/issues/39518

# Tests
1. Verify if E/App isn't crashing in LHN with this change
2. Verify if the `live-markdown` example app isn't crashing too with this change

# QA
Same as Tests
