### PR TITLE
Fix/65244 - Paste the copied message having quote markdown displays wrong line with original

### DIFF
--- a/__tests__/ExpensiMark-Markdown-test.js
+++ b/__tests__/ExpensiMark-Markdown-test.js
@@ -152,11 +152,18 @@ test('Test HTML string with encoded entities', () => {
 test('Test HTML string with blockquote', () => {
     const testString = '<blockquote><p>This GH seems to assume that there will be something in the paste\nbuffer when you copy block-quoted text out of slack. But when I dump\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\nbuffer, then dump it into terminal, there\'s nothing. And if I dump it </blockquote>'
         + '<blockquote>line1\nline2\n\nsome <em>lorem ipsum</em> into a blockquote in Slack, copy it to the\n\n\nbuffer </blockquote>'
-        + '<blockquote style="color:red;" data-label="note">line1 <em>lorem ipsum</em></blockquote>';
+        + '<blockquote style="color:red;" data-label="note">line1 <em>lorem ipsum</em></blockquote>'
+        + '<blockquote> </blockquote>empty_line _lorem ipsum'
+        + '<blockquote>    </blockquote>space_line _lorem ipsum'
+        + '<blockquote>    \n    </blockquote>break_line _lorem ipsum';
 
-    const resultString = '> This GH seems to assume that there will be something in the paste\n> buffer when you copy block-quoted text out of slack. But when I dump\n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> buffer, then dump it into terminal, there\'s nothing. And if I dump it\n'
-        + '> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer\n'
-        + '> line1 _lorem ipsum_';
+    const resultString = '> This GH seems to assume that there will be something in the paste\n> buffer when you copy block-quoted text out of slack. But when I dump\n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> buffer, then dump it into terminal, there\'s nothing. And if I dump it \n'
+        + '> line1\n> line2\n> \n> some _lorem ipsum_ into a blockquote in Slack, copy it to the\n> \n> \n> buffer \n'
+        + '> line1 _lorem ipsum_\n'
+        + '> \nempty_line _lorem ipsum\n'
+        + '>    \nspace_line _lorem ipsum\n'
+        + '>    \n>    \nbreak_line _lorem ipsum'
+        ;
 
     expect(parser.htmlToMarkdown(testString)).toBe(resultString);
 });

--- a/__tests__/ExpensiMark-test.js
+++ b/__tests__/ExpensiMark-test.js
@@ -100,3 +100,31 @@ describe('Test ExpensiMark getAttributeCache', () => {
         expect(attrCache).toBe(undefined);
     })
 });
+
+describe('Test ExpensiMark replaceBlockElementWithNewLine', () => {
+    const blockElement = ['div', 'comment', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'li'];
+    describe.each(blockElement)('replace <%s> block exactly', (blockName) => {
+        test('without blockquote', () => {
+            const input = `textLine1<${blockName}>textLine2</${blockName}>textLine3   <${blockName}>textLine4\n</${blockName}><${blockName}># </${blockName}><${blockName}>textLine6</${blockName}>`;
+            const expected = 'textLine1\ntextLine2\ntextLine3   \ntextLine4\n# textLine6';
+            expect(parser.replaceBlockElementWithNewLine(input)).toBe(expected);
+        });
+        test('with blockquote', () => {
+            const input = `<blockquote>> <${blockName}>textLine</${blockName}></blockquote>`;
+            const expected = '> textLine';
+            expect(parser.replaceBlockElementWithNewLine(input)).toBe(expected);
+        });
+    });
+
+    test('replace <blockquote> block exactly', () => {
+        const input = `<blockquote>> textLine1 </blockquote><blockquote>> textLine2\n</blockquote><blockquote>> textLine3</blockquote>`;
+        const expected = '> textLine1 \n> textLine2\n> textLine3';
+        expect(parser.replaceBlockElementWithNewLine(input)).toBe(expected);
+    });
+
+    test('replace multi block exactly', () => {
+        const input = `<blockquote>> textLine1 </blockquote><blockquote>> <p>textLine2\n<p><div>textLine3</div></blockquote><h1>textLine4</h1><div><p><comment>textLine5\n\n</comment></p></div><li><p>textLine6</p></li>`;
+        const expected = '> textLine1 \n> textLine2\ntextLine3\ntextLine4\ntextLine5\ntextLine6';
+        expect(parser.replaceBlockElementWithNewLine(input)).toBe(expected);
+    });
+});

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -659,6 +659,8 @@ export default class ExpensiMark {
                     let resultString: string[] | string = g2
                         .replace(/\n?(<h1># )/g, '$1')
                         .replace(/(<h1>|<\/h1>)+/g, '\n')
+                        // Replace trim() with manually removing line breaks at the beginning and end of the string to avoid adding extra lines
+                        .replace(/^(\n)+|(\n)+$/g, '')
                         .split('\n');
 
                     // Wrap each string in the array with <blockquote> and </blockquote>
@@ -672,7 +674,9 @@ export default class ExpensiMark {
                             let depth;
                             do {
                                 depth = (modifiedText.match(/<blockquote>/gi) || []).length;
-                                modifiedText = modifiedText.replace(/<blockquote>/gi, '');
+                                // Need (\s)? because the server usually sends a space character after <blockquote> so we need to consume it,
+                                // avoid being redundant because it is added in the return part
+                                modifiedText = modifiedText.replace(/<blockquote>(\s)?/gi, '');
                                 modifiedText = modifiedText.replace(/<\/blockquote>/gi, '');
                             } while (/<blockquote>/i.test(modifiedText));
                             return `${'>'.repeat(depth)} ${modifiedText}`;
@@ -1122,14 +1126,19 @@ export default class ExpensiMark {
      * replace block element with '\n' if :
      * 1. We have text within the element.
      * 2. The text does not end with a new line.
-     * 3. The text does not have quote mark '>' .
-     * 4. It's not the last element in the string.
+     * 3. It's not the last element in the string.
      */
     replaceBlockElementWithNewLine(htmlString: string): string {
         // eslint-disable-next-line max-len
-        let splitText = htmlString.split(
-            /<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>|<blockquote>|<\/blockquote>/,
-        );
+        let splitText = htmlString
+            // Lines starting with quote mark '>' will have '\n' added to them so to avoid adding extra '\n', remove the block element right next to it
+            .replaceAll(
+                /<blockquote>> (<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>)/gi,
+                '<blockquote>> ',
+            )
+            .split(
+                /<div.*?>|<\/div>|<comment.*?>|\n<\/comment>|<\/comment>|<h1>|<\/h1>|<h2>|<\/h2>|<h3>|<\/h3>|<h4>|<\/h4>|<h5>|<\/h5>|<h6>|<\/h6>|<p>|<\/p>|<li>|<\/li>|<blockquote>|<\/blockquote>/,
+            );
         const stripHTML = (text: string) => Str.stripHTML(text);
         splitText = splitText.map(stripHTML);
         let joinedText = '';

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -659,7 +659,6 @@ export default class ExpensiMark {
                     let resultString: string[] | string = g2
                         .replace(/\n?(<h1># )/g, '$1')
                         .replace(/(<h1>|<\/h1>)+/g, '\n')
-                        .trim()
                         .split('\n');
 
                     // Wrap each string in the array with <blockquote> and </blockquote>
@@ -1148,9 +1147,8 @@ export default class ExpensiMark {
                 return;
             }
 
-            const nextItem = splitText?.[index + 1];
-            // Insert '\n' unless it ends with '\n' or '>' or it's the last element, or if it's a header ('# ') with a space.
-            if ((nextItem && text.match(/>[\s]?$/) && !nextItem.startsWith('> ')) || text.match(/\n[\s]?$/) || index === splitText.length - 1 || text === '# ') {
+            // Insert '\n' unless it ends with '\n' or it's the last element, or if it's a header ('# ') with a space.
+            if (text.match(/\n[\s]?$/) || index === splitText.length - 1 || text === '# ') {
                 joinedText += text;
             } else {
                 joinedText += `${text}\n`;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

### Fixed Issues
$ https://github.com/Expensify/App/issues/65244
PROPOSAL: https://github.com/Expensify/App/issues/65244#issuecomment-3041145770

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
1. Open https://staging.new.expensify.com/
2. Go to any chat
3. Type ">" and space for creating quote markdown
4. Press Shift Enter
5. Type anything on the second line and send message
6. Copy this message
7. Paste this message to composer box
8. Note that the pasted message is same as original

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/42544b66-f1c8-4e0b-9c20-5655f2feed8a




</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/a200dc6f-9297-442c-a745-da32bc1d012a




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/f7f7d1f9-2325-4742-a8f0-15fc937c584c




</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/8e34661d-f11b-466f-8d8b-b2244c6a63a3




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/e421a9e5-e9aa-4512-ac2f-d12efa53d3a5




</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/e8c92f90-75b4-43ec-a23d-c50771605ade




</details>
