### PR TITLE
Support both objects and arrays in the ExpenseRule constructor

### DIFF
--- a/lib/ExpenseRule.jsx
+++ b/lib/ExpenseRule.jsx
@@ -2,7 +2,7 @@ export default class ExpenseRule {
     /**
      * Creates a new instance of this class.
      *
-     * @param {Object} ruleArray
+     * @param {Object|Array} ruleArray
      */
     constructor(ruleArray) {
         // It's not 100% certain that `ruleArray` is an array or an object, so support both of them so the app doesn't crash


### PR DESCRIPTION
See this slack thread: https://expensify.slack.com/archives/C03SSAQ7P/p1752768158420389

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/526415

# Tests
1. Update Web-E to use this code
2. Update [this line](https://github.com/Expensify/Web-Expensify/blob/2a240b2ed025a83b99ba45528ba86ee05a97a2dc/site/deprecated/lib_policy.js#L4256) to pass this specific object to the `_.each()`

```
{
        "applyWhen": [
            {
                "condition": "matches",
                "field": "category",
                "value": "IT Software Licenses and Subscriptions (General)"
            }
        ],
        "id": "61800d3f11a5f",
        "tax": {
            "field_id_TAX": {
                "externalID": "175"
            }
        }
    }
```

3. Open a report
4. Click on an expense to open megaedit
5. Verify you can open megaedit and edit the expense

# QA
1. Support log into `tgolen@expensify.com`
2. Open a report
3. Click on an expense
4. Verify that megaEdit can be opened and there is no JS console error
