### PR TITLE
[No QA] Fix checking for jsonCode error handlers

### DIFF
--- a/lib/APIDeferred.jsx
+++ b/lib/APIDeferred.jsx
@@ -49,7 +49,7 @@ export default function APIDeferred(promise, extractedProperty) {
      */
     function handleError(jsonCode, response) {
         // Look for handlers for this error code
-        const handlers = errorHandlers[jsonCode];
+        const handlers = errorHandlers[jsonCode] ?? [];
         if (handlers.length > 0) {
             Func.bulkInvoke(handlers, [jsonCode, response]);
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expensify-common",
-  "version": "2.0.152",
+  "version": "2.0.153",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expensify-common",
-      "version": "2.0.152",
+      "version": "2.0.153",
       "license": "MIT",
       "dependencies": {
         "awesome-phonenumber": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expensify-common",
-  "version": "2.0.152",
+  "version": "2.0.153",
   "author": "Expensify, Inc.",
   "description": "Expensify libraries and components shared across different repos",
   "homepage": "https://expensify.com",


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
Fixes an issue found when testing [this PR](https://github.com/Expensify/App/pull/62314), where the backend returns the response `"404 No user with that partner/userID"` when [trying to log in again](https://github.com/Expensify/Web-Expensify/blob/8bdc12e05262b41119e50cd2459a51e5069978dd/homepage/js/signin.jsx#L2443-L2456), after the user has been signed out from signout.php, via a redirect from New Expensify. If any APIDeferred returns a non-200 jsonCode and there isn't an error handler set up for it, when we try to access the error handler it will fail. Now I have fixed checking for the error handler so it works even if one doesn't exist.

# Tests
1. Check out this [App PR](https://github.com/Expensify/App/pull/62314) and build the dev site
3. Run `npm link` in expensify-common
4. In Web-E run `npm link expensify-common`
1. Restart grunt with force so it allows a different version of expensify-common `npm run grunt:watch -- --force`, and builds with these changes
5. Perform the test from that PR with an existing account and verify it succeeds

Clean up
1. In Web-E run `npm unlink expensify-common && npm install`


Original error

https://github.com/user-attachments/assets/30c7b83d-f8a9-4b18-b1ca-377de298056c

With this fix

https://github.com/user-attachments/assets/6d82281b-b7b7-45fa-b105-40e3d5879e07



# QA
No QA
