### PR TITLE
fix: allow replacing code/quote symbols without escaping

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -67,6 +67,14 @@ test('Test quote markdown replacement', () => {
     expect(parser.replace(quoteTestStartString)).toBe(quoteTestReplacedString);
 });
 
+test('Test quote markdown replacement with shouldEscapeText set as false', () => {
+    const quoteTestStartString = '> This is a *quote* that started on a new line.\nHere is a >quote that did not\n```\nhere is a codefenced quote\n>it should not be quoted\n```';
+    const quoteTestReplacedString =
+        '<blockquote>This is a <strong>quote</strong> that started on a new line.</blockquote>Here is a >quote that did not<br /><pre>here&#32;is&#32;a&#32;codefenced&#32;quote<br />>it&#32;should&#32;not&#32;be&#32;quoted<br /></pre>';
+
+    expect(parser.replace(quoteTestStartString, {shouldEscapeText: false})).toBe(quoteTestReplacedString);
+});
+
 // Words wrapped in _ successfully replaced with <em></em>
 test('Test italic markdown replacement', () => {
     const italicTestStartString = 'This is a _sentence,_ and it has some _punctuation, words, and spaces_. ___ _italic__ _test_ _ testing_ test_test_test. _ test _ _test _';
@@ -454,12 +462,23 @@ test('Test code fencing', () => {
     expect(parser.replace(codeFenceExampleMarkdown)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br /></pre>');
 });
 
+test('Test code fencing with shouldEscapeText set to false', () => {
+    const codeFenceExampleMarkdown = "```\nconst javaScript = 'javaScript'\n```";
+    expect(parser.replace(codeFenceExampleMarkdown, {shouldEscapeText: false})).toBe("<pre>const&#32;javaScript&#32;=&#32;'javaScript'<br /></pre>");
+});
+
 test('Test code fencing with spaces and new lines', () => {
     let codeFenceExample = "```\nconst javaScript = 'javaScript'\n    const php = 'php'\n```";
     expect(parser.replace(codeFenceExample)).toBe('<pre>const&#32;javaScript&#32;=&#32;&#x27;javaScript&#x27;<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;&#x27;php&#x27;<br /></pre>');
 
+    codeFenceExample = "```\nconst javaScript = 'javaScript'\n    const php = 'php'\n```";
+    expect(parser.replace(codeFenceExample, {shouldEscapeText: false})).toBe("<pre>const&#32;javaScript&#32;=&#32;'javaScript'<br />&#32;&#32;&#32;&#32;const&#32;php&#32;=&#32;'php'<br /></pre>");
+
     codeFenceExample = '```\n\n# test\n\n```';
     expect(parser.replace(codeFenceExample)).toBe('<pre><br />#&#32;test<br /><br /></pre>');
+
+    codeFenceExample = '```\n\n# test\n\n```';
+    expect(parser.replace(codeFenceExample, {shouldEscapeText: false})).toBe('<pre><br />#&#32;test<br /><br /></pre>');
 
     codeFenceExample = '```\n\n\n# test\n\n```';
     expect(parser.replace(codeFenceExample)).toBe('<pre><br /><br />#&#32;test<br /><br /></pre>');
@@ -485,6 +504,11 @@ test('Test inline code blocks', () => {
     expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is <code>JavaScript</code>. How about you?');
 });
 
+test('Test inline code blocks with shouldEscapeText set to false', () => {
+    const inlineCodeStartString = 'My favorite language is `JavaScript`. How about you?';
+    expect(parser.replace(inlineCodeStartString, {shouldEscapeText: false})).toBe('My favorite language is <code>JavaScript</code>. How about you?');
+});
+
 test('Test double backticks', () => {
     const testString = 'My favorite language is ``JavaScript``. How about you?';
     expect(parser.replace(testString)).toBe('My favorite language is &#x60;&#x60;JavaScript&#x60;&#x60;. How about you?');
@@ -498,6 +522,11 @@ test('Test inline code blocks with triple backticks', () => {
 test('Test multiple inline codes in one line', () => {
     const inlineCodeStartString = 'My favorite language is `JavaScript`. How about you? I also like `Python`.';
     expect(parser.replace(inlineCodeStartString)).toBe('My favorite language is <code>JavaScript</code>. How about you? I also like <code>Python</code>.');
+});
+
+test('Test multiple inline codes in one line with shouldEscapeText set to false', () => {
+    const inlineCodeStartString = 'My favorite language is `JavaScript`. How about you? I also like `Python`.';
+    expect(parser.replace(inlineCodeStartString, {shouldEscapeText: false})).toBe('My favorite language is <code>JavaScript</code>. How about you? I also like <code>Python</code>.');
 });
 
 test('Test triple backticks', () => {
@@ -529,6 +558,13 @@ test('Test words enclosed in double backticks', () => {
 test('Test code fencing with ExpensiMark syntax inside', () => {
     const codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
     expect(parser.replace(codeFenceExample)).toBe(
+        '<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)<br /></pre>',
+    );
+});
+
+test('Test code fencing with ExpensiMark syntax inside and shouldEscapeText set to false', () => {
+    const codeFenceExample = '```\nThis is how you can write ~strikethrough~, *bold*, _italics_, and [links](https://www.expensify.com)\n```';
+    expect(parser.replace(codeFenceExample, {shouldEscapeText: false})).toBe(
         '<pre>This&#32;is&#32;how&#32;you&#32;can&#32;write&#32;~strikethrough~,&#32;*bold*,&#32;_italics_,&#32;and&#32;[links](https://www.expensify.com)<br /></pre>',
     );
 });

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -171,7 +171,7 @@ export default class ExpensiMark {
                 name: 'codeFence',
 
                 // &#x60; is a backtick symbol we are matching on three of them before then after a new line character
-                regex: /(?<![^^\r\n])(&#x60;&#x60;&#x60;(\r\n|\n))((?:\s*?(?!(?:\r\n|\n)?&#x60;&#x60;&#x60;(?!&#x60;))[\S])+\s*?(?:\r\n|\n))(&#x60;&#x60;&#x60;)/g,
+                regex: /(?<![^^\r\n])((?:&#x60;&#x60;&#x60;|```)(\r\n|\n))((?:\s*?(?!(?:\r\n|\n)?(?:&#x60;&#x60;&#x60;|```)(?!&#x60;|`))[\S])+\s*?(?:\r\n|\n))(&#x60;&#x60;&#x60;|```)/g,
 
                 // We're using a function here to perform an additional replace on the content
                 // inside the backticks because Android is not able to use <pre> tags and does
@@ -227,7 +227,7 @@ export default class ExpensiMark {
                 // but we should not replace backtick symbols if they include <pre> tags between them.
                 // At least one non-whitespace character or a specific whitespace character (" " and "\u00A0")
                 // must be present inside the backticks.
-                regex: /(\B|_|)&#x60;(.*?)&#x60;(\B|_|)(?!(?!<pre>)[^<]*(?:<(?!pre>)[^<]*)*<\/pre>|[^<]*<\/video>)/gm,
+                regex: /(\B|_|)(?:&#x60;|`)(.*?)(?:&#x60;|`)(\B|_|)(?!(?!<pre>)[^<]*(?:<(?!pre>)[^<]*)*<\/pre>|[^<]*<\/video>)/gm,
                 replacement: (_extras, match, g1, g2, g3) => {
                     const g2Value = g2.trim() === '' ? g2.replaceAll(' ', '&nbsp;') : g2;
                     if (!g2Value) {
@@ -425,7 +425,7 @@ export default class ExpensiMark {
                 // block quotes naturally appear on their own line. Blockquotes should not appear in code fences or
                 // inline code blocks. A single prepending space should be stripped if it exists
                 process: (textToProcess, replacement, shouldKeepRawInput = false) => {
-                    const regex = /^(?:&gt;)+ +(?! )(?![^<]*(?:<\/pre>|<\/code>|<\/video>))([^\v\n\r]*)/gm;
+                    const regex = /^(?:&gt;|>)+ +(?! )(?![^<]*(?:<\/pre>|<\/code>|<\/video>))([^\v\n\r]*)/gm;
 
                     let replacedText = this.replaceTextWithExtras(textToProcess, regex, EXTRAS_DEFAULT, replacement);
                     if (shouldKeepRawInput) {
@@ -1283,7 +1283,7 @@ export default class ExpensiMark {
             isStartingWithSpace = !!g2;
             return '';
         };
-        const textToReplace = text.replace(/^&gt;( )?/gm, handleMatch);
+        const textToReplace = text.replace(/^(?:&gt;|>)( )?/gm, handleMatch);
         const filterRules = ['heading1'];
         // If we don't reach the max quote depth, we allow the recursive call to process other possible quotes
         if (this.currentQuoteDepth < this.maxQuoteDepth - 1 && !isStartingWithSpace) {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/64092

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Added some test cases to cover some case when we use `ExpensiMark.replace` with `shouldEscapeText` set to `false`

2. What tests did you perform that validates your changed worked?
In Expensify App:
- Go to workspace -> Members -> Invite member
- Select a user -> Next
- Enter the following text as invite message and confirm:
````
> This is a *quote* that started on a new line.
Here is a >quote that did not
```
here is a codefenced quote
>it should not be quoted

let js = 'javascript'
```
````
- Login with the invited user's email
- Go to workspace chat
- Verify the invite message is rendered correctly like below:

<img width="348" height="234" alt="Screenshot 2025-08-11 at 14 45 20" src="https://github.com/user-attachments/assets/b16e4fd6-9257-4b91-8f0d-79d9c9726413" />


# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
Same as tests