### PR TITLE
Fix short mention with single character followed by dot isn't recognized

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -1530,6 +1530,12 @@ describe('Tests for short mentions', () => {
         const resultString = '<mention-short>@john.doe</mention-short><mention-here>@here</mention-here>';
         expect(parser.replace(testString)).toBe(resultString);
     });
+
+    test('short mentions should work for single character followed by dot', () => {
+        const testString = '@j.doe';
+        const resultString = '<mention-short>@j.doe</mention-short>';
+        expect(parser.replace(testString)).toBe(resultString);
+    });
 });
 
 // Examples that should match for here mentions:

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -503,7 +503,7 @@ export default class ExpensiMark {
                 name: 'shortMentions',
 
                 regex: new RegExp(
-                    `${Constants.CONST.REG_EXP.PRE_MENTION_TEXT_PART}(@(?=((?=[\\w]+[\\w'#%+-]+(?:\\.[\\w'#%+-]+)*)[\\w\\.'#%+-]{1,64}(?= |_|\\b))(?!([:\\/\\\\]))(?<end>.*))(?!here)\\S{3,254}(?=\\k<end>$))(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>|<\\/mention-user>|<\\/mention-here>))`,
+                    `${Constants.CONST.REG_EXP.PRE_MENTION_TEXT_PART}(@(?=((?=[\\w]+[\\w'#%+-]*(?:\\.[\\w'#%+-]+)*)[\\w\\.'#%+-]{1,64}(?= |_|\\b))(?!([:\\/\\\\]))(?<end>.*))(?!here)\\S{3,254}(?=\\k<end>$))(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>|<\\/mention-user>|<\\/mention-here>))`,
                     'gim',
                 ),
                 replacement: (_extras, match, g1, g2) => {


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/69685

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
Added a new caes to the unit test
1. What tests did you perform that validates your changed worked?
Same as QA

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?

In Expensify App
Prerequisite: login with a private domain, create a WS, and invite a user with the same private domain
1. Open the WS chat chat
2. Send a short mention with a single character followed by dot (for example, @j.doe)
3. Verify the mention is recognized

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ac2ee51e-ace0-4d2a-822b-946895bae847


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f0b588bf-acf7-40c5-84e4-b6dae00baa4f


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/586bfa56-45f3-4d97-ab1b-0133901d2426


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/7bc161ce-6cdd-4acd-b5a8-e3387274f62f


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a7366aa9-9941-4af8-ac6e-e735bb09fe85


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/41a51cad-645c-4f73-bf69-c6e04a54c563


</details>
