### PR TITLE
[NO QA] Prevent parsing HTML or running expensive ops when there is an empty string

### DIFF
--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -991,7 +991,6 @@ export default class ExpensiMark {
     /**
      * Checks matched URLs for validity and replace valid links with html elements
      */
-    // TODO
     modifyTextForUrlLinks(regex: RegExp, textToCheck: string, replacement: ReplacementFn): string {
         let match = regex.exec(textToCheck);
         let replacedText = '';

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -1237,6 +1237,10 @@ export default class ExpensiMark {
      * Replaces HTML with markdown
      */
     htmlToMarkdown(htmlString: string, extras: Extras = EXTRAS_DEFAULT): string {
+        if (!htmlString) {
+            return '';
+        }
+
         let generatedMarkdown = htmlString;
         const body = /<(body)(?:"[^"]*"|'[^']*'|[^'"><])*>(?:\n|\r\n)?([\s\S]*?)(?:\n|\r\n)?<\/\1>(?![^<]*(<\/pre>|<\/code>))/im;
         const parseBodyTag = generatedMarkdown.match(body);

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -951,6 +951,10 @@ export default class ExpensiMark {
      * If not provided, all available rules will be applied. If provided, the rules in the array will be skipped.
      */
     replace(text: string, {filterRules = [], shouldEscapeText = true, shouldKeepRawInput = false, disabledRules = [], extras = EXTRAS_DEFAULT}: ReplaceOptions = {}): string {
+        if (!text) {
+            return '';
+        }
+
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? Utils.escapeText(text) : text;
         const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
@@ -987,6 +991,7 @@ export default class ExpensiMark {
     /**
      * Checks matched URLs for validity and replace valid links with html elements
      */
+    // TODO
     modifyTextForUrlLinks(regex: RegExp, textToCheck: string, replacement: ReplacementFn): string {
         let match = regex.exec(textToCheck);
         let replacedText = '';


### PR DESCRIPTION
Prevents expensive HTML parsing when we initially render the composer. Reduces the time to render this component from 10.8ms to 0.2ms (98% reduction)

**Before**
<img width="1911" height="954" alt="image" src="https://github.com/user-attachments/assets/01d84009-4f07-4a3d-961f-282378fcf871" />

**After**
<img width="1955" height="1028" alt="image" src="https://github.com/user-attachments/assets/49d52b71-9924-4ff1-a2c0-745723b44741" />

### Fixed Issues
$ https://github.com/Expensify/App/issues/77175

# Tests
N/A

# QA
N/A