### PR TITLE
[NO QA] Optimize Expensimark Replace

### DIFF
--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -46,7 +46,7 @@ type CommonRule = {
     rawInputReplacement?: Replacement;
     pre?: (input: string) => string;
     post?: (input: string) => string;
-    shouldSkip?: (textToCheck: string) => boolean;
+    shouldSkipProcessing?: (textToCheck: string) => boolean;
 };
 
 type RuleWithRegex = CommonRule & {
@@ -197,12 +197,6 @@ export default class ExpensiMark {
             {
                 name: 'video',
                 regex: MARKDOWN_VIDEO_REGEX,
-                shouldSkip: (textToCheck) => {
-                    const hasOpeningBracket = textToCheck.includes('![');
-                    const hasClosingBracket = textToCheck.includes('](');
-                    const hasVideoExtension = Constants.CONST.VIDEO_EXTENSIONS.some((extension) => textToCheck.includes(`.${extension}`));
-                    return !(hasOpeningBracket && hasClosingBracket && hasVideoExtension);
-                },
                 /**
                  * @param extras - The extras object
                  * @param videoName - The first capture group - video name
@@ -218,6 +212,12 @@ export default class ExpensiMark {
                     const attrCache = this.getAttributeCache(extras).attrCache;
                     const extraAttrs = attrCache && attrCache[videoSource];
                     return `<video data-expensify-source="${Str.sanitizeURL(videoSource)}" data-raw-href="${videoSource}" data-link-variant="${typeof videoName === 'string' ? 'labeled' : 'auto'}" ${extraAttrs || ''}>${videoName ? `${videoName}` : ''}</video>`;
+                },
+                shouldSkipProcessing: (textToCheck) => {
+                    const hasOpeningBracket = textToCheck.includes('![');
+                    const hasClosingBracket = textToCheck.includes('](');
+                    const hasVideoExtension = Constants.CONST.VIDEO_EXTENSIONS.some((extension) => textToCheck.includes(`.${extension}`));
+                    return !(hasOpeningBracket && hasClosingBracket && hasVideoExtension);
                 },
             },
 
@@ -304,6 +304,11 @@ export default class ExpensiMark {
                     const attrCache = this.getAttributeCache(extras).attrCache;
                     const extraAttrs = attrCache && attrCache[imgSource];
                     return `<img src="${Str.sanitizeURL(imgSource)}"${imgAlt ? ` alt="${this.escapeAttributeContent(imgAlt)}"` : ''} data-raw-href="${imgSource}" data-link-variant="${typeof imgAlt === 'string' ? 'labeled' : 'auto'}" ${extraAttrs || ''}/>`;
+                },
+                shouldSkipProcessing: (textToCheck) => {
+                    const hasOpeningBracket = textToCheck.includes('![');
+                    const hasClosingBracket = textToCheck.includes('](');
+                    return !(hasOpeningBracket && hasClosingBracket);
                 },
             },
 
@@ -974,7 +979,7 @@ export default class ExpensiMark {
                 replacedText = rule.pre(replacedText);
             }
 
-            if (rule.shouldSkip && rule.shouldSkip(replacedText)) {
+            if (rule.shouldSkipProcessing && rule.shouldSkipProcessing(replacedText)) {
                 return;
             }
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -332,6 +332,9 @@ export default class ExpensiMark {
                     }
                     return `<a href="${Str.sanitizeURL(g2)}" data-raw-href="${g2}" data-link-variant="labeled" target="_blank" rel="noreferrer noopener">${g1}</a>`;
                 },
+                shouldSkipProcessing: (textToCheck) => {
+                    return !textToCheck.includes('.') || !textToCheck.includes('://');
+                },
             },
 
             /**
@@ -360,7 +363,6 @@ export default class ExpensiMark {
              */
             {
                 name: 'reportMentions',
-
                 regex: /(?<=^[*~_:]?|[ \n][*~_:]?|[:#])(#[\p{Ll}0-9-]{1,99})(?![^<]*(?:<\/pre>|<\/code>|<\/a>))/gimu,
                 replacement: '<mention-report>$1</mention-report>',
             },
@@ -426,6 +428,9 @@ export default class ExpensiMark {
                 rawInputReplacement: (_extras, _match, g1, g2) => {
                     const href = Str.sanitizeURL(g2);
                     return `${g1}<a href="${href}" data-raw-href="${g2}" data-link-variant="auto" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
+                },
+                shouldSkipProcessing: (textToCheck) => {
+                    return !textToCheck.includes('.') || !textToCheck.includes('://');
                 },
             },
 
@@ -997,7 +1002,7 @@ export default class ExpensiMark {
 
             const endTime = performance.now();
             const timeTaken = endTime - startTime;
-            if (timeTaken > 5) {
+            if (timeTaken > 0.5) {
                 console.info(`[ExpensiMark] Time taken to apply rule "${rule.name}": ${timeTaken} ms`);
             }
         };
@@ -1018,10 +1023,6 @@ export default class ExpensiMark {
      * Checks matched URLs for validity and replace valid links with html elements
      */
     modifyTextForUrlLinks(regex: RegExp, textToCheck: string, replacement: ReplacementFn): string {
-        if (!textToCheck.includes('.') && !textToCheck.includes('://')) {
-            return textToCheck;
-        }
-
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -972,14 +972,6 @@ export default class ExpensiMark {
         const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
 
         const processRule = (rule: Rule) => {
-            const startTime = performance.now();
-
-            // Pre-process text before applying regex
-            // PRE and POST Arent making it slow
-            // video: 6.8 - Uses regex
-            // link: 8.1 - uses process
-            // image: 6.3 - uses regex
-            // autolink: 8.1 - uses process
             if (rule.pre) {
                 replacedText = rule.pre(replacedText);
             }
@@ -999,14 +991,7 @@ export default class ExpensiMark {
             if (rule.post) {
                 replacedText = rule.post(replacedText);
             }
-
-            const endTime = performance.now();
-            const timeTaken = endTime - startTime;
-            if (timeTaken > 0.5) {
-                console.info(`[ExpensiMark] Time taken to apply rule "${rule.name}": ${timeTaken} ms`);
-            }
         };
-
         try {
             rules.forEach(processRule);
         } catch (e) {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -197,6 +197,12 @@ export default class ExpensiMark {
             {
                 name: 'video',
                 regex: MARKDOWN_VIDEO_REGEX,
+                shouldSkip: (textToCheck) => {
+                    const hasOpeningBracket = textToCheck.includes('![');
+                    const hasClosingBracket = textToCheck.includes('](');
+                    const hasVideoExtension = Constants.CONST.VIDEO_EXTENSIONS.some((extension) => textToCheck.includes(`.${extension}`));
+                    return !(hasOpeningBracket && hasClosingBracket && hasVideoExtension);
+                },
                 /**
                  * @param extras - The extras object
                  * @param videoName - The first capture group - video name

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -969,6 +969,7 @@ export default class ExpensiMark {
         const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
 
         const processRule = (rule: Rule) => {
+            // Pre-process text before applying regex
             if (rule.pre) {
                 replacedText = rule.pre(replacedText);
             }

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -960,15 +960,17 @@ export default class ExpensiMark {
 
             // Pre-process text before applying regex
             // PRE and POST Arent making it slow
+            // video: 6.8 - Uses regex
+            // link: 8.1 - uses process
+            // image: 6.3 - uses regex
+            // autolink: 8.1 - uses process
             if (rule.pre) {
                 replacedText = rule.pre(replacedText);
             }
             const replacement = shouldKeepRawInput && rule.rawInputReplacement ? rule.rawInputReplacement : rule.replacement;
             if ('process' in rule) {
-                console.log('Using process function for rule: ', rule.name);
                 replacedText = rule.process(replacedText, replacement, shouldKeepRawInput);
             } else {
-                console.log('Using regex replacement for rule: ', rule.name);
                 replacedText = this.replaceTextWithExtras(replacedText, rule.regex, extras, replacement);
             }
 
@@ -979,7 +981,9 @@ export default class ExpensiMark {
 
             const endTime = performance.now();
             const timeTaken = endTime - startTime;
-            console.info(`[ExpensiMark] Time taken to apply rule "${rule.name}": ${timeTaken} ms`);
+            if (timeTaken > 5) {
+                console.info(`[ExpensiMark] Time taken to apply rule "${rule.name}": ${timeTaken} ms`);
+            }
         };
 
         try {
@@ -991,11 +995,6 @@ export default class ExpensiMark {
             return shouldEscapeText ? Utils.escapeText(text) : text;
         }
 
-        // video: 6.8 - Uses regex
-        // link: 8.1 - uses process
-        // image: 6.3 - uses regex
-        // autolink: 8.1 - uses process
-
         return replacedText;
     }
 
@@ -1003,6 +1002,10 @@ export default class ExpensiMark {
      * Checks matched URLs for validity and replace valid links with html elements
      */
     modifyTextForUrlLinks(regex: RegExp, textToCheck: string, replacement: ReplacementFn): string {
+        if (!textToCheck.includes('.') && !textToCheck.includes('://')) {
+            return textToCheck;
+        }
+
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -955,7 +955,11 @@ export default class ExpensiMark {
         let replacedText = shouldEscapeText ? Utils.escapeText(text) : text;
         const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
 
+        const endTime1 = performance.now();
+
         const processRule = (rule: Rule) => {
+            const startTime = performance.now();
+
             // Pre-process text before applying regex
             if (rule.pre) {
                 replacedText = rule.pre(replacedText);
@@ -971,7 +975,12 @@ export default class ExpensiMark {
             if (rule.post) {
                 replacedText = rule.post(replacedText);
             }
+
+            const endTime = performance.now();
+            const timeTaken = endTime - startTime;
+            console.info(`[ExpensiMark] Time taken to apply rule "${rule.name}": ${timeTaken} ms`);
         };
+
         try {
             rules.forEach(processRule);
         } catch (e) {
@@ -980,6 +989,11 @@ export default class ExpensiMark {
             // We want to return text without applying rules if exception occurs during replacing
             return shouldEscapeText ? Utils.escapeText(text) : text;
         }
+
+        // video: 6.8
+        // link: 8.1
+        // image: 6.3
+        // autolink: 8.1
 
         return replacedText;
     }

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -955,19 +955,20 @@ export default class ExpensiMark {
         let replacedText = shouldEscapeText ? Utils.escapeText(text) : text;
         const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
 
-        const endTime1 = performance.now();
-
         const processRule = (rule: Rule) => {
             const startTime = performance.now();
 
             // Pre-process text before applying regex
+            // PRE and POST Arent making it slow
             if (rule.pre) {
                 replacedText = rule.pre(replacedText);
             }
             const replacement = shouldKeepRawInput && rule.rawInputReplacement ? rule.rawInputReplacement : rule.replacement;
             if ('process' in rule) {
+                console.log('Using process function for rule: ', rule.name);
                 replacedText = rule.process(replacedText, replacement, shouldKeepRawInput);
             } else {
+                console.log('Using regex replacement for rule: ', rule.name);
                 replacedText = this.replaceTextWithExtras(replacedText, rule.regex, extras, replacement);
             }
 
@@ -990,10 +991,10 @@ export default class ExpensiMark {
             return shouldEscapeText ? Utils.escapeText(text) : text;
         }
 
-        // video: 6.8
-        // link: 8.1
-        // image: 6.3
-        // autolink: 8.1
+        // video: 6.8 - Uses regex
+        // link: 8.1 - uses process
+        // image: 6.3 - uses regex
+        // autolink: 8.1 - uses process
 
         return replacedText;
     }

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -46,6 +46,7 @@ type CommonRule = {
     rawInputReplacement?: Replacement;
     pre?: (input: string) => string;
     post?: (input: string) => string;
+    shouldSkip?: (textToCheck: string) => boolean;
 };
 
 type RuleWithRegex = CommonRule & {
@@ -75,7 +76,6 @@ type TruncateOptions = {
 
 const MARKDOWN_LINK_REGEX = new RegExp(`\\[((?:[^\\[\\]\\r\\n]*(?:\\[[^\\[\\]\\r\\n]*][^\\[\\]\\r\\n]*)*))]\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
 const MARKDOWN_IMAGE_REGEX = new RegExp(`\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(${UrlPatterns.MARKDOWN_URL_REGEX}\\)(?![^<]*(<\\/pre>|<\\/code>))`, 'gi');
-
 const MARKDOWN_VIDEO_REGEX = new RegExp(
     `\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(((${UrlPatterns.MARKDOWN_URL_REGEX})\\.(?:${Constants.CONST.VIDEO_EXTENSIONS.join('|')}))\\)(?![^<]*(<\\/pre>|<\\/code>))`,
     'gi',
@@ -967,6 +967,11 @@ export default class ExpensiMark {
             if (rule.pre) {
                 replacedText = rule.pre(replacedText);
             }
+
+            if (rule.shouldSkip && rule.shouldSkip(replacedText)) {
+                return;
+            }
+
             const replacement = shouldKeepRawInput && rule.rawInputReplacement ? rule.rawInputReplacement : rule.replacement;
             if ('process' in rule) {
                 replacedText = rule.process(replacedText, replacement, shouldKeepRawInput);

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -214,10 +214,9 @@ export default class ExpensiMark {
                     return `<video data-expensify-source="${Str.sanitizeURL(videoSource)}" data-raw-href="${videoSource}" data-link-variant="${typeof videoName === 'string' ? 'labeled' : 'auto'}" ${extraAttrs || ''}>${videoName ? `${videoName}` : ''}</video>`;
                 },
                 shouldSkipProcessing: (textToCheck) => {
-                    const hasOpeningBracket = textToCheck.includes('![');
-                    const hasClosingBracket = textToCheck.includes('](');
-                    const hasVideoExtension = Constants.CONST.VIDEO_EXTENSIONS.some((extension) => textToCheck.includes(`.${extension}`));
-                    return !(hasOpeningBracket && hasClosingBracket && hasVideoExtension);
+                    const missingSpecialCharacters = !textToCheck.includes('!') || !textToCheck.includes('(') || !textToCheck.includes(')');
+                    const missingVideoExtension = !Constants.CONST.VIDEO_EXTENSIONS.some((extension) => textToCheck.includes(`.${extension}`));
+                    return missingSpecialCharacters || missingVideoExtension;
                 },
             },
 
@@ -306,9 +305,7 @@ export default class ExpensiMark {
                     return `<img src="${Str.sanitizeURL(imgSource)}"${imgAlt ? ` alt="${this.escapeAttributeContent(imgAlt)}"` : ''} data-raw-href="${imgSource}" data-link-variant="${typeof imgAlt === 'string' ? 'labeled' : 'auto'}" ${extraAttrs || ''}/>`;
                 },
                 shouldSkipProcessing: (textToCheck) => {
-                    const hasOpeningBracket = textToCheck.includes('![');
-                    const hasClosingBracket = textToCheck.includes('](');
-                    return !(hasOpeningBracket && hasClosingBracket);
+                    return !textToCheck.includes('!') || !textToCheck.includes('(') || !textToCheck.includes(')');
                 },
             },
 
@@ -333,7 +330,7 @@ export default class ExpensiMark {
                     return `<a href="${Str.sanitizeURL(g2)}" data-raw-href="${g2}" data-link-variant="labeled" target="_blank" rel="noreferrer noopener">${g1}</a>`;
                 },
                 shouldSkipProcessing: (textToCheck) => {
-                    return !textToCheck.includes('.') || !textToCheck.includes('://');
+                    return !textToCheck.includes('.');
                 },
             },
 
@@ -430,7 +427,7 @@ export default class ExpensiMark {
                     return `${g1}<a href="${href}" data-raw-href="${g2}" data-link-variant="auto" target="_blank" rel="noreferrer noopener">${g2}</a>${g1}`;
                 },
                 shouldSkipProcessing: (textToCheck) => {
-                    return !textToCheck.includes('.') || !textToCheck.includes('://');
+                    return !textToCheck.includes('.');
                 },
             },
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
+import ExpensiMark from './ExpensiMark';
+
 // eslint-disable-next-line rulesdir/no-api-in-views
 export {default as API} from './API';
 export {default as APIDeferred} from './APIDeferred';
@@ -20,3 +22,7 @@ export {default as fastMerge} from './fastMerge';
 export {default as Str} from './str';
 export {default as TLD_REGEX} from './tlds';
 export {default as md5} from './md5';
+
+const expensimark = new ExpensiMark();
+
+expensimark.replace('<h1>Hello world</h1>');

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,3 @@
-import ExpensiMark from './ExpensiMark';
-
 // eslint-disable-next-line rulesdir/no-api-in-views
 export {default as API} from './API';
 export {default as APIDeferred} from './APIDeferred';
@@ -22,7 +20,3 @@ export {default as fastMerge} from './fastMerge';
 export {default as Str} from './str';
 export {default as TLD_REGEX} from './tlds';
 export {default as md5} from './md5';
-
-const expensimark = new ExpensiMark();
-
-expensimark.replace('<h1>Hello world</h1>');


### PR DESCRIPTION
Adds the ability to add pre-check validation to expensimark rules, before using expensive regexes. 
Previously, the following rules took:
**Link**: 8ms
**Autolink**: 8ms
**Image**: 6ms
**Video**: 7ms
to parse/replace. We use parser.replace all over e/app, and most elements don't need to have these expensive regexes used on them. To remedy this, we've added the ability to prevent rules from attempting to replace content. This reduces the time for each rule down to 0.01ms.

Below are the results from a full parsing of `<h1>Hello world</h1>`

**Before**
```
jacksenyitko@Mac expensify-common % npx tsx lib/index.ts
ExpensiMark replaced in 31.58775 milliseconds
```

**After**
```
jacksenyitko@Mac expensify-common % npx tsx lib/index.ts
ExpensiMark replaced in 1.8977920000000381 milliseconds
```

This is a `94% reduction` for most cases

### Fixed Issues
$ https://github.com/Expensify/App/issues/77175

# Tests
N/A

# QA
N/A