### PR TITLE
Fix Network.post() silently dropping falsy-but-defined params from FormData

### DIFF
--- a/lib/Network.jsx
+++ b/lib/Network.jsx
@@ -87,7 +87,7 @@ export default function Network(endpoint) {
             // If it does, we should use formData instead of parameters and update
             // the ajax settings accordingly
             Object.entries(parameters).forEach(([key, value]) => {
-                if (!value) {
+                if (value === undefined) {
                     return;
                 }
 


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

Fix Network.post() silently dropping falsy-but-defined values from FormData.

The check `if (!value)` is a falsy guard — it drops false, 0, '', null, and undefined. For multipart requests (those containing a File or Blob), this meant parameters like `csrfToken` could be silently omitted from the FormData body if their value was falsy.

The `keepalive()` method in the same file already uses the correct guard `if (value === undefined)`. This aligns `post()` to match.

**History:** This fix was originally made in 2020 (commit 832cd5a) and then reverted 10 minutes later in the same PR (#262) as "an unnecessary change" with no further explanation. The revert left `keepalive()` with the correct `undefined` check while `post()` regressed back to the falsy check.

**Behavioral change for callers:** Boolean `false`, `null`, `0`, and `''` values were previously dropped from FormData silently. After this fix they are included and serialized by FormData (false → 'false', null → 'null', etc.). Audited Web-Expensify callers of file upload commands — the affected falsy values are boolean `false` (e.g. `shouldSkipSmartScan`, `isManualRequestScan`) and `undefined`. PHP's `Str::toBool()` (used by `Request::getBool`) calls `filter_var($input, FILTER_VALIDATE_BOOLEAN)` which correctly maps the string `"false"` → `false`, so behavior is unchanged.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/535855

# Tests
1. No existing automated test coverage for the FormData construction path.
2. Verified by code trace: `post()` only uses FormData as `settings.data` when a `File` or `Blob` is present in parameters (i.e., receipt/attachment upload commands). Regular API calls are unaffected — they use `settings.data = parameters` (the plain object).

# QA

**Regression — receipt upload still works end-to-end:**
1. Log in to OldDot (expensify.com)
2. Open DevTools → Network tab, filter by `Expense_Create`
3. Go to the Expenses page and click the SmartScan / upload receipt button
4. Upload any image file (jpg, png)
5. In the Network tab, find the `Expense_Create` POST request
6. Click the request → Payload tab → view the multipart form data body
7. Confirm `csrfToken` is present with a non-empty value
8. Confirm `isManualRequestScan` is present with value `"false"` (previously this was dropped; now it is sent as the string `"false"`, which PHP correctly interprets as `false`)
9. Confirm the receipt upload succeeds and the expense appears in the list

**Regression — non-file API calls unaffected:**
1. With DevTools open, perform any regular (non-file) API action (e.g., submit a report)
2. Confirm the request does not use multipart/form-data (it should be `application/x-www-form-urlencoded` or JSON)
3. Confirm the action succeeds normally