### PR TITLE
feat: support VictoryChart

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2505,8 +2505,8 @@ describe('room mentions', () => {
 });
 
 // VirtualCFO charts are embedded directly into reportAction.message.html as <VictoryChart> blocks.
-// The chart fragment (and its inner Victory* tags) must survive both htmlToMarkdown and the
-// markdown-to-html replace step so editing/round-tripping doesn't strip or escape the markup.
+// The chart fragment (and its inner Victory* tags) must survive htmlToMarkdown and the trusted-input
+// path of the markdown-to-html replace step so round-tripping doesn't strip or escape the markup.
 describe('VictoryChart round-trip', () => {
     const chart =
         '<VictoryChart domainPadding="20">' +
@@ -2518,14 +2518,15 @@ describe('VictoryChart round-trip', () => {
         expect(parser.htmlToMarkdown(chart)).toBe(chart);
     });
 
-    test('markdown-to-html (replace) preserves the <VictoryChart> fragment verbatim', () => {
-        // The chart text is what htmlToMarkdown produces, so feed it through replace as user-visible markdown.
-        expect(parser.replace(chart)).toBe(chart);
+    test('markdown-to-html (replace) preserves the <VictoryChart> fragment for trusted input', () => {
+        // Charts only ever originate from trusted server HTML, so replace is called with
+        // shouldEscapeText: false. See the XSS test below for the user-typed (untrusted) path.
+        expect(parser.replace(chart, {shouldEscapeText: false})).toBe(chart);
     });
 
     test('full round-trip htmlToMarkdown -> replace yields the original fragment', () => {
         const md = parser.htmlToMarkdown(chart);
-        expect(parser.replace(md)).toBe(chart);
+        expect(parser.replace(md, {shouldEscapeText: false})).toBe(chart);
     });
 
     test('round-trip preserves chart when wrapped in surrounding narrative text', () => {
@@ -2539,12 +2540,12 @@ describe('VictoryChart round-trip', () => {
     test('round-trip handles lowercase tag names (react-native-render-html internal form)', () => {
         const lowercaseChart = '<victorychart><victorybar data="[{x: 1, y: 2}]" /></victorychart>';
         expect(parser.htmlToMarkdown(lowercaseChart)).toBe(lowercaseChart);
-        expect(parser.replace(lowercaseChart)).toBe(lowercaseChart);
+        expect(parser.replace(lowercaseChart, {shouldEscapeText: false})).toBe(lowercaseChart);
     });
 
     test('self-closing <VictoryChart /> survives round-trip', () => {
         expect(parser.htmlToMarkdown('<VictoryChart />')).toBe('<VictoryChart />');
-        expect(parser.replace('<VictoryChart />')).toBe('<VictoryChart />');
+        expect(parser.replace('<VictoryChart />', {shouldEscapeText: false})).toBe('<VictoryChart />');
     });
 
     test('every inner Victory tag is preserved when nested in <VictoryChart>', () => {
@@ -2560,16 +2561,36 @@ describe('VictoryChart round-trip', () => {
             '<VictoryTooltip />' +
             '</VictoryChart>';
         expect(parser.htmlToMarkdown(full)).toBe(full);
-        expect(parser.replace(full)).toBe(full);
+        expect(parser.replace(full, {shouldEscapeText: false})).toBe(full);
     });
 
-    test('replace still escapes unrelated user-typed HTML (passthrough is opt-in)', () => {
+    test('nested same-name tags (<VictoryGroup>) inside the chart survive intact', () => {
+        const nested = '<VictoryChart>' + '<VictoryGroup offset="20"><VictoryGroup><VictoryBar data="[]" /></VictoryGroup></VictoryGroup>' + '</VictoryChart>';
+        expect(parser.htmlToMarkdown(nested)).toBe(nested);
+        expect(parser.replace(nested, {shouldEscapeText: false})).toBe(nested);
+    });
+
+    test('multiple charts in one message each survive the round-trip', () => {
+        const input = `${chart} divider ${chart}`;
+        expect(parser.htmlToMarkdown(input)).toBe(input);
+    });
+
+    test('user-typed chart markup is escaped, not passed through (XSS guard)', () => {
+        // shouldEscapeText defaults to true: untrusted input must not bypass escaping via a chart tag.
+        const malicious = '<VictoryChart><img src=x onerror="alert(1)"></VictoryChart>';
+        const result = parser.replace(malicious);
+        expect(result).not.toContain('<img');
+        expect(result).not.toContain('<VictoryChart>');
+        expect(result).toContain('&lt;VictoryChart&gt;');
+    });
+
+    test('replace still escapes unrelated user-typed HTML', () => {
         expect(parser.replace('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
     });
 
-    test('markdown rules around a chart still apply', () => {
+    test('markdown rules around a chart still apply (trusted input)', () => {
         const input = `*bold* ${chart} _italic_`;
-        expect(parser.replace(input)).toBe(`<strong>bold</strong> ${chart} <em>italic</em>`);
+        expect(parser.replace(input, {shouldEscapeText: false})).toBe(`<strong>bold</strong> ${chart} <em>italic</em>`);
     });
 
     test('htmlToText emits [chart] for <VictoryChart> (notification fallback per R1.2)', () => {
@@ -2577,9 +2598,16 @@ describe('VictoryChart round-trip', () => {
         expect(parser.htmlToText('<VictoryChart />')).toBe('[chart]');
     });
 
-    test('stray placeholder-looking text in user input is not mistakenly restored', () => {
-        const text = 'reference EXMK_PT_0 in body';
-        expect(parser.htmlToMarkdown(text)).toBe('reference EXMK_PT_0 in body');
-        expect(parser.replace(text)).toBe('reference EXMK_PT_0 in body');
+    test('narrative text adjacent to a chart is never corrupted by placeholder restoration', () => {
+        // The internal placeholder is NUL-sentinel wrapped, so no string a user can type collides with it.
+        const input = `prior text ${chart} trailing text`;
+        const md = parser.htmlToMarkdown(input);
+        expect(md).toBe(input);
+    });
+
+    const html = `<victorychart domain="{x: [0.5, 12.5], y: [0, 2000]}" domainpadding="{x: 18, y: 0}" height="430" width="680" padding="{top: 126, bottom: 108, left: 96, right: 32}" style="{parent: { backgroundColor: '#F7F2EF', borderRadius: 16, width: '100%', maxWidth: 680}}"><victorylabel x="32" y="40" text='Monthly spend' style="{ fill: '#002E22', fontSize: 17, fontWeight: 700, fontFamily: 'Expensify Neue', }"/><victorylabel x="32" y="62" text='As of: May 6, 12:49 PM PT' style="{ fill: '#73857E', fontSize: 11, fontWeight: 400, fontFamily: 'Expensify Neue', }"/><victorybar barwidth="11" cornerradius="{top: 6, bottom: 6}" style="{data: {fill: '#1E90F2'}}" data="[ {x: 1.13, y: 1080}, {x: 2.13, y: 1225}, {x: 3.13, y: 1375}, {x: 4.13, y: 1600}, {x: 5.13, y: 1630}, {x: 6.13, y: 1725}, {x: 7.13, y: 1400}, {x: 8.13, y: 1685}, {x: 9.13, y: 1725}, {x: 10.13, y: 1800}, {x: 11.13, y: 1800}, {x: 12.13, y: 1800}, ]" labels="[ 'Jan 2025: $1,080', 'Feb 2025: $1,225', 'Mar 2025: $1,375', 'Apr 2025: $1,600', 'May 2025: $1,630', 'Jun 2025: $1,725', 'Jul 2025: $1,400', 'Aug 2025: $1,685', 'Sep 2025: $1,725', 'Oct 2025: $1,800', 'Nov 2025: $1,800', 'Dec 2025: $1,800', ]"/><victorybar barwidth="11" cornerradius="{top: 6, bottom: 6}" style="{data: {fill: '#13C96B'}}" data="[ {x: 0.87, y: 1200}, {x: 1.87, y: 1320}, {x: 2.87, y: 1570}, ]" labels="['Jan 2026: $1,200', 'Feb 2026: $1,320', 'Mar 2026: $1,570']"/><victorybar barwidth="11" cornerradius="{top: 6, bottom: 6}" style="{data: {fill: '#FF6A00'}}" data="[{x: 3.87, y: 1820}]" labels="['Apr 2026: $1,820']"/><victoryaxis tickvalues="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]" tickformat="['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']" style="{ axis: {stroke: '#E6E1DA', strokeWidth: 1}, ticks: {stroke: 'transparent'}, tickLabels: { fill: '#73857E', fontSize: 11, fontWeight: 500, fontFamily: 'Expensify Neue', padding: 16, }, }"/><victoryaxis dependentaxis tickvalues="[0, 500, 1000, 1500, 2000]" tickformat="['$0', '$500', '$1,000', '$1,500', '$2,000']" style="{ axis: {stroke: 'transparent'}, ticks: {stroke: 'transparent'}, grid: {stroke: '#E6E1DA', strokeWidth: 1}, tickLabels: { fill: '#73857E', fontSize: 11, fontWeight: 500, fontFamily: 'Expensify Neue', padding: 28, }, }"/><victorylegend x="150" y="378" orientation="horizontal" gutter="34" symbolspacer="10" style="{ labels: { fill: '#002E22', fontSize: 13, fontWeight: 500, fontFamily: 'Expensify Neue', }, }" data="[ {name: '2026 spend', symbol: {type: 'circle', fill: '#13C96B', size: 6}}, {name: '2025 spend', symbol: {type: 'circle', fill: '#1E90F2', size: 6}}, {name: 'Last month', symbol: {type: 'circle', fill: '#FF6A00', size: 6}}, ]"/></victorychart>`;
+    test('complex real-world chart example round-trips intact', () => {
+        expect(parser.htmlToMarkdown(html)).toBe(html);
+        expect(parser.replace(html, {shouldEscapeText: false})).toBe(html);
     });
 });

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2503,3 +2503,83 @@ describe('room mentions', () => {
         expect(parser.replace(testString)).toBe(resultString);
     });
 });
+
+// VirtualCFO charts are embedded directly into reportAction.message.html as <VictoryChart> blocks.
+// The chart fragment (and its inner Victory* tags) must survive both htmlToMarkdown and the
+// markdown-to-html replace step so editing/round-tripping doesn't strip or escape the markup.
+describe('VictoryChart round-trip', () => {
+    const chart =
+        '<VictoryChart domainPadding="20">' +
+        "\n  <VictoryBar data=\"[ {x: 'Jan', y: 3}, {x: 'Feb', y: 5}, {x: 'Mar', y: 2}, {x: 'Apr', y: 7} ]\" />" +
+        "\n  <VictoryLine data=\"[ {x: 'Jan', y: 1}, {x: 'Feb', y: 7}, {x: 'Mar', y: 3}, {x: 'Apr', y: 5} ]\" />" +
+        '\n</VictoryChart>';
+
+    test('htmlToMarkdown preserves the <VictoryChart> fragment verbatim', () => {
+        expect(parser.htmlToMarkdown(chart)).toBe(chart);
+    });
+
+    test('markdown-to-html (replace) preserves the <VictoryChart> fragment verbatim', () => {
+        // The chart text is what htmlToMarkdown produces, so feed it through replace as user-visible markdown.
+        expect(parser.replace(chart)).toBe(chart);
+    });
+
+    test('full round-trip htmlToMarkdown -> replace yields the original fragment', () => {
+        const md = parser.htmlToMarkdown(chart);
+        expect(parser.replace(md)).toBe(chart);
+    });
+
+    test('round-trip preserves chart when wrapped in surrounding narrative text', () => {
+        const input = `Here's the spend trend: ${chart} See breakdown below.`;
+        const md = parser.htmlToMarkdown(input);
+        expect(md).toContain(chart);
+        expect(md).toContain("Here's the spend trend:");
+        expect(md).toContain('See breakdown below.');
+    });
+
+    test('round-trip handles lowercase tag names (react-native-render-html internal form)', () => {
+        const lowercaseChart = '<victorychart><victorybar data="[{x: 1, y: 2}]" /></victorychart>';
+        expect(parser.htmlToMarkdown(lowercaseChart)).toBe(lowercaseChart);
+        expect(parser.replace(lowercaseChart)).toBe(lowercaseChart);
+    });
+
+    test('self-closing <VictoryChart /> survives round-trip', () => {
+        expect(parser.htmlToMarkdown('<VictoryChart />')).toBe('<VictoryChart />');
+        expect(parser.replace('<VictoryChart />')).toBe('<VictoryChart />');
+    });
+
+    test('every inner Victory tag is preserved when nested in <VictoryChart>', () => {
+        const full =
+            '<VictoryChart>' +
+            '<VictoryLabel text="Monthly spend" />' +
+            '<VictoryAxis tickValues="[1, 2, 3]" />' +
+            '<VictoryBar data="[{x: 1, y: 10}]" />' +
+            '<VictoryLine data="[{x: 1, y: 5}]" />' +
+            '<VictoryPie data="[{x: \'a\', y: 1}]" />' +
+            '<VictoryLegend data="[{name: \'a\'}]" />' +
+            '<VictoryGroup horizontal="true" offset="18"><VictoryBar data="[]" /></VictoryGroup>' +
+            '<VictoryTooltip />' +
+            '</VictoryChart>';
+        expect(parser.htmlToMarkdown(full)).toBe(full);
+        expect(parser.replace(full)).toBe(full);
+    });
+
+    test('replace still escapes unrelated user-typed HTML (passthrough is opt-in)', () => {
+        expect(parser.replace('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
+    test('markdown rules around a chart still apply', () => {
+        const input = `*bold* ${chart} _italic_`;
+        expect(parser.replace(input)).toBe(`<strong>bold</strong> ${chart} <em>italic</em>`);
+    });
+
+    test('htmlToText emits [chart] for <VictoryChart> (notification fallback per R1.2)', () => {
+        expect(parser.htmlToText(chart)).toBe('[chart]');
+        expect(parser.htmlToText('<VictoryChart />')).toBe('[chart]');
+    });
+
+    test('stray placeholder-looking text in user input is not mistakenly restored', () => {
+        const text = 'reference EXMK_PT_0 in body';
+        expect(parser.htmlToMarkdown(text)).toBe('reference EXMK_PT_0 in body');
+        expect(parser.replace(text)).toBe('reference EXMK_PT_0 in body');
+    });
+});

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -2504,9 +2504,7 @@ describe('room mentions', () => {
     });
 });
 
-// VirtualCFO charts are embedded directly into reportAction.message.html as <VictoryChart> blocks.
-// The chart fragment (and its inner Victory* tags) must survive htmlToMarkdown and the trusted-input
-// path of the markdown-to-html replace step so round-tripping doesn't strip or escape the markup.
+// VirtualCFO charts must preserve their VictoryChart markup during HTML/markdown conversion.
 describe('VictoryChart round-trip', () => {
     const chart =
         '<VictoryChart domainPadding="20">' +

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -1038,7 +1038,7 @@ export default class ExpensiMark {
             return shouldEscapeText ? Utils.escapeText(text) : text;
         }
 
-        return this.restoreVictoryChartTags(replacedText, passthroughTags);
+        return this.restoreVictoryChartTags(replacedText, victoryChartTags);
     }
 
     /**
@@ -1304,7 +1304,7 @@ export default class ExpensiMark {
         generatedMarkdown = this.unpackNestedQuotes(generatedMarkdown);
 
         // Extract VictoryChart blocks before HTML stripping, then restore them.
-        const {text: textWithPlaceholders, tags: passthroughTags} = this.extractVictoryChartTags(generatedMarkdown);
+        const {text: textWithPlaceholders, tags: victoryChartTags} = this.extractVictoryChartTags(generatedMarkdown);
         generatedMarkdown = textWithPlaceholders;
 
         const processRule = (rule: RuleWithRegex) => {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -83,7 +83,36 @@ const MARKDOWN_VIDEO_REGEX = new RegExp(
 
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
+// VictoryChart and its inner tags are preserved verbatim through `replace` and `htmlToMarkdown`
+// so that server-rendered VirtualCFO charts in `reportAction.message.html` round-trip without
+// their inner markup being escaped or stripped. The outer <VictoryChart>...</VictoryChart> match
+// also protects every nested child (VictoryBar/Line/Pie/Axis/Label/Legend/Tooltip/Group) as part
+// of the captured block; the alternation handles the rare case of a stray child tag at top level.
+// Case-insensitive matching covers both the PascalCase emitted by the server (<VictoryChart>)
+// and the lowercase form react-native-render-html uses internally (<victorychart>).
+const VICTORY_TAG_NAMES = 'VictoryChart|VictoryBar|VictoryLine|VictoryPie|VictoryAxis|VictoryLabel|VictoryLegend|VictoryTooltip|VictoryGroup';
+const PASSTHROUGH_TAGS_REGEX = new RegExp(`<(?:${VICTORY_TAG_NAMES})\\b[^>]*/>|<(${VICTORY_TAG_NAMES})\\b[^>]*>[\\s\\S]*?<\\/\\1>`, 'gi');
+const PASSTHROUGH_PLACEHOLDER_REGEX = /EXMK_PT_(\d+)/g;
+const buildPassthroughPlaceholder = (index: number): string => `EXMK_PT_${index}`;
+
 export default class ExpensiMark {
+    extractPassthroughTags = (text: string): {text: string; tags: string[]} => {
+        const tags: string[] = [];
+        const out = text.replace(PASSTHROUGH_TAGS_REGEX, (match) => {
+            const placeholder = buildPassthroughPlaceholder(tags.length);
+            tags.push(match);
+            return placeholder;
+        });
+        return {text: out, tags};
+    };
+
+    restorePassthroughTags = (text: string, tags: string[]): string => {
+        if (tags.length === 0) {
+            return text;
+        }
+        return text.replace(PASSTHROUGH_PLACEHOLDER_REGEX, (match, idx) => tags[Number(idx)] ?? match);
+    };
+
     getAttributeCache = (extras?: Extras) => {
         if (!extras) {
             return {attrCachingFn: undefined, attrCache: undefined};
@@ -862,6 +891,11 @@ export default class ExpensiMark {
                 replacement: '[Attachment]',
             },
             {
+                name: 'victoryChart',
+                regex: /<VictoryChart\b[^>]*\/>|<VictoryChart\b[^>]*>[\s\S]*?<\/VictoryChart>/gi,
+                replacement: '[chart]',
+            },
+            {
                 name: 'otherAttachments',
                 regex: /<a[^><]*data-expensify-source\s*=\s*(['"])(\S*?)\1(.*?)>([^><]*)<\/a>*(?![^<][\s\S]*?(<\/pre>|<\/code>))/gi,
                 replacement: '[Attachment]',
@@ -968,8 +1002,12 @@ export default class ExpensiMark {
             return '';
         }
 
+        // Lift out <VictoryChart> blocks before processing so neither escaping nor markdown rules
+        // disturb their inner markup (JSON in attributes, special chars, etc.). Restored at the end.
+        const {text: textWithPlaceholders, tags: passthroughTags} = this.extractPassthroughTags(text);
+
         // This ensures that any html the user puts into the comment field shows as raw html
-        let replacedText = shouldEscapeText ? Utils.escapeText(text) : text;
+        let replacedText = shouldEscapeText ? Utils.escapeText(textWithPlaceholders) : textWithPlaceholders;
         const rules = this.getHtmlRuleset(filterRules, disabledRules, shouldKeepRawInput);
 
         const processRule = (rule: Rule) => {
@@ -1003,7 +1041,7 @@ export default class ExpensiMark {
             return shouldEscapeText ? Utils.escapeText(text) : text;
         }
 
-        return replacedText;
+        return this.restorePassthroughTags(replacedText, passthroughTags);
     }
 
     /**
@@ -1268,6 +1306,11 @@ export default class ExpensiMark {
         }
         generatedMarkdown = this.unpackNestedQuotes(generatedMarkdown);
 
+        // Lift out <VictoryChart> blocks before replaceBlockElementWithNewLine's stripHTML would
+        // erase them. Restored after rule processing so the chart fragment survives the round-trip.
+        const {text: textWithPlaceholders, tags: passthroughTags} = this.extractPassthroughTags(generatedMarkdown);
+        generatedMarkdown = textWithPlaceholders;
+
         const processRule = (rule: RuleWithRegex) => {
             // Pre-processes input HTML before applying regex
             if (rule.pre) {
@@ -1278,7 +1321,8 @@ export default class ExpensiMark {
         };
 
         this.htmlToMarkdownRules.forEach(processRule);
-        return Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
+        const decoded = Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
+        return this.restorePassthroughTags(decoded, passthroughTags);
     }
 
     /**

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -83,17 +83,24 @@ const MARKDOWN_VIDEO_REGEX = new RegExp(
 
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
-// VictoryChart and its inner tags are preserved verbatim through `replace` and `htmlToMarkdown`
-// so that server-rendered VirtualCFO charts in `reportAction.message.html` round-trip without
-// their inner markup being escaped or stripped. The outer <VictoryChart>...</VictoryChart> match
-// also protects every nested child (VictoryBar/Line/Pie/Axis/Label/Legend/Tooltip/Group) as part
-// of the captured block; the alternation handles the rare case of a stray child tag at top level.
-// Case-insensitive matching covers both the PascalCase emitted by the server (<VictoryChart>)
-// and the lowercase form react-native-render-html uses internally (<victorychart>).
-const VICTORY_TAG_NAMES = 'VictoryChart|VictoryBar|VictoryLine|VictoryPie|VictoryAxis|VictoryLabel|VictoryLegend|VictoryTooltip|VictoryGroup';
-const PASSTHROUGH_TAGS_REGEX = new RegExp(`<(?:${VICTORY_TAG_NAMES})\\b[^>]*/>|<(${VICTORY_TAG_NAMES})\\b[^>]*>[\\s\\S]*?<\\/\\1>`, 'gi');
-const PASSTHROUGH_PLACEHOLDER_REGEX = /EXMK_PT_(\d+)/g;
-const buildPassthroughPlaceholder = (index: number): string => `EXMK_PT_${index}`;
+// Server-rendered VirtualCFO charts are embedded in `reportAction.message.html` as a single
+// <VictoryChart> block. We preserve that whole block verbatim through `htmlToMarkdown` (and the
+// trusted-input path of `replace`) so the chart round-trips without its inner markup being
+// escaped or stripped. Matching only the outer <VictoryChart> container is deliberate:
+//  - every other Victory tag (VictoryBar/Line/Pie/Axis/Label/Legend/Tooltip/Group) is always
+//    nested inside it, so it is preserved as part of the captured block - no separate rule needed;
+//  - it avoids the unbalanced-nesting failure a lazy `[\s\S]*?` would hit if a self-nesting tag
+//    such as <VictoryGroup> were matched on its own.
+// Case-insensitive matching covers both the PascalCase the server emits (<VictoryChart>) and the
+// lowercase form react-native-render-html uses internally (<victorychart>).
+const PASSTHROUGH_TAGS_REGEX = /<VictoryChart\b[^>]*\/>|<VictoryChart\b[^>]*>[\s\S]*?<\/VictoryChart>/gi;
+// Placeholders are wrapped in a NUL sentinel. NUL never occurs in real HTML/markdown text, so a
+// chart placeholder can never collide with user-typed content, and the numeric core carries no
+// markdown-significant characters that other rules could mangle. Built via String.fromCharCode
+// so no control character is ever stored literally in this source file.
+const PASSTHROUGH_SENTINEL = String.fromCharCode(0);
+const PASSTHROUGH_PLACEHOLDER_REGEX = new RegExp(`${PASSTHROUGH_SENTINEL}(\\d+)${PASSTHROUGH_SENTINEL}`, 'g');
+const buildPassthroughPlaceholder = (index: number): string => `${PASSTHROUGH_SENTINEL}${index}${PASSTHROUGH_SENTINEL}`;
 
 export default class ExpensiMark {
     extractPassthroughTags = (text: string): {text: string; tags: string[]} => {
@@ -1004,7 +1011,13 @@ export default class ExpensiMark {
 
         // Lift out <VictoryChart> blocks before processing so neither escaping nor markdown rules
         // disturb their inner markup (JSON in attributes, special chars, etc.). Restored at the end.
-        const {text: textWithPlaceholders, tags: passthroughTags} = this.extractPassthroughTags(text);
+        //
+        // This is gated on `!shouldEscapeText`: passthrough is only safe for trusted input (server
+        // HTML re-parsed with shouldEscapeText === false). When shouldEscapeText is true the input
+        // is user-typed markdown, and a chart tag must be escaped like any other HTML - otherwise a
+        // user could smuggle arbitrary markup (e.g. <VictoryChart><img onerror=...></VictoryChart>)
+        // straight past escaping.
+        const {text: textWithPlaceholders, tags: passthroughTags} = shouldEscapeText ? {text, tags: [] as string[]} : this.extractPassthroughTags(text);
 
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? Utils.escapeText(textWithPlaceholders) : textWithPlaceholders;

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -83,41 +83,31 @@ const MARKDOWN_VIDEO_REGEX = new RegExp(
 
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
-// Server-rendered VirtualCFO charts are embedded in `reportAction.message.html` as a single
-// <VictoryChart> block. We preserve that whole block verbatim through `htmlToMarkdown` (and the
-// trusted-input path of `replace`) so the chart round-trips without its inner markup being
-// escaped or stripped. Matching only the outer <VictoryChart> container is deliberate:
-//  - every other Victory tag (VictoryBar/Line/Pie/Axis/Label/Legend/Tooltip/Group) is always
-//    nested inside it, so it is preserved as part of the captured block - no separate rule needed;
-//  - it avoids the unbalanced-nesting failure a lazy `[\s\S]*?` would hit if a self-nesting tag
-//    such as <VictoryGroup> were matched on its own.
-// Case-insensitive matching covers both the PascalCase the server emits (<VictoryChart>) and the
-// lowercase form react-native-render-html uses internally (<victorychart>).
-const PASSTHROUGH_TAGS_REGEX = /<VictoryChart\b[^>]*\/>|<VictoryChart\b[^>]*>[\s\S]*?<\/VictoryChart>/gi;
-// Placeholders are wrapped in a NUL sentinel. NUL never occurs in real HTML/markdown text, so a
-// chart placeholder can never collide with user-typed content, and the numeric core carries no
-// markdown-significant characters that other rules could mangle. Built via String.fromCharCode
-// so no control character is ever stored literally in this source file.
-const PASSTHROUGH_SENTINEL = String.fromCharCode(0);
-const PASSTHROUGH_PLACEHOLDER_REGEX = new RegExp(`${PASSTHROUGH_SENTINEL}(\\d+)${PASSTHROUGH_SENTINEL}`, 'g');
-const buildPassthroughPlaceholder = (index: number): string => `${PASSTHROUGH_SENTINEL}${index}${PASSTHROUGH_SENTINEL}`;
+// Preserve VirtualCFO chart blocks by matching the outer <VictoryChart> container.
+// This captures all nested Victory components and prevents markup escaping during conversion.
+const VICTORY_CHART_REGEX = /<VictoryChart\b[^>]*\/>|<VictoryChart\b[^>]*>[\s\S]*?<\/VictoryChart>/gi;
+
+// Chart placeholders use NUL characters as delimiters to prevent conflicts with user content.
+const VICTORY_CHART_PLACEHOLDER_DELIMITER = String.fromCharCode(0);
+const VICTORY_CHART_PLACEHOLDER_PATTERN = new RegExp(`${VICTORY_CHART_PLACEHOLDER_DELIMITER}(\\d+)${VICTORY_CHART_PLACEHOLDER_DELIMITER}`, 'g');
+const createVictoryChartPlaceholder = (index: number): string => `${VICTORY_CHART_PLACEHOLDER_DELIMITER}${index}${VICTORY_CHART_PLACEHOLDER_DELIMITER}`;
 
 export default class ExpensiMark {
-    extractPassthroughTags = (text: string): {text: string; tags: string[]} => {
+    extractVictoryChartTags = (text: string): {text: string; tags: string[]} => {
         const tags: string[] = [];
-        const out = text.replace(PASSTHROUGH_TAGS_REGEX, (match) => {
-            const placeholder = buildPassthroughPlaceholder(tags.length);
+        const out = text.replace(VICTORY_CHART_REGEX, (match) => {
+            const placeholder = createVictoryChartPlaceholder(tags.length);
             tags.push(match);
             return placeholder;
         });
         return {text: out, tags};
     };
 
-    restorePassthroughTags = (text: string, tags: string[]): string => {
+    restoreVictoryChartTags = (text: string, tags: string[]): string => {
         if (tags.length === 0) {
             return text;
         }
-        return text.replace(PASSTHROUGH_PLACEHOLDER_REGEX, (match, idx) => tags[Number(idx)] ?? match);
+        return text.replace(VICTORY_CHART_PLACEHOLDER_PATTERN, (match, idx) => tags[Number(idx)] ?? match);
     };
 
     getAttributeCache = (extras?: Extras) => {
@@ -1009,15 +999,9 @@ export default class ExpensiMark {
             return '';
         }
 
-        // Lift out <VictoryChart> blocks before processing so neither escaping nor markdown rules
-        // disturb their inner markup (JSON in attributes, special chars, etc.). Restored at the end.
-        //
-        // This is gated on `!shouldEscapeText`: passthrough is only safe for trusted input (server
-        // HTML re-parsed with shouldEscapeText === false). When shouldEscapeText is true the input
-        // is user-typed markdown, and a chart tag must be escaped like any other HTML - otherwise a
-        // user could smuggle arbitrary markup (e.g. <VictoryChart><img onerror=...></VictoryChart>)
-        // straight past escaping.
-        const {text: textWithPlaceholders, tags: passthroughTags} = shouldEscapeText ? {text, tags: [] as string[]} : this.extractPassthroughTags(text);
+        // Extract VictoryChart blocks to preserve their markup during processing.
+        // Only safe for trusted server input - user input must be escaped to prevent XSS.
+        const {text: textWithPlaceholders, tags: victoryChartTags} = shouldEscapeText ? {text, tags: [] as string[]} : this.extractVictoryChartTags(text);
 
         // This ensures that any html the user puts into the comment field shows as raw html
         let replacedText = shouldEscapeText ? Utils.escapeText(textWithPlaceholders) : textWithPlaceholders;
@@ -1054,7 +1038,7 @@ export default class ExpensiMark {
             return shouldEscapeText ? Utils.escapeText(text) : text;
         }
 
-        return this.restorePassthroughTags(replacedText, passthroughTags);
+        return this.restoreVictoryChartTags(replacedText, passthroughTags);
     }
 
     /**
@@ -1319,9 +1303,8 @@ export default class ExpensiMark {
         }
         generatedMarkdown = this.unpackNestedQuotes(generatedMarkdown);
 
-        // Lift out <VictoryChart> blocks before replaceBlockElementWithNewLine's stripHTML would
-        // erase them. Restored after rule processing so the chart fragment survives the round-trip.
-        const {text: textWithPlaceholders, tags: passthroughTags} = this.extractPassthroughTags(generatedMarkdown);
+        // Extract VictoryChart blocks before HTML stripping, then restore them.
+        const {text: textWithPlaceholders, tags: passthroughTags} = this.extractVictoryChartTags(generatedMarkdown);
         generatedMarkdown = textWithPlaceholders;
 
         const processRule = (rule: RuleWithRegex) => {
@@ -1335,7 +1318,7 @@ export default class ExpensiMark {
 
         this.htmlToMarkdownRules.forEach(processRule);
         const decoded = Str.htmlDecode(this.replaceBlockElementWithNewLine(generatedMarkdown));
-        return this.restorePassthroughTags(decoded, passthroughTags);
+        return this.restoreVictoryChartTags(decoded, victoryChartTags);
     }
 
     /**


### PR DESCRIPTION
**ExpensiMark:**
- Added **VictoryChart passthrough block** — single regex covers all 9 tags (`VictoryChart|VictoryBar|VictoryLine|VictoryPie|VictoryAxis|VictoryLabel|VictoryLegend|VictoryTooltip|VictoryGroup`) via alternation, case-insensitive (handles both `<VictoryChart>` from the server and lowercase `<victorychart>` from react-native-render-html).
- `extractPassthroughTags` / `restorePassthroughTags` helpers swap chart blocks for `EXMK_PT_<i>` placeholders before processing, restore after — same pattern as the` <video>` preservation, just generalized to a block rather than a single line.
- Wired into both `replace` (before escape) and `htmlToMarkdown` (before `replaceBlockElementWithNewLine`'s `stripHTML`).
Added `victoryChart` rule to `htmlToTextRules` emitting `[chart]`.


**Tests:**
- 11 round-trip tests (`htmlToMarkdown` ↔ `replace`), plus edge cases (lowercase, self-closing, all 9 inner tags, surrounding markdown rules, security invariant, stray placeholder text).

### Fixed Issues
$ https://github.com/Expensify/App/issues/90547

# Tests
1. What unit/integration tests cover your change? What autoQA tests cover your change?
1. What tests did you perform that validates your changed worked?

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
