### PR TITLE
Upgrade eslint-config-expensify to 4.0.4

### DIFF
--- a/__tests__/CLI-test.js
+++ b/__tests__/CLI-test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names -- @jest-environment is a valid Jest directive */
 /**
  * @jest-environment node
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-jest": "^29.0.0",
         "babelify": "10.0.0",
         "eslint": "^9.36.0",
-        "eslint-config-expensify": "4.0.3",
+        "eslint-config-expensify": "4.0.4",
         "eslint-config-prettier": "^10.1.5",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-prettier": "^5.2.1",
@@ -5806,9 +5806,9 @@
       }
     },
     "node_modules/eslint-config-expensify": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-expensify/-/eslint-config-expensify-4.0.3.tgz",
-      "integrity": "sha512-5kGGKj8Ye/JV8vWidkXUX1KtwyAOZIbp6+8Gn7PmTGCGrXKJYrX8rWU0u8LUDBuvmv8q/j6NVMy6z6zk64s6RQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-expensify/-/eslint-config-expensify-4.0.4.tgz",
+      "integrity": "sha512-dZ/aYJ109rkvejDyR928Jc7awqHuXAArFYtk9uhqZjvPoDA4xL0ONtGEPmp+5KhkWzHsH4g/f9c0GXJKd//FoA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "babel-jest": "^29.0.0",
     "babelify": "10.0.0",
     "eslint": "^9.36.0",
-    "eslint-config-expensify": "4.0.3",
+    "eslint-config-expensify": "4.0.4",
     "eslint-config-prettier": "^10.1.5",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-prettier": "^5.2.1",


### PR DESCRIPTION
Upgrades `eslint-config-expensify` to 4.0.4, which includes built-in support for the `@jest-environment` JSDoc tag in the jest config ([eslint-config-expensify#191](https://github.com/Expensify/eslint-config-expensify/pull/191)). Removes the now-redundant `eslint-disable jsdoc/check-tag-names` workaround from `CLI-test.js`.

### Fixed Issues
$ n/a

# Tests
lint / CI only
