### PR TITLE
Truncate oversized log messages before sending to server

### DIFF
--- a/__tests__/Logger-test.js
+++ b/__tests__/Logger-test.js
@@ -99,6 +99,42 @@ test('Test Log.client()', () => {
     expect(mockClientLoggingCallback).toHaveBeenCalledWith('Test', '');
 });
 
+test('Test oversized messages are truncated before being sent to the server', () => {
+    const mockCallback = jest.fn();
+    const LogWithLimit = new Logger({
+        serverLoggingCallback: mockCallback,
+        clientLoggingCallback: jest.fn(),
+    });
+
+    const oneMegabyte = 1024 * 1024;
+    const maxLength = oneMegabyte - 1024;
+    const omittedCount = 500;
+    // `info()` prepends the "[info] " prefix, so build the raw message minus that prefix length
+    // to land the final message exactly `omittedCount` characters over the cap.
+    const prefixLength = '[info] '.length;
+    const rawMessage = 'x'.repeat((maxLength + omittedCount) - prefixLength);
+    LogWithLimit.info(rawMessage, true);
+
+    const packet = JSON.parse(mockCallback.mock.calls[0][1].logPacket);
+    const {message} = packet[0];
+    expect(message.length).toBe(maxLength + `…[truncated ${omittedCount} characters]`.length);
+    expect(message.startsWith('[info] xxx')).toBe(true);
+    expect(message.endsWith(`…[truncated ${omittedCount} characters]`)).toBe(true);
+});
+
+test('Test messages at or below the cap are left untouched', () => {
+    const mockCallback = jest.fn();
+    const LogWithLimit = new Logger({
+        serverLoggingCallback: mockCallback,
+        clientLoggingCallback: jest.fn(),
+    });
+
+    LogWithLimit.info('short message', true);
+
+    const packet = JSON.parse(mockCallback.mock.calls[0][1].logPacket);
+    expect(packet[0].message).toBe('[info] short message');
+});
+
 test('Test getContextEmail captures email per log line', () => {
     const mockCallback = jest.fn();
     const LogWithEmail = new Logger({

--- a/__tests__/Logger-test.js
+++ b/__tests__/Logger-test.js
@@ -112,7 +112,8 @@ test('Test oversized messages are truncated before being sent to the server', ()
     // `info()` prepends the "[info] " prefix, so build the raw message minus that prefix length
     // to land the final message exactly `omittedCount` characters over the cap.
     const prefixLength = '[info] '.length;
-    const rawMessage = 'x'.repeat(maxLength + omittedCount - prefixLength);
+    const overCapLength = maxLength + omittedCount;
+    const rawMessage = 'x'.repeat(overCapLength - prefixLength);
     LogWithLimit.info(rawMessage, true);
 
     const packet = JSON.parse(mockCallback.mock.calls[0][1].logPacket);

--- a/__tests__/Logger-test.js
+++ b/__tests__/Logger-test.js
@@ -112,7 +112,7 @@ test('Test oversized messages are truncated before being sent to the server', ()
     // `info()` prepends the "[info] " prefix, so build the raw message minus that prefix length
     // to land the final message exactly `omittedCount` characters over the cap.
     const prefixLength = '[info] '.length;
-    const rawMessage = 'x'.repeat((maxLength + omittedCount) - prefixLength);
+    const rawMessage = 'x'.repeat(maxLength + omittedCount - prefixLength);
     LogWithLimit.info(rawMessage, true);
 
     const packet = JSON.parse(mockCallback.mock.calls[0][1].logPacket);

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -22,6 +22,12 @@ type LoggerOptions = {
 
 const MAX_LOG_LINES_BEFORE_FLUSH = 50;
 
+// The server drops (and alerts on) any single log message whose byte length exceeds 1MB, so cap
+// each message just below that. We truncate rather than drop so oversized lines are still logged
+// (head of the message + a marker) instead of being lost. The margin leaves room for the marker.
+const ONE_MEGABYTE = 1024 * 1024;
+const MAX_LOG_MESSAGE_LENGTH = ONE_MEGABYTE - 1024;
+
 export default class Logger {
     logLines: LogLine[];
 
@@ -99,8 +105,14 @@ export default class Logger {
             // Silently fail if getContextEmail throws - logging should not crash
         }
 
+        let cappedMessage = message;
+        if (message.length > MAX_LOG_MESSAGE_LENGTH) {
+            const omittedCount = message.length - MAX_LOG_MESSAGE_LENGTH;
+            cappedMessage = `${message.slice(0, MAX_LOG_MESSAGE_LENGTH)}…[truncated ${omittedCount} characters]`;
+        }
+
         const length = this.logLines.push({
-            message,
+            message: cappedMessage,
             parameters,
             onlyFlushWithOthers,
             timestamp: new Date(),


### PR DESCRIPTION
<!-- Add an explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/655280

# Tests
1. In https://github.com/Expensify/App/blob/main/src/libs/Log.ts, add

```
if (typeof window !== 'undefined') {
    (window as unknown as {TestLog: typeof Log}).TestLog = Log;
}
```

2. In https://github.com/Expensify/Web-Expensify/blob/77dce47f0cdae88d1c9bfcd57987c241883a07bb/lib/LogAPI.php#L54, add

```
if (preg_match('/\[truncated \d+ characters\]$/', $log['message'])) {
                    self::info('Received truncated client log message', ['length' => strlen($log['message'])]);
                }
```

3. Run App, open the browser console, and run 

```
window.TestLog.info('X'.repeat(2 * 1024 * 1024), true);
```

4. Verify `Received truncated client log message` is shown in the log

<img width="674" height="89" alt="Screenshot 2026-07-03 at 6 57 49 PM" src="https://github.com/user-attachments/assets/f46b06a1-d6aa-4256-b5f1-31b314bf2826" />

# QA

N/A
