### PR TITLE
[No QA] Remove `sequenceNumber`

### DIFF
--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -12,6 +12,7 @@ export default function ReportHistoryStore(API, PubSub) {
         throw new Error('Cannot instantiate ReportHistoryStore without API');
     }
 
+
     const store = {
         API,
         cache: {},

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -191,7 +191,7 @@ export default function ReportHistoryStore(API, PubSub) {
             getFromCache(reportID)
                 .done((cachedHistory) => {
                     if (cachedHistory.some(({reportActionID}) => reportActionID === reportAction.reportActionID)) {
-                        mergeHistoryByTimestamp(reportID, [reportAction]);
+                        mergeHistoryByReportActionID(reportID, [reportAction]);
                         return promise.resolve(filterHiddenActions(store.cache[reportID]));
                     }
 

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -69,19 +69,6 @@ export default function ReportHistoryStore(API, PubSub) {
     }
 
     /**
-     * Gets the history.
-     * 
-     * @deprecated use getFlatHistory instead.
-     *
-     * @param {Number} reportID
-     * @param {Boolean} ignoreCache
-     * @returns {Deferred}
-     */
-    function get(reportID, ignoreCache) {
-        return getFlatHistory(reportID, ignoreCache);
-    }
-
-    /**
      * Gets the history. This flow does not depend on the deprecated sequence number in report actions.
      *
      * @param {Number} reportID
@@ -108,6 +95,19 @@ export default function ReportHistoryStore(API, PubSub) {
     }
 
     /**
+     * Gets the history.
+     *
+     * @deprecated use getFlatHistory instead.
+     *
+     * @param {Number} reportID
+     * @param {Boolean} ignoreCache
+     * @returns {Deferred}
+     */
+    function get(reportID, ignoreCache) {
+        return getFlatHistory(reportID, ignoreCache);
+    }
+
+    /**
      * Gets the history from the cache if it exists. Otherwise fully loads the history.
      *
      * @param {Number} reportID
@@ -126,7 +126,13 @@ export default function ReportHistoryStore(API, PubSub) {
 
     return {
         /**
+         * Gets the history.
+         *
          * @deprecated use getFlatHistory instead.
+         *
+         * @param {Number} reportID
+         * @param {Boolean} ignoreCache
+         * @returns {Deferred}
          */
         get: (reportID, ignoreCache = false) => {
             const promise = new Deferred();

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -12,7 +12,6 @@ export default function ReportHistoryStore(API, PubSub) {
         throw new Error('Cannot instantiate ReportHistoryStore without API');
     }
 
-
     const store = {
         API,
         cache: {},

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -146,6 +146,9 @@ export default function ReportHistoryStore(API, PubSub) {
     }
 
     return {
+        /**
+         * @deprecated use getFlatHistory instead.
+         */
         get: (reportID, ignoreCache = false) => {
             const promise = new Deferred();
             get(reportID, ignoreCache)

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -153,7 +153,7 @@ export default function ReportHistoryStore(API, PubSub) {
             getFromCache(reportID)
                 .done((cachedHistory) => {
                     if (cachedHistory.some(({reportActionID}) => reportActionID === reportAction.reportActionID)) {
-                        mergeHistoryByReportActionID(reportID, [reportAction]);
+                        mergeHistoryByTimestamp(reportID, [reportAction]);
                         return promise.resolve(filterHiddenActions(store.cache[reportID]));
                     }
 

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -32,27 +32,6 @@ export default function ReportHistoryStore(API, PubSub) {
      * @param {Number} reportID
      * @param {Object[]} newHistory
      */
-    function mergeItems(reportID, newHistory) {
-        if (newHistory.length === 0) {
-            return;
-        }
-
-        const newCache = newHistory.reverse().reduce((prev, curr) => {
-            if (!prev.some((item) => item.sequenceNumber === curr.sequenceNumber)) {
-                prev.unshift(curr);
-            }
-            return prev;
-        }, store.cache[reportID] || []);
-
-        store.cache[reportID] = newCache.sort((a, b) => b.sequenceNumber - a.sequenceNumber);
-    }
-
-    /**
-     * Merges history items into the cache and creates it if it doesn't yet exist.
-     *
-     * @param {Number} reportID
-     * @param {Object[]} newHistory
-     */
     function mergeHistoryByTimestamp(reportID, newHistory) {
         if (newHistory.length === 0) {
             return;

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -91,32 +91,15 @@ export default function ReportHistoryStore(API, PubSub) {
 
     /**
      * Gets the history.
+     * 
+     * @deprecated use getFlatHistory instead.
      *
      * @param {Number} reportID
      * @param {Boolean} ignoreCache
      * @returns {Deferred}
      */
     function get(reportID, ignoreCache) {
-        const promise = new Deferred();
-
-        if (ignoreCache) {
-            delete store.cache[reportID];
-        }
-
-        const cachedHistory = store.cache[reportID] || [];
-        const firstHistoryItem = cachedHistory[0] || {};
-
-        store.API.Report_GetHistory({
-            reportID,
-            offset: firstHistoryItem.sequenceNumber || 0,
-        })
-            .done((recentHistory) => {
-                mergeItems(reportID, recentHistory);
-                promise.resolve(store.cache[reportID]);
-            })
-            .fail(promise.reject);
-
-        return promise;
+        return getFlatHistory(reportID, ignoreCache);
     }
 
     /**

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -169,26 +169,6 @@ export default function ReportHistoryStore(API, PubSub) {
             return promise;
         },
 
-        insertIntoCache: (reportID, reportAction) => {
-            const promise = new Deferred();
-            getFromCache(reportID)
-                .done((cachedHistory) => {
-                    const sequenceNumber = reportAction.sequenceNumber;
-
-                    if (cachedHistory.length >= sequenceNumber) {
-                        mergeItems(reportID, [reportAction]);
-                        return promise.resolve(filterHiddenActions(store.cache[reportID]));
-                    }
-
-                    get(reportID)
-                        .done((reportHistory) => promise.resolve(filterHiddenActions(reportHistory)))
-                        .fail(promise.reject);
-                })
-                .fail(promise.reject);
-
-            return promise;
-        },
-
         insertIntoCacheByActionID: (reportID, reportAction) => {
             const promise = new Deferred();
             getFromCache(reportID)


### PR DESCRIPTION

Removed functions that are no longer needed/used, these are based on `sequenceNumber` and we are removing that from backend so these function should not be kept.

- Removed `insertIntoCache`
- Made `get` an alias to `getFlatHistory` (they have same outcome, even though the `get` function sends a `offset` param, this param is not used in Web-E)

### Fixed Issues
https://github.com/Expensify/Expensify/issues/589297

# Tests

n/a

# QA

n/a