### PR TITLE
Fix calculating tax percentage with null value

### DIFF
--- a/lib/Num.jsx
+++ b/lib/Num.jsx
@@ -193,7 +193,8 @@ export default {
          * @returns {number} The amount of tax
          */
         calculateTaxFromPercentage(total, percentage) {
-            const divisor = percentage ? Str.percentageStringToNumber(percentage) / 100 + 1 : 1;
+            const percentageAsDecimal = percentage ? Str.percentageStringToNumber(percentage) / 100 : 0;
+            const divisor = percentageAsDecimal + 1;
             return this.calculateTaxFromDivisor(total, divisor);
         },
 

--- a/lib/Num.jsx
+++ b/lib/Num.jsx
@@ -193,8 +193,7 @@ export default {
          * @returns {number} The amount of tax
          */
         calculateTaxFromPercentage(total, percentage) {
-            const percentageAsDecimal = Str.percentageStringToNumber(percentage) / 100;
-            const divisor = percentage ? percentageAsDecimal + 1 : 1;
+            const divisor = percentage ? Str.percentageStringToNumber(percentage) / 100 + 1 : 1;
             return this.calculateTaxFromDivisor(total, divisor);
         },
 


### PR DESCRIPTION
Reverts this https://github.com/Expensify/expensify-common/commit/0d8b643fdca5ba0c3e3a59bdfa2a0f0027e2b5fe#diff-4fe186c408cd7703a167c4fbf55a1a0a4bc045ca3567a50aa40b2e7dc35f55e7L194-L195

If percentage is null, the `percentageStringToNumber` errors out

### Fixed Issues
Part of https://github.com/Expensify/Expensify/issues/658931

# Tests


Reproduced and tested locally


<img width="2560" height="1380" alt="Screenshot 2026-07-14 at 5 57 45 PM" src="https://github.com/user-attachments/assets/e95d1c77-d562-43b2-90f6-67f0b516f288" />

# QA
1. What does QA need to do to validate your changes?
1. What areas to they need to test for regressions?
