### PR TITLE
[v1] Remove `sequenceNumber` dependent functions

### DIFF
--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -114,6 +114,32 @@ export default class ReportHistoryStore {
             },
 
             /**
+             * Set a history item directly into the cache. Checks to see if we have the previous item first.
+             *
+             * @param {Number} reportID
+             * @param {Object} reportAction
+             *
+             * @returns {Deferred}
+             */
+            insertIntoCacheByActionID: (reportID, reportAction) => {
+                const promise = new Deferred();
+                this.getFromCache(reportID)
+                    .done((cachedHistory) => {
+                        if (cachedHistory.some(({reportActionID}) => reportActionID === reportAction.reportActionID)) {
+                            this.mergeHistoryByTimestamp(reportID, [reportAction]);
+                            return promise.resolve(this.filterHiddenActions(this.cache[reportID]));
+                        }
+
+                        this.getFlatHistory(reportID)
+                            .done(reportHistory => promise.resolve(this.filterHiddenActions(reportHistory)))
+                            .fail(promise.reject);
+                    })
+                    .fail(promise.reject);
+
+                return promise;
+            },
+
+            /**
              * Certain events need to completely clear the cache. This method allows other code modules using this
              * (like Web, Mobile) to assign which events would do so.
              *

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -125,7 +125,7 @@ export default class ReportHistoryStore {
                 const promise = new Deferred();
                 this.getFromCache(reportID)
                     .done((cachedHistory) => {
-                        if (cachedHistory.some(({reportActionID}) => reportActionID === reportAction.reportActionID)) {
+                        if (_.some(cachedHistory, ({reportActionID}) => reportActionID === reportAction.reportActionID)) {
                             this.mergeHistoryByTimestamp(reportID, [reportAction]);
                             return promise.resolve(this.filterHiddenActions(this.cache[reportID]));
                         }

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -279,13 +279,7 @@ export default class ReportHistoryStore {
 
         // First check to see if we even have this history in cache
         if (_.isEmpty(cachedHistory)) {
-            this.API.Report_GetHistory({reportID})
-                .done((reportHistory) => {
-                    this.mergeItems(reportID, reportHistory);
-                    promise.resolve(this.cache[reportID]);
-                })
-                .fail(promise.reject);
-            return promise;
+            return this.getFlatHistory(reportID);
         }
 
         return promise.resolve(cachedHistory);

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -38,6 +38,25 @@ export default class ReportHistoryStore {
          */
         return {
             /**
+             * Returns the history for a given report. This flow does not depend on the deprecated sequence number in report actions.
+             * Note that we are unable to ask for the cached history.
+             *
+             * @param {Number} reportID
+             * @param {Boolean} ignoreCache - useful if you need to force the report history to reload completely.
+             *
+             * @returns {Deferred}
+             */
+            getFlatHistory: (reportID, ignoreCache = false) => {
+                const promise = new Deferred();
+                this.getFlatHistory(reportID, ignoreCache)
+                    .done((reportHistory) => {
+                        promise.resolve(this.filterHiddenActions(reportHistory));
+                    })
+                    .fail(promise.reject);
+                return promise;
+            },
+
+            /**
              * Returns the history for a given report.
              * Note that we are unable to ask for the cached history.
              *
@@ -128,6 +147,37 @@ export default class ReportHistoryStore {
 
         // Sort items in case they have become out of sync
         this.cache[reportID] = _.sortBy(newCache, 'sequenceNumber').reverse();
+    }
+
+    /**
+     * Gets the history. This flow does not depend on the deprecated sequence number in report actions.
+     *
+     * @param {Number} reportID
+     * @param {Boolean} ignoreCache
+     *
+     * @returns {Deferred}
+     */
+    getFlatHistory(reportID, ignoreCache) {
+        const promise = new Deferred();
+
+        // Remove the cache entry if we're ignoring the cache, since we'll be replacing it later.
+        if (ignoreCache) {
+            delete this.cache[reportID];
+        }
+
+        this.API.Report_GetHistory({
+            reportID,
+        })
+            .done((recentHistory) => {
+                // Update history with new items fetched
+                this.mergeHistoryByTimestamp(reportID, recentHistory);
+
+                // Return history for this report
+                promise.resolve(this.cache[reportID]);
+            })
+            .fail(promise.reject);
+
+        return promise;
     }
 
     /**

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -233,32 +233,7 @@ export default class ReportHistoryStore {
      * @returns {Deferred}
      */
     get(reportID, ignoreCache) {
-        const promise = new Deferred();
-
-        // Remove the cache entry if we're ignoring the cache, since we'll be replacing it later.
-        if (ignoreCache) {
-            delete this.cache[reportID];
-        }
-
-        // We'll poll the API for the un-cached history
-        const cachedHistory = this.cache[reportID] || [];
-        const firstHistoryItem = _.first(cachedHistory) || {};
-
-        // Grab the most recent sequenceNumber we have and poll the API for fresh data
-        this.API.Report_GetHistory({
-            reportID,
-            offset: firstHistoryItem.sequenceNumber || 0
-        })
-            .done((recentHistory) => {
-                // Update history with new items fetched
-                this.mergeItems(reportID, recentHistory);
-
-                // Return history for this report
-                promise.resolve(this.cache[reportID]);
-            })
-            .fail(promise.reject);
-
-        return promise;
+        return this.getFlatHistory(reportID, ignoreCache);
     }
 
     /**

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -150,6 +150,28 @@ export default class ReportHistoryStore {
     }
 
     /**
+     * Merges history items into the cache and creates it if it doesn't yet exist.
+     *
+     * @param {Number} reportID
+     * @param {Object[]} newHistory
+     */
+    mergeHistoryByTimestamp(reportID, newHistory) {
+        if (newHistory.length === 0) {
+            return;
+        }
+
+        const newCache = _.reduce(newHistory.reverse(), (prev, curr) => {
+            if (!_.findWhere(prev, {reportActionTimestamp: curr.reportActionTimestamp})) {
+                prev.unshift(curr);
+            }
+            return prev;
+        }, this.cache[reportID] || []);
+
+        // Sort items in case they have become out of sync
+        this.cache[reportID] = _.sortBy(newCache, 'reportActionTimestamp').reverse();
+    }
+
+    /**
      * Gets the history. This flow does not depend on the deprecated sequence number in report actions.
      *
      * @param {Number} reportID

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -227,6 +227,8 @@ export default class ReportHistoryStore {
     /**
      * Gets the history.
      *
+     * @deprecated use getFlatHistory instead.
+     *
      * @param {Number} reportID
      * @param {Boolean} ignoreCache
      *

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -147,7 +147,7 @@ export default class ReportHistoryStore {
      * @param {Number} reportID
      * @param {Object[]} newHistory
      */
-    mergeHistoryByTimestamp(reportID, newHistory) {
+    mergeHistoryByReportActionID(reportID, newHistory) {
         if (newHistory.length === 0) {
             return;
         }

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -85,42 +85,6 @@ export default class ReportHistoryStore {
              *
              * @returns {Deferred}
              */
-            insertIntoCache: (reportID, reportAction) => {
-                const promise = new Deferred();
-                this.getFromCache(reportID)
-                    .done((cachedHistory) => {
-                        const sequenceNumber = reportAction.sequenceNumber;
-
-                        // Do we have the reportAction immediately before this one?
-                        // Note: History is zero indexed. So if we want to check if we have the previous message before an
-                        // incoming message with a sequenceNumber of 18 then we'd be looking for a cache length of 18
-                        // which would indicate that we have sequenceNumber 17)
-                        if (cachedHistory.length >= sequenceNumber) {
-                            // If we have the previous one then we can assume we have an up to date history minus the most recent
-                            // and must merge it into the cache
-                            this.mergeItems(reportID, [reportAction]);
-                            return promise.resolve(this.filterHiddenActions(this.cache[reportID]));
-                        }
-
-                        // If we get here we have an incomplete history and should get
-                        // the report history again, but this time do not check the cache first.
-                        this.get(reportID)
-                            .done(reportHistory => promise.resolve(this.filterHiddenActions(reportHistory)))
-                            .fail(promise.reject);
-                    })
-                    .fail(promise.reject);
-
-                return promise;
-            },
-
-            /**
-             * Set a history item directly into the cache. Checks to see if we have the previous item first.
-             *
-             * @param {Number} reportID
-             * @param {Object} reportAction
-             *
-             * @returns {Deferred}
-             */
             insertIntoCacheByActionID: (reportID, reportAction) => {
                 const promise = new Deferred();
                 this.getFromCache(reportID)
@@ -153,28 +117,6 @@ export default class ReportHistoryStore {
             // via PHP or html pages within the app e.g. printablereport.html
             filterHiddenActions: this.filterHiddenActions,
         };
-    }
-
-    /**
-     * Merges history items into the cache and creates it if it doesn't yet exist.
-     *
-     * @param {Number} reportID
-     * @param {Object[]} newHistory
-     */
-    mergeItems(reportID, newHistory) {
-        if (newHistory.length === 0) {
-            return;
-        }
-
-        const newCache = _.reduce(newHistory.reverse(), (prev, curr) => {
-            if (!_.findWhere(prev, {sequenceNumber: curr.sequenceNumber})) {
-                prev.unshift(curr);
-            }
-            return prev;
-        }, this.cache[reportID] || []);
-
-        // Sort items in case they have become out of sync
-        this.cache[reportID] = _.sortBy(newCache, 'sequenceNumber').reverse();
     }
 
     /**

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -172,6 +172,28 @@ export default class ReportHistoryStore {
     }
 
     /**
+     * Merges history items by reportActionID into the cache and creates it if it doesn't yet exist.
+     *
+     * @param {Number} reportID
+     * @param {Object[]} newHistory
+     */
+    mergeHistoryByTimestamp(reportID, newHistory) {
+        if (newHistory.length === 0) {
+            return;
+        }
+
+        const newCache = _.reduce(newHistory.reverse(), (prev, curr) => {
+            if (!_.findWhere(prev, {reportActionID: curr.reportActionID})) {
+                prev.unshift(curr);
+            }
+            return prev;
+        }, this.cache[reportID] || []);
+
+        // Sort items in case they have become out of sync
+        this.cache[reportID] = _.sortBy(newCache, 'reportActionTimestamp').reverse();
+    }
+
+    /**
      * Gets the history. This flow does not depend on the deprecated sequence number in report actions.
      *
      * @param {Number} reportID

--- a/lib/ReportHistoryStore.jsx
+++ b/lib/ReportHistoryStore.jsx
@@ -60,6 +60,8 @@ export default class ReportHistoryStore {
              * Returns the history for a given report.
              * Note that we are unable to ask for the cached history.
              *
+             * @deprecated use getFlatHistory instead.
+             * 
              * @param {Number} reportID
              * @param {Boolean} ignoreCache - useful if you need to force the report history to reload completely.
              *


### PR DESCRIPTION

- Replaced `mergeItems` with `mergeHistoryByTimestamp` 
- Replaced `insertIntoCache` with `insertIntoCacheByActionID` 
- Added `mergeHistoryByReportActionID`
- Added `getFlatHistory`
- Deprecated `get` and made it an alias to `getFlatHistory`

(some of changes here are same as https://github.com/Expensify/expensify-common/pull/929)


### Fixed Issues
https://github.com/Expensify/Expensify/issues/589297

# Tests
n/a

# QA
n/a
