### PR TITLE
Auto-detect invoking runtime in CLI help usage line

### DIFF
--- a/__tests__/CLI-test.js
+++ b/__tests__/CLI-test.js
@@ -198,7 +198,7 @@ describe('CLI', () => {
         const scriptName = 'script.ts';
         const expectedOutput = Str.dedent(
             `
-            Usage: npx ts-node ${scriptName} [--verbose] [--yes] [--no] [--help] [--time <value>] <firstName> [lastName]
+            Usage: node ${scriptName} [--verbose] [--yes] [--no] [--help] [--time <value>] <firstName> [lastName]
 
             Flags:
               --verbose              Enable verbose logging
@@ -533,6 +533,42 @@ describe('CLI', () => {
 
             expect(cli.flags.yes).toBe(false);
             expect(cli.flags.no).toBe(false);
+        });
+    });
+
+    describe('runtime detection in usage line', () => {
+        const TS_NODE_SYMBOL = Symbol.for('ts-node.register.instance');
+        const ORIGINAL_EXEC_ARGV = process.execArgv;
+
+        afterEach(() => {
+            delete process.versions.bun;
+            Reflect.deleteProperty(process, TS_NODE_SYMBOL);
+            process.execArgv = ORIGINAL_EXEC_ARGV;
+        });
+
+        function getHelpOutput() {
+            process.argv.push('--help');
+            expect(() => new CLI({positionalArgs: [{name: 'greeting', description: 'Greeting'}]})).toThrow('exit');
+            return mockLog.mock.calls.flat().join('\n');
+        }
+
+        it('auto-detects bun via process.versions.bun', () => {
+            process.versions.bun = '1.1.0';
+            expect(getHelpOutput()).toContain('Usage: bun script.ts');
+        });
+
+        it('auto-detects ts-node via the internal ts-node.register.instance symbol', () => {
+            Reflect.set(process, TS_NODE_SYMBOL, {});
+            expect(getHelpOutput()).toContain('Usage: npx ts-node script.ts');
+        });
+
+        it('auto-detects tsx via its loader hook in process.execArgv', () => {
+            process.execArgv = [...ORIGINAL_EXEC_ARGV, '--import', '/path/to/node_modules/tsx/dist/loader.mjs'];
+            expect(getHelpOutput()).toContain('Usage: npx tsx script.ts');
+        });
+
+        it('falls back to plain node when no runtime markers are present', () => {
+            expect(getHelpOutput()).toContain('Usage: node script.ts');
         });
     });
 

--- a/lib/CLI.ts
+++ b/lib/CLI.ts
@@ -328,7 +328,7 @@ class CLI<TConfig extends CLIConfig> {
             .join(' ');
         const flagUsage = [...Object.keys(flags), '--yes', '--no', '--help'].map((key) => `[${key.startsWith('--') ? key : `--${key}`}]`).join(' ');
 
-        console.log(`\nUsage: npx ts-node ${scriptName} ${flagUsage} ${namedArgUsage} ${positionalUsage}\n`);
+        console.log(`\nUsage: ${CLI.detectRuntimeCommand()} ${scriptName} ${flagUsage} ${namedArgUsage} ${positionalUsage}\n`);
 
         console.log('Flags:');
         for (const [name, spec] of Object.entries(flags)) {
@@ -358,6 +358,29 @@ class CLI<TConfig extends CLIConfig> {
             }
             console.log('');
         }
+    }
+
+    /**
+     * Attempts to detect the command used to invoke the currently-running script, for display in the usage line of the help message.
+     * Checked in order of most to least reliable signal; falls back to plain `node` if nothing else matches.
+     */
+    private static detectRuntimeCommand(): string {
+        // Bun's own public, documented signal. Cast needed since @types/node's ProcessVersions type has no `bun` key.
+        if ((process.versions as Record<string, string | undefined>).bun) {
+            return 'bun';
+        }
+
+        // Internal symbol ts-node sets on `process` when its register hook is active (the same mechanism other tools, e.g. fastify-autoload, rely on to detect ts-node).
+        if (Reflect.get(process, Symbol.for('ts-node.register.instance'))) {
+            return 'npx ts-node';
+        }
+
+        // tsx registers its loader hooks via --require/--import flags pointing into its own package, visible in execArgv regardless of how it was installed.
+        if (process.execArgv.some((arg) => arg.includes('tsx/dist/'))) {
+            return 'npx tsx';
+        }
+
+        return 'node';
     }
 
     private static parseStringArg<T extends StringArg>(rawString: string, paramName: string, spec: T): InferStringArgParsedValue<T> {


### PR DESCRIPTION
<!-- CLI.ts's help/usage message always printed `npx ts-node` as the invocation command, even when a script was actually run via `bun`, `tsx`, or plain `node`. This auto-detects the invoking runtime instead of hardcoding it. -->

### Fixed Issues
N/A

# Tests
1. Added `describe('runtime detection in usage line', ...)` in `__tests__/CLI-test.js` covering: bun detection (`process.versions.bun`), ts-node detection (the `Symbol.for('ts-node.register.instance')` marker ts-node sets on `process`), tsx detection (its loader hook path in `process.execArgv`), and the plain `node` fallback. The pre-existing `--help` test's expected usage string was updated from the hardcoded `npx ts-node` to `node`, since that's what auto-detection correctly returns when run under plain jest/node.
1. Manually verified against all four real runtimes (not just mocks), each printing the correct `Usage:` prefix:
   - `bun script.ts --help` → `Usage: bun ...`
   - `node script.js --help` (Node 26, compiled dist output) → `Usage: node ...`
   - `npx ts-node script.ts --help` → `Usage: npx ts-node ...`
   - `npx tsx script.ts --help` → `Usage: npx tsx ...`

   This caught a real bug during verification: `tsx` does not set `process.env.TSX` as initially assumed from research — it was falling back to `node` instead. Fixed by detecting tsx's loader hook (`tsx/dist/loader.mjs`) in `process.execArgv` instead, which is what tsx actually sets.

# QA
1. N/A — this only changes the auto-generated `--help` text of a CLI-parsing utility class; there's no user-facing product behavior to validate.
1. No regression risk beyond the help message itself; existing flag/arg parsing behavior is untouched.
