### PR TITLE
perf: Optimized ExpensiMark parser for long text

### DIFF
--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -639,6 +639,21 @@ describe('Test long input candidate parsing', () => {
         );
     });
 
+    test('does not autolink a URL-looking video label', () => {
+        const input = '![example.com](https://example.com/video.mp4)';
+        expect(parser.replace(input)).toBe('<video data-expensify-source="https://example.com/video.mp4" >example.com</video>');
+        expect(parser.replace(input, {shouldKeepRawInput: true})).toBe(
+            '<video data-expensify-source="https://example.com/video.mp4" data-raw-href="https://example.com/video.mp4" data-link-variant="labeled" >example.com</video>',
+        );
+    });
+
+    test('does not autolink inside nested protected tags', () => {
+        const input = '<code><code>example.com</code>after.com</code> outside.com';
+        expect(parser.replace(input, {shouldEscapeText: false})).toBe(
+            '<code><code>example.com</code>after.com</code> <a href="https://outside.com" target="_blank" rel="noreferrer noopener">outside.com</a>',
+        );
+    });
+
     test.each([
         ['*example.com*', `<strong>${anchor('example.com')}</strong>`],
         ['~example.com~', `<del>${anchor('example.com')}</del>`],

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -655,6 +655,26 @@ describe('Test long input candidate parsing', () => {
     });
 
     test.each([
+        ['@*example.com*', '@<strong>example.com</strong>'],
+        ['@_example.com_', '@<em>example.com</em>'],
+        ['@~example.com~', '@<del>example.com</del>'],
+        ['test@*example.com*', 'test@<strong>example.com</strong>'],
+    ])('keeps the @ context when checking a formatted URL candidate in %s', (input, expected) => {
+        expect(parser.replace(input)).toBe(expected);
+        expect(parser.replace(input, {shouldKeepRawInput: true})).toBe(expected);
+    });
+
+    test.each([
+        ['`~` ~strike~', '<code>~</code> ~strike~'],
+        ['`x~` ~strike~', '<code>x~</code> <del>strike</del>'],
+        ['[~](https://example.com) ~strike~', `${anchor('https://example.com', '~')} ~strike~`],
+        ['`*` *bold*', '<code>*</code> <strong>bold</strong>'],
+        ['[*](https://example.com) *bold*', `${anchor('https://example.com', '*')} <strong>bold</strong>`],
+    ])('keeps protected markers when selecting Markdown pairs in %s', (input, expected) => {
+        expect(parser.replace(input)).toBe(expected);
+    });
+
+    test.each([
         ['*example.com*', `<strong>${anchor('example.com')}</strong>`],
         ['~example.com~', `<del>${anchor('example.com')}</del>`],
         ['*[link](https://example.com)*', `<strong>${anchor('https://example.com', 'link')}</strong>`],

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -614,6 +614,63 @@ test('Test wrapped URLs', () => {
     expect(parser.replace(wrappedUrlTestStartString)).toBe(wrappedUrlTestReplacedString);
 });
 
+describe('Test long input candidate parsing', () => {
+    const anchor = (url, label = url) => `<a href="${url.startsWith('http') ? url : `https://${url}`}" target="_blank" rel="noreferrer noopener">${label}</a>`;
+
+    test('autolinks a long domain without parsing the full input as a URL', () => {
+        const domain = `${'a'.repeat(70)}.com`;
+        const prefix = 'a'.repeat(14500);
+        expect(parser.replace(`${prefix} ${domain}`)).toBe(`${prefix} ${anchor(domain)}`);
+    });
+
+    test('preserves the ftps protocol when autolinking a candidate', () => {
+        const input = 'ftps://example.com/file';
+        expect(parser.replace(input)).toBe('<a href="ftps://example.com/file" target="_blank" rel="noreferrer noopener">ftps://example.com/file</a>');
+        expect(parser.replace(input, {shouldKeepRawInput: true})).toBe(
+            '<a href="ftps://example.com/file" data-raw-href="ftps://example.com/file" data-link-variant="auto" target="_blank" rel="noreferrer noopener">ftps://example.com/file</a>',
+        );
+    });
+
+    test.each([
+        ['*example.com*', `<strong>${anchor('example.com')}</strong>`],
+        ['~example.com~', `<del>${anchor('example.com')}</del>`],
+        ['*[link](https://example.com)*', `<strong>${anchor('https://example.com', 'link')}</strong>`],
+        ['~[link](https://example.com)~', `<del>${anchor('https://example.com', 'link')}</del>`],
+        ['*hello [link](https://example.com) after*', `<strong>hello ${anchor('https://example.com', 'link')} after</strong>`],
+        ['~hello [link](https://example.com) after~', `<del>hello ${anchor('https://example.com', 'link')} after</del>`],
+        ['*hello `world` after*', '<strong>hello <code>world</code> after</strong>'],
+        ['~hello `world` after~', '<del>hello <code>world</code> after</del>'],
+        ['*before example.com after*', `<strong>before ${anchor('example.com')} after</strong>`],
+        ['~before example.com after~', `<del>before ${anchor('example.com')} after</del>`],
+    ])('preserves formatting for %s', (input, expected) => {
+        expect(parser.replace(input)).toBe(expected);
+    });
+
+    test.each([
+        ['*bold*', '<strong>bold</strong>'],
+        ['~strikethrough~', '<del>strikethrough</del>'],
+    ])('parses %s after long plain text', (input, expected) => {
+        const prefix = 'a'.repeat(14500);
+        expect(parser.replace(`${prefix} ${input}`)).toBe(`${prefix} ${expected}`);
+    });
+
+    test('preserves raw link data used by live markdown', () => {
+        const input = '*hello [link](https://example.com) and example.com after*';
+        const expected =
+            '<strong>hello <a href="https://example.com" data-raw-href="https://example.com" data-link-variant="labeled" target="_blank" rel="noreferrer noopener">link</a> and ' +
+            '<a href="https://example.com" data-raw-href="example.com" data-link-variant="auto" target="_blank" rel="noreferrer noopener">example.com</a> after</strong>';
+        expect(parser.replace(input, {shouldKeepRawInput: true})).toBe(expected);
+    });
+
+    test.each([
+        ['*_*~*_', '*<em>*~*</em>'],
+        ['*~*~*~', '<strong>~</strong>~*~'],
+        ['_~_/_~*~_', '<em>~</em>/<em>~*~</em>'],
+    ])('preserves existing parsing for overlapping markers in %s', (input, expected) => {
+        expect(parser.replace(input)).toBe(expected);
+    });
+});
+
 test('Test Url, where double quote is not allowed', () => {
     const urlTestStartString =
         '"om https://www.she.com/"\n' +

--- a/__tests__/ExpensiMark-HTML-test.js
+++ b/__tests__/ExpensiMark-HTML-test.js
@@ -631,6 +631,14 @@ describe('Test long input candidate parsing', () => {
         );
     });
 
+    test('autolinks a protocol URL with a dotless host and dotted path', () => {
+        const input = 'http://localhost:3000/foo.app';
+        expect(parser.replace(input)).toBe('<a href="http://localhost:3000/foo.app" target="_blank" rel="noreferrer noopener">http://localhost:3000/foo.app</a>');
+        expect(parser.replace(input, {shouldKeepRawInput: true})).toBe(
+            '<a href="http://localhost:3000/foo.app" data-raw-href="http://localhost:3000/foo.app" data-link-variant="auto" target="_blank" rel="noreferrer noopener">http://localhost:3000/foo.app</a>',
+        );
+    });
+
     test.each([
         ['*example.com*', `<strong>${anchor('example.com')}</strong>`],
         ['~example.com~', `<del>${anchor('example.com')}</del>`],

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -80,6 +80,9 @@ const MARKDOWN_VIDEO_REGEX = new RegExp(
     `\\!(?:\\[([^\\][]*(?:\\[[^\\][]*][^\\][]*)*)])?\\(((${UrlPatterns.MARKDOWN_URL_REGEX})\\.(?:${Constants.CONST.VIDEO_EXTENSIONS.join('|')}))\\)(?![^<]*(<\\/pre>|<\\/code>))`,
     'gi',
 );
+const BOLD_MARKDOWN_REGEX =
+    /(?<!<[^>]*)(\b_|\B)\*(?!(?:<\/em))(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g;
+const STRIKETHROUGH_MARKDOWN_REGEX = /(?<!<[^>]*)\B~((?![\s~])[\s\S]*?[^\s~](?<!\s))~\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g;
 
 const SLACK_SPAN_NEW_LINE_TAG = '<span class="c-mrkdwn__br" data-stringify-type="paragraph-break" style="box-sizing: inherit; display: block; height: unset;"></span>';
 
@@ -128,6 +131,228 @@ function replaceTextWithExtras(text: string, regexp: RegExp, extras: Extras, rep
         return text.replace(regexp, (...args) => replacement(extras, ...args));
     }
     return text.replace(regexp, replacement);
+}
+
+function replaceBoldMarkdown(text: string, regexp: RegExp, replacement: Replacement): string {
+    if (!text.includes('*')) {
+        return text;
+    }
+
+    const starPositions = [];
+    const protectedTags = [];
+    const blockedTagNames = new Set(['a', 'code', 'pre', 'video']);
+    let index = 0;
+
+    while (index < text.length) {
+        if (text[index] === '<') {
+            const tagEnd = text.indexOf('>', index + 1);
+            if (tagEnd === -1) {
+                break;
+            }
+
+            const tag = text.slice(index + 1, tagEnd).trim();
+            const isClosingTag = tag.startsWith('/');
+            const tagName = tag.match(/^\/?\s*([a-z][a-z0-9-]*)/i)?.[1]?.toLowerCase();
+            if (tagName && blockedTagNames.has(tagName)) {
+                if (isClosingTag) {
+                    const matchingTagIndex = protectedTags.lastIndexOf(tagName);
+                    if (matchingTagIndex !== -1) {
+                        protectedTags.splice(matchingTagIndex, 1);
+                    }
+                } else if (!tag.endsWith('/')) {
+                    protectedTags.push(tagName);
+                }
+            }
+
+            index = tagEnd + 1;
+            continue;
+        }
+
+        if (text[index] === '*' && protectedTags.length === 0) {
+            starPositions.push(index);
+        }
+        index++;
+    }
+
+    if (starPositions.length < 2) {
+        return text;
+    }
+
+    const isWordCharacter = (character?: string) => {
+        if (!character) {
+            return false;
+        }
+        const code = character.charCodeAt(0);
+        return character === '_' || (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+    };
+    const canOpen = (position: number) => {
+        const nextCharacter = text[position + 1];
+        if (!nextCharacter || /\s|\*/.test(nextCharacter) || text.startsWith('</em', position + 1)) {
+            return false;
+        }
+
+        const previousCharacter = text[position - 1];
+        if (!isWordCharacter(previousCharacter)) {
+            return true;
+        }
+        return previousCharacter === '_' && !isWordCharacter(text[position - 2]);
+    };
+    const canClose = (position: number) => {
+        const previousCharacter = text[position - 1];
+        return Boolean(previousCharacter && !/\s|\*/.test(previousCharacter) && !isWordCharacter(text[position + 1]));
+    };
+
+    const output = [];
+    const candidateRegex = regexp;
+    let outputStart = 0;
+    let openingPosition;
+
+    for (const starPosition of starPositions) {
+        if (openingPosition === undefined) {
+            openingPosition = canOpen(starPosition) ? starPosition : undefined;
+            continue;
+        }
+        if (!canClose(starPosition)) {
+            continue;
+        }
+
+        const prefixLength = openingPosition > 0 ? 1 : 0;
+        const suffixLength = starPosition + 1 < text.length ? 1 : 0;
+        const candidateStart = openingPosition - prefixLength;
+        const candidateEnd = starPosition + 1 + suffixLength;
+        const candidate = text.slice(candidateStart, candidateEnd);
+        candidateRegex.lastIndex = 0;
+        const candidateMatch = candidateRegex.exec(candidate);
+        if (!candidateMatch) {
+            openingPosition = canOpen(starPosition) ? starPosition : undefined;
+            continue;
+        }
+        candidateRegex.lastIndex = 0;
+        const replacedCandidate = replaceTextWithExtras(candidate, candidateRegex, EXTRAS_DEFAULT, replacement);
+        if (replacedCandidate !== candidate) {
+            const replacedCoreEnd = suffixLength ? replacedCandidate.length - suffixLength : replacedCandidate.length;
+            output.push(text.slice(outputStart, openingPosition));
+            output.push(replacedCandidate.slice(prefixLength, replacedCoreEnd));
+            outputStart = starPosition + 1;
+            openingPosition = undefined;
+            continue;
+        }
+        openingPosition = undefined;
+    }
+
+    if (output.length === 0) {
+        return text;
+    }
+
+    output.push(text.slice(outputStart));
+    return output.join('');
+}
+
+function replaceStrikethroughMarkdown(text: string, regexp: RegExp, replacement: Replacement): string {
+    if (!text.includes('~')) {
+        return text;
+    }
+
+    const tildePositions = [];
+    const protectedTags = [];
+    const blockedTagNames = new Set(['a', 'code', 'pre', 'video']);
+    let index = 0;
+
+    while (index < text.length) {
+        if (text[index] === '<') {
+            const tagEnd = text.indexOf('>', index + 1);
+            if (tagEnd === -1) {
+                break;
+            }
+
+            const tag = text.slice(index + 1, tagEnd).trim();
+            const isClosingTag = tag.startsWith('/');
+            const tagName = tag.match(/^\/?\s*([a-z][a-z0-9-]*)/i)?.[1]?.toLowerCase();
+            if (tagName && blockedTagNames.has(tagName)) {
+                if (isClosingTag) {
+                    const matchingTagIndex = protectedTags.lastIndexOf(tagName);
+                    if (matchingTagIndex !== -1) {
+                        protectedTags.splice(matchingTagIndex, 1);
+                    }
+                } else if (!tag.endsWith('/')) {
+                    protectedTags.push(tagName);
+                }
+            }
+
+            index = tagEnd + 1;
+            continue;
+        }
+
+        if (text[index] === '~' && protectedTags.length === 0) {
+            tildePositions.push(index);
+        }
+        index++;
+    }
+
+    if (tildePositions.length < 2) {
+        return text;
+    }
+
+    const isWordCharacter = (character?: string) => {
+        if (!character) {
+            return false;
+        }
+        const code = character.charCodeAt(0);
+        return character === '_' || (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+    };
+    const canOpen = (position: number) => {
+        const nextCharacter = text[position + 1];
+        return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
+    };
+    const canClose = (position: number) => {
+        const previousCharacter = text[position - 1];
+        return Boolean(previousCharacter && !/\s|~/.test(previousCharacter) && !isWordCharacter(text[position + 1]));
+    };
+
+    const output = [];
+    const candidateRegex = regexp;
+    let outputStart = 0;
+    let openingPosition;
+
+    for (const tildePosition of tildePositions) {
+        if (openingPosition === undefined) {
+            openingPosition = canOpen(tildePosition) ? tildePosition : undefined;
+            continue;
+        }
+        if (!canClose(tildePosition)) {
+            continue;
+        }
+
+        const prefixLength = openingPosition > 0 ? 1 : 0;
+        const suffixLength = tildePosition + 1 < text.length ? 1 : 0;
+        const candidateStart = openingPosition - prefixLength;
+        const candidateEnd = tildePosition + 1 + suffixLength;
+        const candidate = text.slice(candidateStart, candidateEnd);
+        candidateRegex.lastIndex = 0;
+        const candidateMatch = candidateRegex.exec(candidate);
+        if (!candidateMatch) {
+            openingPosition = canOpen(tildePosition) ? tildePosition : undefined;
+            continue;
+        }
+        candidateRegex.lastIndex = 0;
+        const replacedCandidate = replaceTextWithExtras(candidate, candidateRegex, EXTRAS_DEFAULT, replacement);
+        if (replacedCandidate !== candidate) {
+            const replacedCoreEnd = suffixLength ? replacedCandidate.length - suffixLength : replacedCandidate.length;
+            output.push(text.slice(outputStart, openingPosition));
+            output.push(replacedCandidate.slice(prefixLength, replacedCoreEnd));
+            outputStart = tildePosition + 1;
+            openingPosition = undefined;
+            continue;
+        }
+        openingPosition = undefined;
+    }
+
+    if (output.length === 0) {
+        return text;
+    }
+
+    output.push(text.slice(outputStart));
+    return output.join('');
 }
 
 /**
@@ -688,7 +913,7 @@ export default class ExpensiMark {
 
                 process: (textToProcess, replacement) => {
                     const regex = new RegExp(`(?![^<]*>|[^<>]*<\\/(?!h1>))([_*~]*?)${UrlPatterns.MARKDOWN_URL_REGEX}\\1(?!((?:(?!<a).)+)?<\\/a>|[^<]*(<\\/pre>|<\\/code>))`, 'gi');
-                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement as ReplacementFn);
+                    return this.modifyTextForUrlLinks(regex, textToProcess, replacement as ReplacementFn, true);
                 },
 
                 replacement: (_extras, _match, g1, g2) => {
@@ -809,7 +1034,7 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                regex: /(?<!<[^>]*)(\b_|\B)\*(?!(?:<\/em))(?![^<]*(?:<\/pre>|<\/code>|<\/a>|<\/video>))((?![\s*])[\s\S]*?[^\s*](?<!\s))\*\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
+                process: (textToProcess, replacement) => replaceBoldMarkdown(textToProcess, BOLD_MARKDOWN_REGEX, replacement),
                 replacement: (_extras, match, g1, g2) => {
                     if (g1.includes('_')) {
                         return `${g1}<strong>${g2}</strong>`;
@@ -820,7 +1045,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'strikethrough',
-                regex: /(?<!<[^>]*)\B~((?![\s~])[\s\S]*?[^\s~](?<!\s))~\B(?![^<]*>)(?![^<]*(<\/pre>|<\/code>|<\/a>|<\/video>))/g,
+                process: (textToProcess, replacement) => replaceStrikethroughMarkdown(textToProcess, STRIKETHROUGH_MARKDOWN_REGEX, replacement),
                 replacement: (_extras, match, g1) => (g1.includes('</pre>') || containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
             },
             {
@@ -1301,7 +1526,108 @@ export default class ExpensiMark {
     /**
      * Checks matched URLs for validity and replace valid links with html elements
      */
-    modifyTextForUrlLinks(regex: RegExp, textToCheck: string, replacement: ReplacementFn): string {
+    modifyTextForUrlLinks(regex: RegExp, textToCheck: string, replacement: ReplacementFn, shouldScanForUrls = false): string {
+        if (shouldScanForUrls) {
+            const output = [];
+            const candidateRegex = regex;
+            let outputStart = 0;
+            let index = 0;
+            let hostnameRunStart = 0;
+            const isAlphaNumeric = (character: string) => {
+                const code = character.charCodeAt(0);
+                return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+            };
+            const isHostnameCharacter = (character: string) => isAlphaNumeric(character) || character === '-' || character === '.';
+            const isSpace = (character: string) => {
+                const code = character.charCodeAt(0);
+                return code <= 32 || code === 160;
+            };
+
+            while (index < textToCheck.length) {
+                if (textToCheck[index] === '<') {
+                    const tagEnd = textToCheck.indexOf('>', index + 1);
+                    if (tagEnd === -1) {
+                        break;
+                    }
+
+                    let closingTag = '';
+                    if (textToCheck.startsWith('<a ', index) || textToCheck.startsWith('<a>', index)) {
+                        closingTag = '</a>';
+                    } else if (textToCheck.startsWith('<pre', index)) {
+                        closingTag = '</pre>';
+                    } else if (textToCheck.startsWith('<code', index)) {
+                        closingTag = '</code>';
+                    }
+
+                    if (closingTag) {
+                        const closingTagStart = textToCheck.indexOf(closingTag, tagEnd + 1);
+                        index = closingTagStart === -1 ? textToCheck.length : closingTagStart + closingTag.length;
+                    } else {
+                        index = tagEnd + 1;
+                    }
+                    hostnameRunStart = index;
+                    continue;
+                }
+
+                if (!isHostnameCharacter(textToCheck[index])) {
+                    hostnameRunStart = index + 1;
+                    index++;
+                    continue;
+                }
+                if (textToCheck[index] !== '.') {
+                    index++;
+                    continue;
+                }
+
+                const hostnameStart = hostnameRunStart;
+                let tldEnd = index + 1;
+                while (tldEnd < textToCheck.length && (isAlphaNumeric(textToCheck[tldEnd]) || textToCheck[tldEnd] === '-')) {
+                    tldEnd++;
+                }
+                if (hostnameStart === index || tldEnd === index + 1) {
+                    index++;
+                    continue;
+                }
+
+                let candidateStart = hostnameStart;
+                const protocol = textToCheck.slice(Math.max(0, hostnameStart - 8), hostnameStart).toLowerCase();
+                if (protocol.endsWith('https://')) {
+                    candidateStart = hostnameStart - 8;
+                } else if (protocol.endsWith('http://')) {
+                    candidateStart = hostnameStart - 7;
+                } else if (protocol.endsWith('ftps://')) {
+                    candidateStart = hostnameStart - 7;
+                } else if (protocol.endsWith('ftp://')) {
+                    candidateStart = hostnameStart - 6;
+                }
+                if (candidateStart > 0 && textToCheck[candidateStart - 1] === '@') {
+                    candidateStart--;
+                }
+                while (candidateStart > 0 && '_*~'.includes(textToCheck[candidateStart - 1])) {
+                    candidateStart--;
+                }
+
+                let candidateEnd = tldEnd;
+                while (candidateEnd < textToCheck.length && !isSpace(textToCheck[candidateEnd]) && textToCheck[candidateEnd] !== '<') {
+                    candidateEnd++;
+                }
+
+                const candidate = textToCheck.slice(candidateStart, candidateEnd);
+                candidateRegex.lastIndex = 0;
+                output.push(textToCheck.slice(outputStart, candidateStart));
+                output.push(this.modifyTextForUrlLinks(candidateRegex, candidate, replacement));
+                outputStart = candidateEnd;
+                index = candidateEnd;
+                hostnameRunStart = candidateEnd;
+            }
+
+            if (output.length === 0) {
+                return textToCheck;
+            }
+            output.push(textToCheck.slice(outputStart));
+            return output.join('');
+        }
+
         let match = regex.exec(textToCheck);
         let replacedText = '';
         let startIndex = 0;

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -192,13 +192,13 @@ function canOpenStrikethroughMarkdown(text: string, position: number): boolean {
     }
 
     const nextCharacter = text[position + 1];
-    return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
+    return !!nextCharacter && !/\s|~/.test(nextCharacter);
 }
 
 /** Returns whether the marker at this position can close a bold or strikethrough range. */
 function canCloseMarkdown(text: string, position: number, marker: '*' | '~'): boolean {
     const previousCharacter = text[position - 1];
-    return Boolean(previousCharacter && !/\s/.test(previousCharacter) && previousCharacter !== marker && !isWordCharacter(text[position + 1]));
+    return !!previousCharacter && !/\s/.test(previousCharacter) && previousCharacter !== marker && !isWordCharacter(text[position + 1]);
 }
 
 /** Records when scanning enters or leaves <a>, <code>, <pre>, or <video>, then returns the character after the tag. */
@@ -227,7 +227,7 @@ function updateProtectedTagStack(text: string, tagStart: number, protectedTags: 
 
 /** Returns whether the character can be part of a hostname such as example.com. */
 function isHostnameCharacter(character?: string): boolean {
-    return Boolean(character && (isAsciiAlphaNumeric(character) || character === '-' || character === '.'));
+    return !!character && (isAsciiAlphaNumeric(character) || character === '-' || character === '.');
 }
 
 /** Returns whether the character is whitespace that ends a possible URL. */

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -45,12 +45,15 @@ const ASCII_LOWERCASE_END = 'z'.charCodeAt(0);
 const ASCII_WHITESPACE_END = ' '.charCodeAt(0);
 const NON_BREAKING_SPACE_CODE = 160;
 const URL_PROTOCOLS = ['https://', 'http://', 'ftps://', 'ftp://'] as const;
+const URL_CANDIDATE_PREFIX_CHARACTERS = '@_*~';
 const PROTECTED_TAG_NAMES = new Set(['a', 'code', 'pre', 'video']);
 
 type ReplacementFn = (extras: Extras, ...matches: string[]) => string;
 type Replacement = ReplacementFn | string;
 type ProcessFn = (textToProcess: string, replacement: Replacement, shouldKeepRawInput: boolean) => string;
 type UrlCandidate = {start: number; end: number};
+type MarkdownMarker = {position: number; isProtected: boolean};
+type CanOpenMarkdown = (text: string, position: number, isProtected: boolean) => boolean;
 
 type CommonRule = {
     name: string;
@@ -162,7 +165,11 @@ function isWordCharacter(character?: string): boolean {
     return character === '_' || isAsciiAlphaNumeric(character);
 }
 
-function canOpenBoldMarkdown(text: string, position: number): boolean {
+function canOpenBoldMarkdown(text: string, position: number, isProtected: boolean): boolean {
+    if (isProtected) {
+        return false;
+    }
+
     const nextCharacter = text[position + 1];
     if (!nextCharacter || /\s|\*/.test(nextCharacter) || text.startsWith('</em', position + 1)) {
         return false;
@@ -176,6 +183,10 @@ function canOpenBoldMarkdown(text: string, position: number): boolean {
 }
 
 function canOpenStrikethroughMarkdown(text: string, position: number): boolean {
+    if (isWordCharacter(text[position - 1])) {
+        return false;
+    }
+
     const nextCharacter = text[position + 1];
     return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
 }
@@ -236,13 +247,10 @@ function findHostnameEnd(text: string, hostnameStart: number, dotPosition: numbe
     return hostnameEnd;
 }
 
-// Expands example.com to include nearby @, *, _, or ~, plus its path, until whitespace or HTML.
+// Expands example.com to include nearby @, *, _, or ~ in any order, plus its path, until whitespace or HTML.
 function extendUrlCandidateBoundaries(text: string, start: number, end: number): UrlCandidate {
     let candidateStart = start;
-    if (candidateStart > 0 && text[candidateStart - 1] === '@') {
-        candidateStart--;
-    }
-    while (candidateStart > 0 && '_*~'.includes(text[candidateStart - 1])) {
+    while (candidateStart > 0 && URL_CANDIDATE_PREFIX_CHARACTERS.includes(text[candidateStart - 1])) {
         candidateStart--;
     }
 
@@ -310,12 +318,12 @@ function findUrlCandidates(text: string): UrlCandidate[] {
     return candidates;
 }
 
-function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Replacement, marker: '*' | '~', canOpen: (text: string, position: number) => boolean): string {
+function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Replacement, marker: '*' | '~', canOpen: CanOpenMarkdown): string {
     if (!text.includes(marker)) {
         return text;
     }
 
-    const markerPositions = [];
+    const markers: MarkdownMarker[] = [];
     const protectedTags: string[] = [];
     let index = 0;
 
@@ -329,13 +337,14 @@ function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Re
             continue;
         }
 
-        if (text[index] === marker && protectedTags.length === 0) {
-            markerPositions.push(index);
+        // Keep protected markers in order, but remember that they cannot be replaced.
+        if (text[index] === marker) {
+            markers.push({position: index, isProtected: protectedTags.length > 0});
         }
         index++;
     }
 
-    if (markerPositions.length < 2) {
+    if (markers.length < 2) {
         return text;
     }
 
@@ -347,17 +356,24 @@ function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Re
     const output = [];
     const candidateRegex = regexp;
     let outputStart = 0;
-    let openingPosition;
+    let openingMarker: MarkdownMarker | undefined;
 
-    for (const markerPosition of markerPositions) {
-        if (openingPosition === undefined) {
-            openingPosition = canOpen(text, markerPosition) ? markerPosition : undefined;
+    for (const currentMarker of markers) {
+        const markerPosition = currentMarker.position;
+        if (openingMarker === undefined) {
+            openingMarker = canOpen(text, markerPosition, currentMarker.isProtected) ? currentMarker : undefined;
             continue;
         }
-        if (!canClose(markerPosition)) {
+        if (currentMarker.isProtected || !canClose(markerPosition)) {
             continue;
         }
 
+        if (openingMarker.isProtected) {
+            openingMarker = undefined;
+            continue;
+        }
+
+        const openingPosition = openingMarker.position;
         const prefixLength = openingPosition > 0 ? 1 : 0;
         const suffixLength = markerPosition + 1 < text.length ? 1 : 0;
         const candidateStart = openingPosition - prefixLength;
@@ -366,7 +382,7 @@ function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Re
         candidateRegex.lastIndex = 0;
         const candidateMatch = candidateRegex.exec(candidate);
         if (!candidateMatch) {
-            openingPosition = canOpen(text, markerPosition) ? markerPosition : undefined;
+            openingMarker = canOpen(text, markerPosition, currentMarker.isProtected) ? currentMarker : undefined;
             continue;
         }
         candidateRegex.lastIndex = 0;
@@ -376,10 +392,10 @@ function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Re
             output.push(text.slice(outputStart, openingPosition));
             output.push(replacedCandidate.slice(prefixLength, replacedCoreEnd));
             outputStart = markerPosition + 1;
-            openingPosition = undefined;
+            openingMarker = undefined;
             continue;
         }
-        openingPosition = undefined;
+        openingMarker = undefined;
     }
 
     if (output.length === 0) {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -1455,6 +1455,8 @@ export default class ExpensiMark {
                 const code = character.charCodeAt(0);
                 return code <= 32 || code === 160;
             };
+            // Move left over @, *, _, and ~ so the existing URL regex receives the full
+            // surrounding text, such as *example.com* or @example.com.
             const getCandidateStart = (start: number) => {
                 let candidateStart = start;
                 if (candidateStart > 0 && textToCheck[candidateStart - 1] === '@') {
@@ -1465,7 +1467,11 @@ export default class ExpensiMark {
                 }
                 return candidateStart;
             };
+            // Check for a supported protocol before looking for a dot. This keeps URLs
+            // such as http://localhost:3000/foo.app as one candidate.
             const getProtocolAt = (position: number) => URL_PROTOCOLS.find((protocol) => textToCheck.slice(position, position + protocol.length).toLowerCase() === protocol);
+            // Extract one candidate, pass it to the existing URL replacement code, and move
+            // every scanner position past it so it is not scanned again.
             const processUrlCandidate = (candidateStart: number, candidateEnd: number) => {
                 const candidate = textToCheck.slice(candidateStart, candidateEnd);
                 candidateRegex.lastIndex = 0;

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -148,6 +148,7 @@ function replaceTextWithExtras(text: string, regexp: RegExp, extras: Extras, rep
     return text.replace(regexp, replacement);
 }
 
+/** Returns whether the character is an ASCII letter or digit. */
 function isAsciiAlphaNumeric(character?: string): boolean {
     if (!character) {
         return false;
@@ -161,10 +162,12 @@ function isAsciiAlphaNumeric(character?: string): boolean {
     );
 }
 
+/** Returns whether the character is an ASCII letter, digit, or underscore. */
 function isWordCharacter(character?: string): boolean {
     return character === '_' || isAsciiAlphaNumeric(character);
 }
 
+/** Returns whether the marker at this position can open a bold range. */
 function canOpenBoldMarkdown(text: string, position: number, isProtected: boolean): boolean {
     if (isProtected) {
         return false;
@@ -182,6 +185,7 @@ function canOpenBoldMarkdown(text: string, position: number, isProtected: boolea
     return previousCharacter === '_' && !isWordCharacter(text[position - 2]);
 }
 
+/** Returns whether the marker at this position can open a strikethrough range. */
 function canOpenStrikethroughMarkdown(text: string, position: number): boolean {
     if (isWordCharacter(text[position - 1])) {
         return false;
@@ -191,7 +195,13 @@ function canOpenStrikethroughMarkdown(text: string, position: number): boolean {
     return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
 }
 
-// Records when scanning enters or leaves <a>, <code>, <pre>, or <video>, then returns the character after the tag.
+/** Returns whether the marker at this position can close a bold or strikethrough range. */
+function canCloseMarkdown(text: string, position: number, marker: '*' | '~'): boolean {
+    const previousCharacter = text[position - 1];
+    return Boolean(previousCharacter && !/\s/.test(previousCharacter) && previousCharacter !== marker && !isWordCharacter(text[position + 1]));
+}
+
+/** Records when scanning enters or leaves <a>, <code>, <pre>, or <video>, then returns the character after the tag. */
 function updateProtectedTagStack(text: string, tagStart: number, protectedTags: string[]): number | undefined {
     const tagEnd = text.indexOf('>', tagStart + 1);
     if (tagEnd === -1) {
@@ -215,18 +225,18 @@ function updateProtectedTagStack(text: string, tagStart: number, protectedTags: 
     return tagEnd + 1;
 }
 
-// Allows letters, numbers, '-', and '.' because they can appear in a domain such as example.com.
+/** Returns whether the character can be part of a hostname such as example.com. */
 function isHostnameCharacter(character?: string): boolean {
     return Boolean(character && (isAsciiAlphaNumeric(character) || character === '-' || character === '.'));
 }
 
-// Returns true when whitespace marks the end of the possible URL.
+/** Returns whether the character is whitespace that ends a possible URL. */
 function isUrlBoundarySpace(character: string): boolean {
     const code = character.charCodeAt(0);
     return code <= ASCII_WHITESPACE_END || code === NON_BREAKING_SPACE_CODE;
 }
 
-// Checks for http://, https://, ftp://, or ftps:// starting at this position.
+/** Returns the supported URL protocol that starts at this position, if one exists. */
 function getProtocolAt(text: string, position: number) {
     const firstCharacter = text[position]?.toLowerCase();
     if (firstCharacter !== 'h' && firstCharacter !== 'f') {
@@ -235,7 +245,7 @@ function getProtocolAt(text: string, position: number) {
     return URL_PROTOCOLS.find((protocol) => text.slice(position, position + protocol.length).toLowerCase() === protocol);
 }
 
-// Reads the text after the dot in example.com and returns where the hostname ends.
+/** Reads the text after the dot in example.com and returns where the hostname ends. */
 function findHostnameEnd(text: string, hostnameStart: number, dotPosition: number): number | undefined {
     let hostnameEnd = dotPosition + 1;
     while (hostnameEnd < text.length && (isAsciiAlphaNumeric(text[hostnameEnd]) || text[hostnameEnd] === '-')) {
@@ -247,7 +257,7 @@ function findHostnameEnd(text: string, hostnameStart: number, dotPosition: numbe
     return hostnameEnd;
 }
 
-// Expands example.com to include nearby @, *, _, or ~ in any order, plus its path, until whitespace or HTML.
+/** Expands example.com to include nearby @, *, _, or ~ in any order, plus its path, until whitespace or HTML. */
 function extendUrlCandidateBoundaries(text: string, start: number, end: number): UrlCandidate {
     let candidateStart = start;
     while (candidateStart > 0 && URL_CANDIDATE_PREFIX_CHARACTERS.includes(text[candidateStart - 1])) {
@@ -261,7 +271,7 @@ function extendUrlCandidateBoundaries(text: string, start: number, end: number):
     return {start: candidateStart, end: candidateEnd};
 }
 
-// Finds possible URL ranges, skips URL-looking text inside protected tags, and leaves validity to the existing regex.
+/** Finds possible URL ranges, skips URL-looking text inside protected tags, and leaves validity to the existing regex. */
 function findUrlCandidates(text: string): UrlCandidate[] {
     const candidates: UrlCandidate[] = [];
     const protectedTags: string[] = [];
@@ -318,6 +328,7 @@ function findUrlCandidates(text: string): UrlCandidate[] {
     return candidates;
 }
 
+/** Finds possible bold or strikethrough pairs, preserves marker order inside protected tags, and runs the existing regex only on each candidate. */
 function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Replacement, marker: '*' | '~', canOpen: CanOpenMarkdown): string {
     if (!text.includes(marker)) {
         return text;
@@ -344,14 +355,10 @@ function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Re
         index++;
     }
 
+    // A Markdown range needs both an opening and closing marker, such as the two * characters in *bold*.
     if (markers.length < 2) {
         return text;
     }
-
-    const canClose = (position: number) => {
-        const previousCharacter = text[position - 1];
-        return Boolean(previousCharacter && !/\s/.test(previousCharacter) && previousCharacter !== marker && !isWordCharacter(text[position + 1]));
-    };
 
     const output = [];
     const candidateRegex = regexp;
@@ -364,7 +371,7 @@ function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Re
             openingMarker = canOpen(text, markerPosition, currentMarker.isProtected) ? currentMarker : undefined;
             continue;
         }
-        if (currentMarker.isProtected || !canClose(markerPosition)) {
+        if (currentMarker.isProtected || !canCloseMarkdown(text, markerPosition, marker)) {
             continue;
         }
 

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -1455,6 +1455,26 @@ export default class ExpensiMark {
                 const code = character.charCodeAt(0);
                 return code <= 32 || code === 160;
             };
+            const getCandidateStart = (start: number) => {
+                let candidateStart = start;
+                if (candidateStart > 0 && textToCheck[candidateStart - 1] === '@') {
+                    candidateStart--;
+                }
+                while (candidateStart > 0 && '_*~'.includes(textToCheck[candidateStart - 1])) {
+                    candidateStart--;
+                }
+                return candidateStart;
+            };
+            const getProtocolAt = (position: number) => URL_PROTOCOLS.find((protocol) => textToCheck.slice(position, position + protocol.length).toLowerCase() === protocol);
+            const processUrlCandidate = (candidateStart: number, candidateEnd: number) => {
+                const candidate = textToCheck.slice(candidateStart, candidateEnd);
+                candidateRegex.lastIndex = 0;
+                output.push(textToCheck.slice(outputStart, candidateStart));
+                output.push(this.modifyTextForUrlLinks(candidateRegex, candidate, replacement));
+                outputStart = candidateEnd;
+                index = candidateEnd;
+                hostnameRunStart = candidateEnd;
+            };
 
             while (index < textToCheck.length) {
                 if (textToCheck[index] === '<') {
@@ -1482,6 +1502,22 @@ export default class ExpensiMark {
                     continue;
                 }
 
+                const currentCharacter = textToCheck[index];
+                if (currentCharacter === 'h' || currentCharacter === 'H' || currentCharacter === 'f' || currentCharacter === 'F') {
+                    const matchedProtocol = getProtocolAt(index);
+                    if (matchedProtocol) {
+                        const candidateStart = getCandidateStart(index);
+
+                        let candidateEnd = index + matchedProtocol.length;
+                        while (candidateEnd < textToCheck.length && !isSpace(textToCheck[candidateEnd]) && textToCheck[candidateEnd] !== '<') {
+                            candidateEnd++;
+                        }
+
+                        processUrlCandidate(candidateStart, candidateEnd);
+                        continue;
+                    }
+                }
+
                 if (!isHostnameCharacter(textToCheck[index])) {
                     hostnameRunStart = index + 1;
                     index++;
@@ -1502,34 +1538,14 @@ export default class ExpensiMark {
                     continue;
                 }
 
-                let candidateStart = hostnameStart;
-                // // Include a protocol such as "https://" so the existing URL regex sees the full URL.
-                const matchedProtocol = URL_PROTOCOLS.find((protocol) => {
-                    const protocolStart = hostnameStart - protocol.length;
-                    return protocolStart >= 0 && textToCheck.slice(protocolStart, hostnameStart).toLowerCase() === protocol;
-                });
-                if (matchedProtocol) {
-                    candidateStart = hostnameStart - matchedProtocol.length;
-                }
-                if (candidateStart > 0 && textToCheck[candidateStart - 1] === '@') {
-                    candidateStart--;
-                }
-                while (candidateStart > 0 && '_*~'.includes(textToCheck[candidateStart - 1])) {
-                    candidateStart--;
-                }
+                const candidateStart = getCandidateStart(hostnameStart);
 
                 let candidateEnd = tldEnd;
                 while (candidateEnd < textToCheck.length && !isSpace(textToCheck[candidateEnd]) && textToCheck[candidateEnd] !== '<') {
                     candidateEnd++;
                 }
 
-                const candidate = textToCheck.slice(candidateStart, candidateEnd);
-                candidateRegex.lastIndex = 0;
-                output.push(textToCheck.slice(outputStart, candidateStart));
-                output.push(this.modifyTextForUrlLinks(candidateRegex, candidate, replacement));
-                outputStart = candidateEnd;
-                index = candidateEnd;
-                hostnameRunStart = candidateEnd;
+                processUrlCandidate(candidateStart, candidateEnd);
             }
 
             if (output.length === 0) {

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -43,6 +43,7 @@ const ASCII_UPPERCASE_END = 'Z'.charCodeAt(0);
 const ASCII_LOWERCASE_START = 'a'.charCodeAt(0);
 const ASCII_LOWERCASE_END = 'z'.charCodeAt(0);
 const URL_PROTOCOLS = ['https://', 'http://', 'ftps://', 'ftp://'] as const;
+const PROTECTED_TAG_NAMES = new Set(['a', 'code', 'pre', 'video']);
 
 type ReplacementFn = (extras: Extras, ...matches: string[]) => string;
 type Replacement = ReplacementFn | string;
@@ -176,38 +177,45 @@ function canOpenStrikethroughMarkdown(text: string, position: number): boolean {
     return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
 }
 
+function updateProtectedTagStack(text: string, tagStart: number, protectedTags: string[]): number | undefined {
+    const tagEnd = text.indexOf('>', tagStart + 1);
+    if (tagEnd === -1) {
+        return undefined;
+    }
+
+    const tag = text.slice(tagStart + 1, tagEnd).trim();
+    const isClosingTag = tag.startsWith('/');
+    const tagName = tag.match(/^\/?\s*([a-z][a-z0-9-]*)/i)?.[1]?.toLowerCase();
+    if (tagName && PROTECTED_TAG_NAMES.has(tagName)) {
+        if (isClosingTag) {
+            const matchingTagIndex = protectedTags.lastIndexOf(tagName);
+            if (matchingTagIndex !== -1) {
+                protectedTags.splice(matchingTagIndex, 1);
+            }
+        } else if (!tag.endsWith('/')) {
+            protectedTags.push(tagName);
+        }
+    }
+
+    return tagEnd + 1;
+}
+
 function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Replacement, marker: '*' | '~', canOpen: (text: string, position: number) => boolean): string {
     if (!text.includes(marker)) {
         return text;
     }
 
     const markerPositions = [];
-    const protectedTags = [];
-    const blockedTagNames = new Set(['a', 'code', 'pre', 'video']);
+    const protectedTags: string[] = [];
     let index = 0;
 
     while (index < text.length) {
         if (text[index] === '<') {
-            const tagEnd = text.indexOf('>', index + 1);
-            if (tagEnd === -1) {
+            const nextIndex = updateProtectedTagStack(text, index, protectedTags);
+            if (nextIndex === undefined) {
                 break;
             }
-
-            const tag = text.slice(index + 1, tagEnd).trim();
-            const isClosingTag = tag.startsWith('/');
-            const tagName = tag.match(/^\/?\s*([a-z][a-z0-9-]*)/i)?.[1]?.toLowerCase();
-            if (tagName && blockedTagNames.has(tagName)) {
-                if (isClosingTag) {
-                    const matchingTagIndex = protectedTags.lastIndexOf(tagName);
-                    if (matchingTagIndex !== -1) {
-                        protectedTags.splice(matchingTagIndex, 1);
-                    }
-                } else if (!tag.endsWith('/')) {
-                    protectedTags.push(tagName);
-                }
-            }
-
-            index = tagEnd + 1;
+            index = nextIndex;
             continue;
         }
 
@@ -1450,6 +1458,7 @@ export default class ExpensiMark {
             let outputStart = 0;
             let index = 0;
             let hostnameRunStart = 0;
+            const protectedTags: string[] = [];
             const isHostnameCharacter = (character: string) => isAsciiAlphaNumeric(character) || character === '-' || character === '.';
             const isSpace = (character: string) => {
                 const code = character.charCodeAt(0);
@@ -1484,26 +1493,16 @@ export default class ExpensiMark {
 
             while (index < textToCheck.length) {
                 if (textToCheck[index] === '<') {
-                    const tagEnd = textToCheck.indexOf('>', index + 1);
-                    if (tagEnd === -1) {
+                    const nextIndex = updateProtectedTagStack(textToCheck, index, protectedTags);
+                    if (nextIndex === undefined) {
                         break;
                     }
-
-                    let closingTag = '';
-                    if (textToCheck.startsWith('<a ', index) || textToCheck.startsWith('<a>', index)) {
-                        closingTag = '</a>';
-                    } else if (textToCheck.startsWith('<pre', index)) {
-                        closingTag = '</pre>';
-                    } else if (textToCheck.startsWith('<code', index)) {
-                        closingTag = '</code>';
-                    }
-
-                    if (closingTag) {
-                        const closingTagStart = textToCheck.indexOf(closingTag, tagEnd + 1);
-                        index = closingTagStart === -1 ? textToCheck.length : closingTagStart + closingTag.length;
-                    } else {
-                        index = tagEnd + 1;
-                    }
+                    index = nextIndex;
+                    hostnameRunStart = index;
+                    continue;
+                }
+                if (protectedTags.length > 0) {
+                    index++;
                     hostnameRunStart = index;
                     continue;
                 }

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -42,6 +42,8 @@ const ASCII_UPPERCASE_START = 'A'.charCodeAt(0);
 const ASCII_UPPERCASE_END = 'Z'.charCodeAt(0);
 const ASCII_LOWERCASE_START = 'a'.charCodeAt(0);
 const ASCII_LOWERCASE_END = 'z'.charCodeAt(0);
+const ASCII_WHITESPACE_END = ' '.charCodeAt(0);
+const NON_BREAKING_SPACE_CODE = 160;
 const URL_PROTOCOLS = ['https://', 'http://', 'ftps://', 'ftp://'] as const;
 const PROTECTED_TAG_NAMES = new Set(['a', 'code', 'pre', 'video']);
 
@@ -210,7 +212,7 @@ function isHostnameCharacter(character?: string): boolean {
 // Returns true when whitespace marks the end of the possible URL.
 function isUrlBoundarySpace(character: string): boolean {
     const code = character.charCodeAt(0);
-    return code <= 32 || code === 160;
+    return code <= ASCII_WHITESPACE_END || code === NON_BREAKING_SPACE_CODE;
 }
 
 // Checks for http://, https://, ftp://, or ftps:// starting at this position.

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -35,6 +35,14 @@ type Extras = {
 export type {Extras};
 
 const EXTRAS_DEFAULT = {};
+// These constants represent the ASCII ranges for digits (0-9) and letters (A-Z, a-z).
+const ASCII_DIGIT_START = '0'.charCodeAt(0);
+const ASCII_DIGIT_END = '9'.charCodeAt(0);
+const ASCII_UPPERCASE_START = 'A'.charCodeAt(0);
+const ASCII_UPPERCASE_END = 'Z'.charCodeAt(0);
+const ASCII_LOWERCASE_START = 'a'.charCodeAt(0);
+const ASCII_LOWERCASE_END = 'z'.charCodeAt(0);
+const URL_PROTOCOLS = ['https://', 'http://', 'ftps://', 'ftp://'] as const;
 
 type ReplacementFn = (extras: Extras, ...matches: string[]) => string;
 type Replacement = ReplacementFn | string;
@@ -133,12 +141,21 @@ function replaceTextWithExtras(text: string, regexp: RegExp, extras: Extras, rep
     return text.replace(regexp, replacement);
 }
 
-function isWordCharacter(character?: string): boolean {
+function isAsciiAlphaNumeric(character?: string): boolean {
     if (!character) {
         return false;
     }
+
     const code = character.charCodeAt(0);
-    return character === '_' || (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+    return (
+        (code >= ASCII_DIGIT_START && code <= ASCII_DIGIT_END) ||
+        (code >= ASCII_UPPERCASE_START && code <= ASCII_UPPERCASE_END) ||
+        (code >= ASCII_LOWERCASE_START && code <= ASCII_LOWERCASE_END)
+    );
+}
+
+function isWordCharacter(character?: string): boolean {
+    return character === '_' || isAsciiAlphaNumeric(character);
 }
 
 function canOpenBoldMarkdown(text: string, position: number): boolean {
@@ -1433,11 +1450,7 @@ export default class ExpensiMark {
             let outputStart = 0;
             let index = 0;
             let hostnameRunStart = 0;
-            const isAlphaNumeric = (character: string) => {
-                const code = character.charCodeAt(0);
-                return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
-            };
-            const isHostnameCharacter = (character: string) => isAlphaNumeric(character) || character === '-' || character === '.';
+            const isHostnameCharacter = (character: string) => isAsciiAlphaNumeric(character) || character === '-' || character === '.';
             const isSpace = (character: string) => {
                 const code = character.charCodeAt(0);
                 return code <= 32 || code === 160;
@@ -1481,7 +1494,7 @@ export default class ExpensiMark {
 
                 const hostnameStart = hostnameRunStart;
                 let tldEnd = index + 1;
-                while (tldEnd < textToCheck.length && (isAlphaNumeric(textToCheck[tldEnd]) || textToCheck[tldEnd] === '-')) {
+                while (tldEnd < textToCheck.length && (isAsciiAlphaNumeric(textToCheck[tldEnd]) || textToCheck[tldEnd] === '-')) {
                     tldEnd++;
                 }
                 if (hostnameStart === index || tldEnd === index + 1) {
@@ -1490,15 +1503,13 @@ export default class ExpensiMark {
                 }
 
                 let candidateStart = hostnameStart;
-                const protocol = textToCheck.slice(Math.max(0, hostnameStart - 8), hostnameStart).toLowerCase();
-                if (protocol.endsWith('https://')) {
-                    candidateStart = hostnameStart - 8;
-                } else if (protocol.endsWith('http://')) {
-                    candidateStart = hostnameStart - 7;
-                } else if (protocol.endsWith('ftps://')) {
-                    candidateStart = hostnameStart - 7;
-                } else if (protocol.endsWith('ftp://')) {
-                    candidateStart = hostnameStart - 6;
+                // // Include a protocol such as "https://" so the existing URL regex sees the full URL.
+                const matchedProtocol = URL_PROTOCOLS.find((protocol) => {
+                    const protocolStart = hostnameStart - protocol.length;
+                    return protocolStart >= 0 && textToCheck.slice(protocolStart, hostnameStart).toLowerCase() === protocol;
+                });
+                if (matchedProtocol) {
+                    candidateStart = hostnameStart - matchedProtocol.length;
                 }
                 if (candidateStart > 0 && textToCheck[candidateStart - 1] === '@') {
                     candidateStart--;

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -48,6 +48,7 @@ const PROTECTED_TAG_NAMES = new Set(['a', 'code', 'pre', 'video']);
 type ReplacementFn = (extras: Extras, ...matches: string[]) => string;
 type Replacement = ReplacementFn | string;
 type ProcessFn = (textToProcess: string, replacement: Replacement, shouldKeepRawInput: boolean) => string;
+type UrlCandidate = {start: number; end: number};
 
 type CommonRule = {
     name: string;
@@ -177,6 +178,7 @@ function canOpenStrikethroughMarkdown(text: string, position: number): boolean {
     return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
 }
 
+// Records when scanning enters or leaves <a>, <code>, <pre>, or <video>, then returns the character after the tag.
 function updateProtectedTagStack(text: string, tagStart: number, protectedTags: string[]): number | undefined {
     const tagEnd = text.indexOf('>', tagStart + 1);
     if (tagEnd === -1) {
@@ -198,6 +200,112 @@ function updateProtectedTagStack(text: string, tagStart: number, protectedTags: 
     }
 
     return tagEnd + 1;
+}
+
+// Allows letters, numbers, '-', and '.' because they can appear in a domain such as example.com.
+function isHostnameCharacter(character?: string): boolean {
+    return Boolean(character && (isAsciiAlphaNumeric(character) || character === '-' || character === '.'));
+}
+
+// Returns true when whitespace marks the end of the possible URL.
+function isUrlBoundarySpace(character: string): boolean {
+    const code = character.charCodeAt(0);
+    return code <= 32 || code === 160;
+}
+
+// Checks for http://, https://, ftp://, or ftps:// starting at this position.
+function getProtocolAt(text: string, position: number) {
+    const firstCharacter = text[position]?.toLowerCase();
+    if (firstCharacter !== 'h' && firstCharacter !== 'f') {
+        return undefined;
+    }
+    return URL_PROTOCOLS.find((protocol) => text.slice(position, position + protocol.length).toLowerCase() === protocol);
+}
+
+// Reads the text after the dot in example.com and returns where the hostname ends.
+function findHostnameEnd(text: string, hostnameStart: number, dotPosition: number): number | undefined {
+    let hostnameEnd = dotPosition + 1;
+    while (hostnameEnd < text.length && (isAsciiAlphaNumeric(text[hostnameEnd]) || text[hostnameEnd] === '-')) {
+        hostnameEnd++;
+    }
+    if (hostnameStart === dotPosition || hostnameEnd === dotPosition + 1) {
+        return undefined;
+    }
+    return hostnameEnd;
+}
+
+// Expands example.com to include nearby @, *, _, or ~, plus its path, until whitespace or HTML.
+function extendUrlCandidateBoundaries(text: string, start: number, end: number): UrlCandidate {
+    let candidateStart = start;
+    if (candidateStart > 0 && text[candidateStart - 1] === '@') {
+        candidateStart--;
+    }
+    while (candidateStart > 0 && '_*~'.includes(text[candidateStart - 1])) {
+        candidateStart--;
+    }
+
+    let candidateEnd = end;
+    while (candidateEnd < text.length && !isUrlBoundarySpace(text[candidateEnd]) && text[candidateEnd] !== '<') {
+        candidateEnd++;
+    }
+    return {start: candidateStart, end: candidateEnd};
+}
+
+// Finds possible URL ranges, skips URL-looking text inside protected tags, and leaves validity to the existing regex.
+function findUrlCandidates(text: string): UrlCandidate[] {
+    const candidates: UrlCandidate[] = [];
+    const protectedTags: string[] = [];
+    let index = 0;
+    let hostnameRunStart = 0;
+
+    while (index < text.length) {
+        if (text[index] === '<') {
+            const nextIndex = updateProtectedTagStack(text, index, protectedTags);
+            if (nextIndex === undefined) {
+                break;
+            }
+            index = nextIndex;
+            hostnameRunStart = index;
+            continue;
+        }
+        if (protectedTags.length > 0) {
+            index++;
+            hostnameRunStart = index;
+            continue;
+        }
+
+        const matchedProtocol = getProtocolAt(text, index);
+        if (matchedProtocol) {
+            const candidate = extendUrlCandidateBoundaries(text, index, index + matchedProtocol.length);
+            candidates.push(candidate);
+            index = candidate.end;
+            hostnameRunStart = candidate.end;
+            continue;
+        }
+
+        if (!isHostnameCharacter(text[index])) {
+            hostnameRunStart = index + 1;
+            index++;
+            continue;
+        }
+        if (text[index] !== '.') {
+            index++;
+            continue;
+        }
+
+        const hostnameEnd = findHostnameEnd(text, hostnameRunStart, index);
+        if (hostnameEnd === undefined) {
+            index++;
+            continue;
+        }
+
+        const candidate = extendUrlCandidateBoundaries(text, hostnameRunStart, hostnameEnd);
+        candidates.push(candidate);
+        index = candidate.end;
+        hostnameRunStart = candidate.end;
+    }
+
+    return candidates;
 }
 
 function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Replacement, marker: '*' | '~', canOpen: (text: string, position: number) => boolean): string {
@@ -1453,109 +1561,23 @@ export default class ExpensiMark {
      */
     modifyTextForUrlLinks(regex: RegExp, textToCheck: string, replacement: ReplacementFn, shouldScanForUrls = false): string {
         if (shouldScanForUrls) {
+            const candidates = findUrlCandidates(textToCheck);
+            if (candidates.length === 0) {
+                return textToCheck;
+            }
+
             const output = [];
             const candidateRegex = regex;
             let outputStart = 0;
-            let index = 0;
-            let hostnameRunStart = 0;
-            const protectedTags: string[] = [];
-            const isHostnameCharacter = (character: string) => isAsciiAlphaNumeric(character) || character === '-' || character === '.';
-            const isSpace = (character: string) => {
-                const code = character.charCodeAt(0);
-                return code <= 32 || code === 160;
-            };
-            // Move left over @, *, _, and ~ so the existing URL regex receives the full
-            // surrounding text, such as *example.com* or @example.com.
-            const getCandidateStart = (start: number) => {
-                let candidateStart = start;
-                if (candidateStart > 0 && textToCheck[candidateStart - 1] === '@') {
-                    candidateStart--;
-                }
-                while (candidateStart > 0 && '_*~'.includes(textToCheck[candidateStart - 1])) {
-                    candidateStart--;
-                }
-                return candidateStart;
-            };
-            // Check for a supported protocol before looking for a dot. This keeps URLs
-            // such as http://localhost:3000/foo.app as one candidate.
-            const getProtocolAt = (position: number) => URL_PROTOCOLS.find((protocol) => textToCheck.slice(position, position + protocol.length).toLowerCase() === protocol);
-            // Extract one candidate, pass it to the existing URL replacement code, and move
-            // every scanner position past it so it is not scanned again.
-            const processUrlCandidate = (candidateStart: number, candidateEnd: number) => {
-                const candidate = textToCheck.slice(candidateStart, candidateEnd);
+
+            for (const {start, end} of candidates) {
+                const candidate = textToCheck.slice(start, end);
                 candidateRegex.lastIndex = 0;
-                output.push(textToCheck.slice(outputStart, candidateStart));
+                output.push(textToCheck.slice(outputStart, start));
                 output.push(this.modifyTextForUrlLinks(candidateRegex, candidate, replacement));
-                outputStart = candidateEnd;
-                index = candidateEnd;
-                hostnameRunStart = candidateEnd;
-            };
-
-            while (index < textToCheck.length) {
-                if (textToCheck[index] === '<') {
-                    const nextIndex = updateProtectedTagStack(textToCheck, index, protectedTags);
-                    if (nextIndex === undefined) {
-                        break;
-                    }
-                    index = nextIndex;
-                    hostnameRunStart = index;
-                    continue;
-                }
-                if (protectedTags.length > 0) {
-                    index++;
-                    hostnameRunStart = index;
-                    continue;
-                }
-
-                const currentCharacter = textToCheck[index];
-                if (currentCharacter === 'h' || currentCharacter === 'H' || currentCharacter === 'f' || currentCharacter === 'F') {
-                    const matchedProtocol = getProtocolAt(index);
-                    if (matchedProtocol) {
-                        const candidateStart = getCandidateStart(index);
-
-                        let candidateEnd = index + matchedProtocol.length;
-                        while (candidateEnd < textToCheck.length && !isSpace(textToCheck[candidateEnd]) && textToCheck[candidateEnd] !== '<') {
-                            candidateEnd++;
-                        }
-
-                        processUrlCandidate(candidateStart, candidateEnd);
-                        continue;
-                    }
-                }
-
-                if (!isHostnameCharacter(textToCheck[index])) {
-                    hostnameRunStart = index + 1;
-                    index++;
-                    continue;
-                }
-                if (textToCheck[index] !== '.') {
-                    index++;
-                    continue;
-                }
-
-                const hostnameStart = hostnameRunStart;
-                let tldEnd = index + 1;
-                while (tldEnd < textToCheck.length && (isAsciiAlphaNumeric(textToCheck[tldEnd]) || textToCheck[tldEnd] === '-')) {
-                    tldEnd++;
-                }
-                if (hostnameStart === index || tldEnd === index + 1) {
-                    index++;
-                    continue;
-                }
-
-                const candidateStart = getCandidateStart(hostnameStart);
-
-                let candidateEnd = tldEnd;
-                while (candidateEnd < textToCheck.length && !isSpace(textToCheck[candidateEnd]) && textToCheck[candidateEnd] !== '<') {
-                    candidateEnd++;
-                }
-
-                processUrlCandidate(candidateStart, candidateEnd);
+                outputStart = end;
             }
 
-            if (output.length === 0) {
-                return textToCheck;
-            }
             output.push(textToCheck.slice(outputStart));
             return output.join('');
         }

--- a/lib/ExpensiMark.ts
+++ b/lib/ExpensiMark.ts
@@ -133,127 +133,38 @@ function replaceTextWithExtras(text: string, regexp: RegExp, extras: Extras, rep
     return text.replace(regexp, replacement);
 }
 
-function replaceBoldMarkdown(text: string, regexp: RegExp, replacement: Replacement): string {
-    if (!text.includes('*')) {
-        return text;
+function isWordCharacter(character?: string): boolean {
+    if (!character) {
+        return false;
     }
-
-    const starPositions = [];
-    const protectedTags = [];
-    const blockedTagNames = new Set(['a', 'code', 'pre', 'video']);
-    let index = 0;
-
-    while (index < text.length) {
-        if (text[index] === '<') {
-            const tagEnd = text.indexOf('>', index + 1);
-            if (tagEnd === -1) {
-                break;
-            }
-
-            const tag = text.slice(index + 1, tagEnd).trim();
-            const isClosingTag = tag.startsWith('/');
-            const tagName = tag.match(/^\/?\s*([a-z][a-z0-9-]*)/i)?.[1]?.toLowerCase();
-            if (tagName && blockedTagNames.has(tagName)) {
-                if (isClosingTag) {
-                    const matchingTagIndex = protectedTags.lastIndexOf(tagName);
-                    if (matchingTagIndex !== -1) {
-                        protectedTags.splice(matchingTagIndex, 1);
-                    }
-                } else if (!tag.endsWith('/')) {
-                    protectedTags.push(tagName);
-                }
-            }
-
-            index = tagEnd + 1;
-            continue;
-        }
-
-        if (text[index] === '*' && protectedTags.length === 0) {
-            starPositions.push(index);
-        }
-        index++;
-    }
-
-    if (starPositions.length < 2) {
-        return text;
-    }
-
-    const isWordCharacter = (character?: string) => {
-        if (!character) {
-            return false;
-        }
-        const code = character.charCodeAt(0);
-        return character === '_' || (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
-    };
-    const canOpen = (position: number) => {
-        const nextCharacter = text[position + 1];
-        if (!nextCharacter || /\s|\*/.test(nextCharacter) || text.startsWith('</em', position + 1)) {
-            return false;
-        }
-
-        const previousCharacter = text[position - 1];
-        if (!isWordCharacter(previousCharacter)) {
-            return true;
-        }
-        return previousCharacter === '_' && !isWordCharacter(text[position - 2]);
-    };
-    const canClose = (position: number) => {
-        const previousCharacter = text[position - 1];
-        return Boolean(previousCharacter && !/\s|\*/.test(previousCharacter) && !isWordCharacter(text[position + 1]));
-    };
-
-    const output = [];
-    const candidateRegex = regexp;
-    let outputStart = 0;
-    let openingPosition;
-
-    for (const starPosition of starPositions) {
-        if (openingPosition === undefined) {
-            openingPosition = canOpen(starPosition) ? starPosition : undefined;
-            continue;
-        }
-        if (!canClose(starPosition)) {
-            continue;
-        }
-
-        const prefixLength = openingPosition > 0 ? 1 : 0;
-        const suffixLength = starPosition + 1 < text.length ? 1 : 0;
-        const candidateStart = openingPosition - prefixLength;
-        const candidateEnd = starPosition + 1 + suffixLength;
-        const candidate = text.slice(candidateStart, candidateEnd);
-        candidateRegex.lastIndex = 0;
-        const candidateMatch = candidateRegex.exec(candidate);
-        if (!candidateMatch) {
-            openingPosition = canOpen(starPosition) ? starPosition : undefined;
-            continue;
-        }
-        candidateRegex.lastIndex = 0;
-        const replacedCandidate = replaceTextWithExtras(candidate, candidateRegex, EXTRAS_DEFAULT, replacement);
-        if (replacedCandidate !== candidate) {
-            const replacedCoreEnd = suffixLength ? replacedCandidate.length - suffixLength : replacedCandidate.length;
-            output.push(text.slice(outputStart, openingPosition));
-            output.push(replacedCandidate.slice(prefixLength, replacedCoreEnd));
-            outputStart = starPosition + 1;
-            openingPosition = undefined;
-            continue;
-        }
-        openingPosition = undefined;
-    }
-
-    if (output.length === 0) {
-        return text;
-    }
-
-    output.push(text.slice(outputStart));
-    return output.join('');
+    const code = character.charCodeAt(0);
+    return character === '_' || (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
 }
 
-function replaceStrikethroughMarkdown(text: string, regexp: RegExp, replacement: Replacement): string {
-    if (!text.includes('~')) {
+function canOpenBoldMarkdown(text: string, position: number): boolean {
+    const nextCharacter = text[position + 1];
+    if (!nextCharacter || /\s|\*/.test(nextCharacter) || text.startsWith('</em', position + 1)) {
+        return false;
+    }
+
+    const previousCharacter = text[position - 1];
+    if (!isWordCharacter(previousCharacter)) {
+        return true;
+    }
+    return previousCharacter === '_' && !isWordCharacter(text[position - 2]);
+}
+
+function canOpenStrikethroughMarkdown(text: string, position: number): boolean {
+    const nextCharacter = text[position + 1];
+    return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
+}
+
+function replaceMarkdownCandidates(text: string, regexp: RegExp, replacement: Replacement, marker: '*' | '~', canOpen: (text: string, position: number) => boolean): string {
+    if (!text.includes(marker)) {
         return text;
     }
 
-    const tildePositions = [];
+    const markerPositions = [];
     const protectedTags = [];
     const blockedTagNames = new Set(['a', 'code', 'pre', 'video']);
     let index = 0;
@@ -283,30 +194,19 @@ function replaceStrikethroughMarkdown(text: string, regexp: RegExp, replacement:
             continue;
         }
 
-        if (text[index] === '~' && protectedTags.length === 0) {
-            tildePositions.push(index);
+        if (text[index] === marker && protectedTags.length === 0) {
+            markerPositions.push(index);
         }
         index++;
     }
 
-    if (tildePositions.length < 2) {
+    if (markerPositions.length < 2) {
         return text;
     }
 
-    const isWordCharacter = (character?: string) => {
-        if (!character) {
-            return false;
-        }
-        const code = character.charCodeAt(0);
-        return character === '_' || (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
-    };
-    const canOpen = (position: number) => {
-        const nextCharacter = text[position + 1];
-        return Boolean(nextCharacter && !/\s|~/.test(nextCharacter));
-    };
     const canClose = (position: number) => {
         const previousCharacter = text[position - 1];
-        return Boolean(previousCharacter && !/\s|~/.test(previousCharacter) && !isWordCharacter(text[position + 1]));
+        return Boolean(previousCharacter && !/\s/.test(previousCharacter) && previousCharacter !== marker && !isWordCharacter(text[position + 1]));
     };
 
     const output = [];
@@ -314,24 +214,24 @@ function replaceStrikethroughMarkdown(text: string, regexp: RegExp, replacement:
     let outputStart = 0;
     let openingPosition;
 
-    for (const tildePosition of tildePositions) {
+    for (const markerPosition of markerPositions) {
         if (openingPosition === undefined) {
-            openingPosition = canOpen(tildePosition) ? tildePosition : undefined;
+            openingPosition = canOpen(text, markerPosition) ? markerPosition : undefined;
             continue;
         }
-        if (!canClose(tildePosition)) {
+        if (!canClose(markerPosition)) {
             continue;
         }
 
         const prefixLength = openingPosition > 0 ? 1 : 0;
-        const suffixLength = tildePosition + 1 < text.length ? 1 : 0;
+        const suffixLength = markerPosition + 1 < text.length ? 1 : 0;
         const candidateStart = openingPosition - prefixLength;
-        const candidateEnd = tildePosition + 1 + suffixLength;
+        const candidateEnd = markerPosition + 1 + suffixLength;
         const candidate = text.slice(candidateStart, candidateEnd);
         candidateRegex.lastIndex = 0;
         const candidateMatch = candidateRegex.exec(candidate);
         if (!candidateMatch) {
-            openingPosition = canOpen(tildePosition) ? tildePosition : undefined;
+            openingPosition = canOpen(text, markerPosition) ? markerPosition : undefined;
             continue;
         }
         candidateRegex.lastIndex = 0;
@@ -340,7 +240,7 @@ function replaceStrikethroughMarkdown(text: string, regexp: RegExp, replacement:
             const replacedCoreEnd = suffixLength ? replacedCandidate.length - suffixLength : replacedCandidate.length;
             output.push(text.slice(outputStart, openingPosition));
             output.push(replacedCandidate.slice(prefixLength, replacedCoreEnd));
-            outputStart = tildePosition + 1;
+            outputStart = markerPosition + 1;
             openingPosition = undefined;
             continue;
         }
@@ -1034,7 +934,7 @@ export default class ExpensiMark {
                 // \B will match everything that \b doesn't, so it works
                 // for * and ~: https://www.rexegg.com/regex-boundaries.html#notb
                 name: 'bold',
-                process: (textToProcess, replacement) => replaceBoldMarkdown(textToProcess, BOLD_MARKDOWN_REGEX, replacement),
+                process: (textToProcess, replacement) => replaceMarkdownCandidates(textToProcess, BOLD_MARKDOWN_REGEX, replacement, '*', canOpenBoldMarkdown),
                 replacement: (_extras, match, g1, g2) => {
                     if (g1.includes('_')) {
                         return `${g1}<strong>${g2}</strong>`;
@@ -1045,7 +945,7 @@ export default class ExpensiMark {
             },
             {
                 name: 'strikethrough',
-                process: (textToProcess, replacement) => replaceStrikethroughMarkdown(textToProcess, STRIKETHROUGH_MARKDOWN_REGEX, replacement),
+                process: (textToProcess, replacement) => replaceMarkdownCandidates(textToProcess, STRIKETHROUGH_MARKDOWN_REGEX, replacement, '~', canOpenStrikethroughMarkdown),
                 replacement: (_extras, match, g1) => (g1.includes('</pre>') || containsNonPairTag(g1) ? match : `<del>${g1}</del>`),
             },
             {


### PR DESCRIPTION
### Explanation of Change

`ExpensiMark.replace()` runs the autolink, bold, and strikethrough regexes against the complete input.

These regexes contain checks that may scan the same text several times while finding a match. This becomes slow when the composer contains a long message, especially on iOS Safari.

This PR first scans the input for possible URL, bold, and strikethrough parts. It then runs the existing ExpensiMark regex only on those smaller parts.

The existing regex still decides whether each part is valid and performs the replacement. This means we are optimizing the existing parser instead of adding another Markdown or URL parser.

For a 14,501-character input, the local App benchmark showed that `ExpensiMark.replace()` went from around 350 ms to 0-1 ms. Typing and editing the same long input remained smooth on Web and iOS Safari.

### Fixed Issues

$ [#95210](https://github.com/Expensify/App/issues/95210)
PROPOSAL: [#95210 (comment)](https://github.com/Expensify/App/issues/95210#issuecomment-4928540531)

### Tests

1. Go to staging.new.expensify.com or open Expensify App
2. Login with any account
3. Go to any chat
4. Paste any text containing markdown (bold, italic and autolink) and 14000+ characters in the composer.
5. Try to write something after pasting.
6. Verify that the typing experience is smooth and it doesn't lag while typing.
7. Verify that the markdown is preserved when we type after 14k text in the composer.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as Test

### QA Steps

Same as Test

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/92a27caa-b734-4023-a07e-84611c3a5f25



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/5fdbb9bf-a2af-4bc2-9a94-7db18615f27a




</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/1de502db-0952-4b9a-b1f3-b91fef9eb5f2



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/bd02c2e7-15d8-4dd0-8b10-516374ea23b8



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/c4366c2b-6eac-4f81-946d-c0debb303d3e




</details>